### PR TITLE
Gate the host's resume on every player being ready and hold it through the load window

### DIFF
--- a/ONI_Together/Configuration.cs
+++ b/ONI_Together/Configuration.cs
@@ -62,6 +62,15 @@ namespace ONI_Together
             set => Host.Server.PauseSimOnPlayerDisconnect = value;
         }
 
+        [Option("STRINGS.UI.CONFIGURATION.TITLES.HOST_SETTINGS.SERVER_SETTINGS.READY_TIMEOUT_SECONDS", "STRINGS.UI.CONFIGURATION.TOOLTIPS.HOST_SETTINGS.SERVER_SETTINGS.READY_TIMEOUT_SECONDS", "STRINGS.UI.CONFIGURATION.HEADERS.A_HOST_SETTINGS")]
+        [JsonIgnore]
+        public int ReadyTimeoutSeconds
+        {
+            get => Host.Server.ReadyTimeoutSeconds;
+            // 0 disables; any enabled value below the connection timeout floor makes no sense.
+            set => Host.Server.ReadyTimeoutSeconds = value <= 0 ? 0 : Mathf.Max(value, 30);
+        }
+
         [Option("STRINGS.UI.CONFIGURATION.TITLES.HOST_SETTINGS.SERVER_SETTINGS.SERVER_TICK_RATE", "STRINGS.UI.CONFIGURATION.TOOLTIPS.HOST_SETTINGS.SERVER_SETTINGS.SERVER_TICK_RATE", "STRINGS.UI.CONFIGURATION.HEADERS.A_HOST_SETTINGS")]
         [JsonIgnore]
         public ServerTickRate ServerTickRate
@@ -278,6 +287,7 @@ namespace ONI_Together
         [JsonProperty] public bool HardSyncAtCycleStart { get; set; } = false;
         [JsonProperty] public bool PauseSimOnPlayerDisconnect { get; set; } = false;
         [JsonProperty] public ServerTickRate TickRate { get; set; } = ServerTickRate.TPS_60;
+        [JsonProperty] public int ReadyTimeoutSeconds { get; set; } = 180;
     }
 
     public enum ServerTickRate

--- a/ONI_Together/DebugTools/UnitTests/OperationalStateCoverageTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OperationalStateCoverageTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Text;
+using ONI_Together.Networking;
+using ONI_Together.Scripts.Buildings;
+using UnityEngine;
+
+namespace ONI_Together.DebugTools.UnitTests
+{
+	/// <summary>
+	/// The HasHostState gate stopped a client building reporting itself as running before the
+	/// host had said anything, which is what was crashing SweepBotStation. That the crash went
+	/// away was verified; that operational status still *displays* correctly afterwards was
+	/// not, and it is the likeliest place for that change to have introduced a regression.
+	///
+	/// What this branch owns is the gate: without host state a building must not report itself
+	/// as running. Whether that state reaches every building belongs to the delivery layer, so
+	/// the coverage number is reported rather than asserted.
+	///
+	/// CLIENT ONLY, read-only, and worth running a few seconds after the world has settled -
+	/// immediately after a join every building is legitimately still waiting.
+	/// </summary>
+	public static class OperationalStateCoverageTests
+	{
+		[UnitTest(name: "Operational: no client building claims unsent host state", category: "Sync")]
+		public static UnitTestResult NoBuildingClaimsUnsentState()
+		{
+			// Not applicable is not a failure.
+			if (!MultiplayerSession.InActiveSession)
+				return UnitTestResult.Pass("skipped: not in a session");
+
+			if (!MultiplayerSession.IsClient)
+				return UnitTestResult.Pass("skipped: client only");
+
+			var receivers = Object.FindObjectsByType<ClientReceiver_Operational>(FindObjectsSortMode.None);
+			if (receivers == null || receivers.Length == 0)
+				return UnitTestResult.Pass("skipped: no gated buildings in the scene yet");
+
+			int withState = 0;
+			int claimingWithoutState = 0;
+			int operational = 0, functional = 0, active = 0;
+
+			foreach (var wrap in receivers)
+			{
+				if (!wrap.HasHostState)
+				{
+					// The point of the gate: with no host state the wrapper must not be able to
+					// report a building as running.
+					if (wrap.IsOperational || wrap.IsFunctional || wrap.IsActive)
+						claimingWithoutState++;
+
+					continue;
+				}
+
+				withState++;
+				if (wrap.IsOperational) operational++;
+				if (wrap.IsFunctional) functional++;
+				if (wrap.IsActive) active++;
+			}
+
+			if (claimingWithoutState > 0)
+				return UnitTestResult.Fail(
+					$"{claimingWithoutState} of {receivers.Length} buildings claim a state the host never sent");
+
+			// Coverage is reported, not asserted. Whether host state reaches every building is
+			// the delivery layer's business, and it was already unreliable before this gate -
+			// the old default of true simply hid it.
+			return UnitTestResult.Pass(
+				$"no building claims unsent state; {withState}/{receivers.Length} have it "
+				+ $"(operational {operational}, functional {functional}, active {active})");
+		}
+	}
+}

--- a/ONI_Together/DebugTools/UnitTests/OperationalStateCoverageTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OperationalStateCoverageTests.cs
@@ -7,17 +7,12 @@ using UnityEngine;
 namespace ONI_Together.DebugTools.UnitTests
 {
 	/// <summary>
-	/// The HasHostState gate stopped a client building reporting itself as running before the
-	/// host had said anything, which is what was crashing SweepBotStation. That the crash went
-	/// away was verified; that operational status still *displays* correctly afterwards was
-	/// not, and it is the likeliest place for that change to have introduced a regression.
+	/// Owns the HasHostState gate: without host state a client building must not report
+	/// itself as running. Whether that state reaches every building belongs to the delivery
+	/// layer, so coverage is reported rather than asserted.
 	///
-	/// What this branch owns is the gate: without host state a building must not report itself
-	/// as running. Whether that state reaches every building belongs to the delivery layer, so
-	/// the coverage number is reported rather than asserted.
-	///
-	/// CLIENT ONLY, read-only, and worth running a few seconds after the world has settled -
-	/// immediately after a join every building is legitimately still waiting.
+	/// CLIENT ONLY, read-only. Run a few seconds after the world settles - right after a
+	/// join every building is legitimately still waiting.
 	/// </summary>
 	public static class OperationalStateCoverageTests
 	{
@@ -61,9 +56,7 @@ namespace ONI_Together.DebugTools.UnitTests
 				return UnitTestResult.Fail(
 					$"{claimingWithoutState} of {receivers.Length} buildings claim a state the host never sent");
 
-			// Coverage is reported, not asserted. Whether host state reaches every building is
-			// the delivery layer's business, and it was already unreliable before this gate -
-			// the old default of true simply hid it.
+			// Coverage is reported, not asserted - delivery is the delivery layer's business.
 			return UnitTestResult.Pass(
 				$"no building claims unsent state; {withState}/{receivers.Length} have it "
 				+ $"(operational {operational}, functional {functional}, active {active})");

--- a/ONI_Together/DebugTools/UnitTests/ResumeGateTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/ResumeGateTests.cs
@@ -5,10 +5,9 @@ using ONI_Together.Networking.Transport;
 namespace ONI_Together.DebugTools.UnitTests
 {
 	/// <summary>
-	/// Drives the host-side resume gate without needing a second machine or a client that
-	/// happens to be mid-load. A load window lasts a handful of seconds and cannot be timed
-	/// by hand, which is why the host-side prefixes had no coverage at all - so these tests
-	/// fabricate the pending load instead of waiting for one.
+	/// Drives the host-side resume gate without a second machine: a real load window lasts
+	/// seconds and cannot be timed by hand, so these tests fabricate the pending load
+	/// instead of waiting for one.
 	///
 	/// HOST ONLY, and they move the sim: each test records the speed and pause state up
 	/// front and restores it in a finally block, and the fabricated loader is always removed.

--- a/ONI_Together/DebugTools/UnitTests/ResumeGateTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/ResumeGateTests.cs
@@ -43,6 +43,13 @@ namespace ONI_Together.DebugTools.UnitTests
 			// returning-loader flag it sets is consumed so nothing is left behind.
 			server.ClaimLoadingReconnect(ProbeLoader);
 			server.ConsumeReconnectFromLoad(ProbeLoader);
+
+			// Put the screen back. Each blocked resume calls RefreshScreen, which renders the
+			// fabricated loader into the overlay ("0/1 ready"), and nothing recomputes it
+			// afterwards - so without this the host is left sitting behind a stale "waiting for
+			// players" overlay once the tests finish.
+			ReadyManager.RefreshScreen();
+			ReadyManager.RefreshReadyState();
 		}
 
 		[UnitTest(name: "Resume gate: a pending load closes the gate", category: "Sync")]

--- a/ONI_Together/DebugTools/UnitTests/ResumeGateTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/ResumeGateTests.cs
@@ -1,0 +1,179 @@
+using ONI_Together.Patches;
+using ONI_Together.Networking;
+using ONI_Together.Networking.Transport;
+
+namespace ONI_Together.DebugTools.UnitTests
+{
+	/// <summary>
+	/// Drives the host-side resume gate without needing a second machine or a client that
+	/// happens to be mid-load. A load window lasts a handful of seconds and cannot be timed
+	/// by hand, which is why the host-side prefixes had no coverage at all - so these tests
+	/// fabricate the pending load instead of waiting for one.
+	///
+	/// HOST ONLY, and they move the sim: each test records the speed and pause state up
+	/// front and restores it in a finally block, and the fabricated loader is always removed.
+	/// </summary>
+	public static class ResumeGateTests
+	{
+		// Off-roster by construction - no transport hands out ids this high, so the probe is
+		// counted as a pending load without touching MultiplayerSession.ConnectedPlayers.
+		private const ulong ProbeLoader = ulong.MaxValue - 11;
+
+		private static UnitTestResult Preconditions(out TransportServer server)
+		{
+			server = NetworkConfig.TransportServer;
+
+			// Not applicable is not a failure. Reported as a pass carrying "skipped" until the
+			// harness grows a real skipped state.
+			if (!MultiplayerSession.InActiveSession || !MultiplayerSession.IsHost)
+				return UnitTestResult.Pass("skipped: host only");
+			if (server == null)
+				return UnitTestResult.Pass("skipped: no transport server");
+			if (SpeedControlScreen.Instance == null)
+				return UnitTestResult.Pass("skipped: SpeedControlScreen not available yet");
+			if (!ReadyManager.CanHostResume())
+				return UnitTestResult.Pass("skipped: the gate is already closed");
+
+			return null;
+		}
+
+		private static void ClearProbe(TransportServer server)
+		{
+			// Same path a returning loader takes: the exact-id match drops the entry, then the
+			// returning-loader flag it sets is consumed so nothing is left behind.
+			server.ClaimLoadingReconnect(ProbeLoader);
+			server.ConsumeReconnectFromLoad(ProbeLoader);
+		}
+
+		[UnitTest(name: "Resume gate: a pending load closes the gate", category: "Sync")]
+		public static UnitTestResult PendingLoadClosesGate()
+		{
+			var pre = Preconditions(out var server);
+			if (pre != null) return pre;
+
+			try
+			{
+				int before = server.PendingLoadingClientCount;
+				server.MarkClientLoading(ProbeLoader);
+
+				if (server.PendingLoadingClientCount != before + 1)
+					return UnitTestResult.Fail("The fabricated loader was not counted as pending");
+
+				if (ReadyManager.CanHostResume())
+					return UnitTestResult.Fail("CanHostResume stayed true while a load was in flight");
+
+				return UnitTestResult.Pass("A pending load closes the resume gate");
+			}
+			finally
+			{
+				ClearProbe(server);
+			}
+		}
+
+		[UnitTest(name: "Resume gate: host cannot resume mid-load", category: "Sync")]
+		public static UnitTestResult HostResumeIsBlockedMidLoad()
+		{
+			var pre = Preconditions(out var server);
+			if (pre != null) return pre;
+
+			bool wasPaused = SpeedControlScreen.Instance.IsPaused;
+			int previousSpeed = SpeedControlScreen.Instance.GetSpeed();
+
+			try
+			{
+				// A resume is only observable from a paused sim.
+				if (!SpeedControlScreen.Instance.IsPaused)
+					SpeedControlScreen.Instance.TogglePause(false);
+
+				server.MarkClientLoading(ProbeLoader);
+
+				// Each of the three local resume entry points the gate patches.
+				SpeedControlScreen.Instance.Unpause(false);
+				if (!SpeedControlScreen.Instance.IsPaused)
+					return UnitTestResult.Fail("Unpause() resumed the sim while a load was in flight");
+
+				SpeedControlScreen.Instance.TogglePause(false);
+				if (!SpeedControlScreen.Instance.IsPaused)
+					return UnitTestResult.Fail("TogglePause() resumed the sim while a load was in flight");
+
+				SpeedControlScreen.Instance.SetSpeed(2);
+				if (!SpeedControlScreen.Instance.IsPaused)
+					return UnitTestResult.Fail("SetSpeed() resumed the sim while a load was in flight");
+
+				return UnitTestResult.Pass("SetSpeed, TogglePause and Unpause are all blocked mid-load");
+			}
+			finally
+			{
+				ClearProbe(server);
+
+				// Restore what the test moved. The gate is open again by now, so these go
+				// through; IsSyncing keeps the restore from being treated as a local request.
+				SpeedControlScreen_SendSpeedPacketPatch.IsSyncing = true;
+				try
+				{
+					if (!wasPaused && SpeedControlScreen.Instance.IsPaused)
+					{
+						SpeedControlScreen.Instance.TogglePause(false);
+						SpeedControlScreen.Instance.SetSpeed(previousSpeed);
+					}
+					else if (wasPaused && !SpeedControlScreen.Instance.IsPaused)
+					{
+						SpeedControlScreen.Instance.TogglePause(false);
+					}
+				}
+				finally
+				{
+					SpeedControlScreen_SendSpeedPacketPatch.IsSyncing = false;
+				}
+			}
+		}
+
+		[UnitTest(name: "Resume gate: pausing is never blocked", category: "Sync")]
+		public static UnitTestResult PausingStaysAllowedMidLoad()
+		{
+			var pre = Preconditions(out var server);
+			if (pre != null) return pre;
+
+			bool wasPaused = SpeedControlScreen.Instance.IsPaused;
+
+			try
+			{
+				// Start from a running sim so the pause is observable.
+				if (SpeedControlScreen.Instance.IsPaused)
+					SpeedControlScreen.Instance.TogglePause(false);
+
+				if (SpeedControlScreen.Instance.IsPaused)
+				{
+					// A gate refusal always logs "[SpeedControl] Blocked ..."; ONI declining the
+					// unpause for its own reasons logs nothing and is not this test's subject.
+					return ReadyManager.CanHostResume()
+						? UnitTestResult.Pass("skipped: ONI declined the setup unpause while the gate was OPEN")
+						: UnitTestResult.Fail("The gate closed between the precondition check and the setup resume");
+				}
+
+				server.MarkClientLoading(ProbeLoader);
+
+				SpeedControlScreen.Instance.TogglePause(false);
+				if (!SpeedControlScreen.Instance.IsPaused)
+					return UnitTestResult.Fail("Pausing was blocked - only resume may be gated");
+
+				return UnitTestResult.Pass("Pausing still works while a load is in flight");
+			}
+			finally
+			{
+				ClearProbe(server);
+
+				SpeedControlScreen_SendSpeedPacketPatch.IsSyncing = true;
+				try
+				{
+					if (!wasPaused && SpeedControlScreen.Instance.IsPaused)
+						SpeedControlScreen.Instance.TogglePause(false);
+				}
+				finally
+				{
+					SpeedControlScreen_SendSpeedPacketPatch.IsSyncing = false;
+				}
+			}
+		}
+	}
+}

--- a/ONI_Together/DebugTools/UnitTests/TransportLoadTrackingTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/TransportLoadTrackingTests.cs
@@ -1,0 +1,121 @@
+using ONI_Together.Networking.Transport;
+
+namespace ONI_Together.DebugTools.UnitTests
+{
+	/// <summary>
+	/// Covers the load-in-flight bookkeeping on TransportServer, which the resume gate and
+	/// the ready-screen total both read. Deliberately side-effect free: the ids used here are
+	/// picked so they can never be in MultiplayerSession.ConnectedPlayers, so the tests are
+	/// safe to run mid-session and never touch shared state.
+	/// </summary>
+	public static class TransportLoadTrackingTests
+	{
+		// Off-roster by construction - no real transport hands out ids this high.
+		private const ulong FakeLoaderA = ulong.MaxValue - 7;
+		private const ulong FakeLoaderB = ulong.MaxValue - 8;
+
+		/// <summary>Minimal concrete transport so the shared bookkeeping can be exercised.</summary>
+		private sealed class ProbeServer : TransportServer
+		{
+			public override void Prepare() { }
+			public override void Start() { }
+			public override void Stop() { }
+			public override void CloseConnections() { }
+			public override void Update() { }
+			public override void OnMessageRecieved() { }
+			public override void KickClient(ulong clientId) { }
+		}
+
+		[UnitTest(name: "Transport: off-roster loader holds the resume gate", category: "Transport")]
+		public static UnitTestResult OffRosterLoaderIsCounted()
+		{
+			var server = new ProbeServer();
+
+			if (server.PendingLoadingClientCount != 0 || server.HasPendingLoadingClients)
+				return UnitTestResult.Fail("A fresh transport reported a pending load");
+
+			server.MarkClientLoading(FakeLoaderA);
+
+			if (!server.IsClientLoading(FakeLoaderA))
+				return UnitTestResult.Fail("MarkClientLoading did not record the loader");
+
+			if (server.PendingLoadingClientCount != 1)
+				return UnitTestResult.Fail(
+					$"Expected 1 off-roster loader, got {server.PendingLoadingClientCount}");
+
+			if (!server.HasPendingLoadingClients)
+				return UnitTestResult.Fail("HasPendingLoadingClients disagreed with the count");
+
+			return UnitTestResult.Pass("An off-roster loader is counted and holds the gate");
+		}
+
+		[UnitTest(name: "Transport: reconnect by exact id clears the load", category: "Transport")]
+		public static UnitTestResult ExactIdReconnectClearsLoad()
+		{
+			var server = new ProbeServer();
+			server.MarkClientLoading(FakeLoaderA);
+
+			// LiteNetLib and Steamworks give a returning client its persistent id back.
+			server.ClaimLoadingReconnect(FakeLoaderA);
+
+			if (server.PendingLoadingClientCount != 0)
+				return UnitTestResult.Fail("The load entry survived a matching reconnect");
+
+			if (!server.ConsumeReconnectFromLoad(FakeLoaderA))
+				return UnitTestResult.Fail("The reconnect was not reported as a returning loader");
+
+			if (server.ConsumeReconnectFromLoad(FakeLoaderA))
+				return UnitTestResult.Fail("The returning-loader flag was not consumed once");
+
+			return UnitTestResult.Pass("An exact-id reconnect clears the load and reports once");
+		}
+
+		[UnitTest(name: "Transport: a kicked loader stops holding the gate", category: "Transport")]
+		public static UnitTestResult ForgetClientLoadingReleasesTheGate()
+		{
+			var server = new ProbeServer();
+			server.MarkClientLoading(FakeLoaderA);
+
+			if (server.PendingLoadingClientCount != 1)
+				return UnitTestResult.Fail("Setup failed - the loader was not counted");
+
+			// A kicked client is not coming back. Its own disconnect event cannot clear the
+			// entry (the kick already removed the peer mapping that event is keyed on), so
+			// without this the gate stays closed until the 120s timeout.
+			server.ForgetClientLoading(FakeLoaderA);
+
+			if (server.PendingLoadingClientCount != 0)
+				return UnitTestResult.Fail("A forgotten loader still holds the gate");
+
+			if (server.ConsumeReconnectFromLoad(FakeLoaderA))
+				return UnitTestResult.Fail("A forgotten loader was credited as a returning loader");
+
+			return UnitTestResult.Pass("ForgetClientLoading releases the gate without crediting a reconnect");
+		}
+
+		[UnitTest(name: "Transport: a new join does not clear someone else's load", category: "Transport")]
+		public static UnitTestResult UnmatchedConnectLeavesLoadPending()
+		{
+			var server = new ProbeServer();
+			server.MarkClientLoading(FakeLoaderA);
+
+			// A different client connecting is a new join, not the loader coming back. If this
+			// consumed A's entry the gate would rest only on B's Unready flag and would open
+			// the moment B reported Ready - with A still mid-load, which is the exact bug the
+			// pending count exists to prevent.
+			server.ClaimLoadingReconnect(FakeLoaderB);
+
+			if (server.PendingLoadingClientCount != 1)
+				return UnitTestResult.Fail(
+					$"A new join consumed the pending load (count {server.PendingLoadingClientCount})");
+
+			if (!server.IsClientLoading(FakeLoaderA))
+				return UnitTestResult.Fail("The original loader's entry was dropped");
+
+			if (server.ConsumeReconnectFromLoad(FakeLoaderB))
+				return UnitTestResult.Fail("A new join was mis-tagged as a returning loader");
+
+			return UnitTestResult.Pass("An unmatched connect leaves the pending load and the gate alone");
+		}
+	}
+}

--- a/ONI_Together/DebugTools/UnitTests/TransportLoadTrackingTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/TransportLoadTrackingTests.cs
@@ -93,29 +93,25 @@ namespace ONI_Together.DebugTools.UnitTests
 			return UnitTestResult.Pass("ForgetClientLoading releases the gate without crediting a reconnect");
 		}
 
-		[UnitTest(name: "Transport: a new join does not clear someone else's load", category: "Transport")]
-		public static UnitTestResult UnmatchedConnectLeavesLoadPending()
+		[UnitTest(name: "Transport: a reconnect under a new id still clears the load", category: "Transport")]
+		public static UnitTestResult ReassignedIdReconnectClearsLoad()
 		{
 			var server = new ProbeServer();
 			server.MarkClientLoading(FakeLoaderA);
 
-			// A different client connecting is a new join, not the loader coming back. If this
-			// consumed A's entry the gate would rest only on B's Unready flag and would open
-			// the moment B reported Ready - with A still mid-load, which is the exact bug the
-			// pending count exists to prevent.
+			// No LAN transport keeps a client id across a reconnect - both derive it from the
+			// peer handle - so the returning loader arrives as someone else and the oldest
+			// pending entry is released instead. Pinned here because the alternative, leaving
+			// it alone, stalls the gate for the full timeout after every load.
 			server.ClaimLoadingReconnect(FakeLoaderB);
 
-			if (server.PendingLoadingClientCount != 1)
-				return UnitTestResult.Fail(
-					$"A new join consumed the pending load (count {server.PendingLoadingClientCount})");
+			if (server.PendingLoadingClientCount != 0)
+				return UnitTestResult.Fail("A reconnect under a new id left the gate closed");
 
-			if (!server.IsClientLoading(FakeLoaderA))
-				return UnitTestResult.Fail("The original loader's entry was dropped");
+			if (!server.ConsumeReconnectFromLoad(FakeLoaderB))
+				return UnitTestResult.Fail("The reconnect was not reported as a returning loader");
 
-			if (server.ConsumeReconnectFromLoad(FakeLoaderB))
-				return UnitTestResult.Fail("A new join was mis-tagged as a returning loader");
-
-			return UnitTestResult.Pass("An unmatched connect leaves the pending load and the gate alone");
+			return UnitTestResult.Pass("A reconnect under a new id releases the pending load");
 		}
 	}
 }

--- a/ONI_Together/Menus/MultiplayerOverlay.cs
+++ b/ONI_Together/Menus/MultiplayerOverlay.cs
@@ -65,11 +65,9 @@ namespace ONI_Together.Menus
 				return;
 			}
 
-			// LoadingOverlay is decorative - nothing on it blocks raycasts - so clicks went
-			// straight through into a world the host had not resumed, and orders placed that
-			// way are lost. Blocked here rather than refused tool by tool: a per-tool guard
-			// has to be repeated for dig, build, deconstruct, sweep... and silently misses
-			// whatever tool is added next.
+			// LoadingOverlay is decorative - nothing on it blocks raycasts - so without this
+			// clicks land in a world the host has not resumed. Blocked here rather than tool
+			// by tool: a per-tool guard silently misses whatever tool is added next.
 			//
 			// Keys are handled separately by ReadyScreenInputPatch, which swallows them so
 			// Escape can no longer answer with Deactivate() and destroy this screen.
@@ -145,10 +143,9 @@ namespace ONI_Together.Menus
 			if (text != Text)
 				DebugConsole.Log($"[MultiplayerOverlay] {(text ?? string.Empty).Replace("\n", " | ")}");
 
-			// Builds only when there is no wrapper at all. Rebuilding whenever the backing UI
-			// had been destroyed was tried and reverted: in game ONI tears its LoadingOverlay
-			// down as fast as we raise it, so the host rebuilt every 5s, each time putting a
-			// fresh full-screen overlay on top of the player.
+			// Builds only when there is no wrapper at all. Do not rebuild when the backing UI
+			// was destroyed: in game ONI tears LoadingOverlay down as fast as we raise it, and
+			// a rebuild loop stacks a fresh full-screen overlay on the player every few seconds.
 			if (overlay == null)
 			{
 				overlay = new MultiplayerOverlay();

--- a/ONI_Together/Menus/MultiplayerOverlay.cs
+++ b/ONI_Together/Menus/MultiplayerOverlay.cs
@@ -139,6 +139,14 @@ namespace ONI_Together.Menus
 		{
 			using var _ = Profiler.Scope();
 
+			// This overlay is the only trace several user-facing failures leave behind:
+			// the paths that show a message and send the player back to the menu draw UI
+			// and log nothing, so a report of "it kicked me out" arrives with no way to
+			// tell which check rejected it. Log the transition rather than every call -
+			// the ready screen re-shows the same text constantly.
+			if (text != Text)
+				DebugConsole.Log($"[MultiplayerOverlay] {(text ?? string.Empty).Replace("\n", " | ")}");
+
 			// Builds only when there is no wrapper at all. Rebuilding whenever the backing UI
 			// had been destroyed was tried and reverted: in game ONI tears its LoadingOverlay
 			// down as fast as we raise it, so the host rebuilt every 5s, each time putting a
@@ -166,6 +174,8 @@ namespace ONI_Together.Menus
 
 			if (overlay == null)
 				return;
+
+			DebugConsole.Log("[MultiplayerOverlay] closed");
 
 			overlay?.Dispose();
 			overlay = null;

--- a/ONI_Together/Menus/MultiplayerOverlay.cs
+++ b/ONI_Together/Menus/MultiplayerOverlay.cs
@@ -4,6 +4,7 @@ using System;
 using Shared.Profiling;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 
 namespace ONI_Together.Menus
@@ -64,6 +65,30 @@ namespace ONI_Together.Menus
 				return;
 			}
 
+			// Make the overlay actually stop clicks reaching the world instead of merely covering
+			// it. LoadingOverlay is decorative - nothing on it blocks raycasts - so every click
+			// went straight through into a world the host had not resumed, and orders placed
+			// that way are lost: a joining client is still in the menu when the packet arrives.
+			//
+			// Blocking here rather than refusing each tool in turn. A per-tool guard has to be
+			// repeated for dig, build, deconstruct, sweep, prioritise... and silently misses
+			// whatever tool is added next.
+			//
+			// Keyboard input is handled separately: LoadingOverlay is a KModalScreen, so it eats
+			// every key and answers Escape by destroying itself. ReadyScreenInputPatch swallows
+			// the key instead, so Escape can no longer tear this screen down.
+			var canvasGroup = inst.gameObject.GetComponent<CanvasGroup>();
+			if (canvasGroup == null)
+				canvasGroup = inst.gameObject.AddComponent<CanvasGroup>();
+			canvasGroup.blocksRaycasts = true;
+			canvasGroup.interactable = true;
+
+			var colorFill = inst.transform.Find("ColorFill")?.GetComponent<Image>();
+			if (colorFill != null)
+				colorFill.raycastTarget = true;
+			else
+				DebugConsole.LogWarning("[MultiplayerOverlay] No ColorFill to block clicks with");
+
 			textComponent = inst.GetComponentInChildren<LocText>();
 			if (textComponent == null)
 			{
@@ -118,9 +143,26 @@ namespace ONI_Together.Menus
 		{
 			using var _ = Profiler.Scope();
 
+			// Deliberately does NOT rebuild when only the backing UI is gone. That was tried:
+			// the idea was that a scene load destroys the LoadingOverlay and leaves the wrapper
+			// alive, so Show would paint nothing. Measured over a full join, the client rebuilt
+			// 0 times - the premise does not hold there - while the host rebuilt every 5s,
+			// because in game ONI tears its LoadingOverlay back down as fast as we raise it.
+			// Each rebuild calls LoadingOverlay.Load and puts a full-screen overlay back on
+			// top, which is what forced the player to hit Escape over and over.
 			if (overlay == null)
 			{
 				overlay = new MultiplayerOverlay();
+
+				// Nothing is usable while this screen is up - keys are swallowed
+				// (ReadyScreenInputPatch) and clicks are blocked - so a pause menu that was
+				// open when the screen went up would be trapped open behind it, unclosable,
+				// until the gate reopens. Close it instead of stranding it.
+				if (PauseScreen.Instance != null && PauseScreen.Instance.isActiveAndEnabled)
+				{
+					DebugConsole.Log("[MultiplayerOverlay] Closing the pause menu under the ready screen");
+					PauseScreen.Instance.Show(false);
+				}
 			}
 			Text = text;
 		}
@@ -129,8 +171,13 @@ namespace ONI_Together.Menus
 		{
 			using var _ = Profiler.Scope();
 
+			if (overlay == null)
+				return;
+
 			overlay?.Dispose();
 			overlay = null;
 		}
+
+
 	}
 }

--- a/ONI_Together/Menus/MultiplayerOverlay.cs
+++ b/ONI_Together/Menus/MultiplayerOverlay.cs
@@ -163,6 +163,25 @@ namespace ONI_Together.Menus
 			Text = text;
 		}
 
+		/// <summary>
+		/// The scene swap destroys the backing LoadingOverlay but not this wrapper, leaving
+		/// IsOpen true over a screen that no longer exists - text writes go to a dead object
+		/// and the player sees a bare world. Call once after a world load so the next Show
+		/// builds a real screen again. One-shot by design: Show itself still never rebuilds
+		/// (a generic rebuild-on-destroyed stacked fresh overlays on the player).
+		/// </summary>
+		public static void ResetAfterSceneSwap()
+		{
+			using var _ = Profiler.Scope();
+
+			if (overlay == null)
+				return;
+
+			DebugConsole.Log("[MultiplayerOverlay] dropping the wrapper the scene swap orphaned");
+			overlay.Dispose();
+			overlay = null;
+		}
+
 		public static void Close()
 		{
 			using var _ = Profiler.Scope();

--- a/ONI_Together/Menus/MultiplayerOverlay.cs
+++ b/ONI_Together/Menus/MultiplayerOverlay.cs
@@ -139,11 +139,9 @@ namespace ONI_Together.Menus
 		{
 			using var _ = Profiler.Scope();
 
-			// This overlay is the only trace several user-facing failures leave behind:
-			// the paths that show a message and send the player back to the menu draw UI
-			// and log nothing, so a report of "it kicked me out" arrives with no way to
-			// tell which check rejected it. Log the transition rather than every call -
-			// the ready screen re-shows the same text constantly.
+			// Several rejection paths surface to the player only through this overlay.
+			// Log transitions, not every call - the ready screen re-shows the same
+			// text constantly.
 			if (text != Text)
 				DebugConsole.Log($"[MultiplayerOverlay] {(text ?? string.Empty).Replace("\n", " | ")}");
 

--- a/ONI_Together/Menus/MultiplayerOverlay.cs
+++ b/ONI_Together/Menus/MultiplayerOverlay.cs
@@ -65,18 +65,14 @@ namespace ONI_Together.Menus
 				return;
 			}
 
-			// Make the overlay actually stop clicks reaching the world instead of merely covering
-			// it. LoadingOverlay is decorative - nothing on it blocks raycasts - so every click
-			// went straight through into a world the host had not resumed, and orders placed
-			// that way are lost: a joining client is still in the menu when the packet arrives.
-			//
-			// Blocking here rather than refusing each tool in turn. A per-tool guard has to be
-			// repeated for dig, build, deconstruct, sweep, prioritise... and silently misses
+			// LoadingOverlay is decorative - nothing on it blocks raycasts - so clicks went
+			// straight through into a world the host had not resumed, and orders placed that
+			// way are lost. Blocked here rather than refused tool by tool: a per-tool guard
+			// has to be repeated for dig, build, deconstruct, sweep... and silently misses
 			// whatever tool is added next.
 			//
-			// Keyboard input is handled separately: LoadingOverlay is a KModalScreen, so it eats
-			// every key and answers Escape by destroying itself. ReadyScreenInputPatch swallows
-			// the key instead, so Escape can no longer tear this screen down.
+			// Keys are handled separately by ReadyScreenInputPatch, which swallows them so
+			// Escape can no longer answer with Deactivate() and destroy this screen.
 			var canvasGroup = inst.gameObject.GetComponent<CanvasGroup>();
 			if (canvasGroup == null)
 				canvasGroup = inst.gameObject.AddComponent<CanvasGroup>();
@@ -143,13 +139,10 @@ namespace ONI_Together.Menus
 		{
 			using var _ = Profiler.Scope();
 
-			// Deliberately does NOT rebuild when only the backing UI is gone. That was tried:
-			// the idea was that a scene load destroys the LoadingOverlay and leaves the wrapper
-			// alive, so Show would paint nothing. Measured over a full join, the client rebuilt
-			// 0 times - the premise does not hold there - while the host rebuilt every 5s,
-			// because in game ONI tears its LoadingOverlay back down as fast as we raise it.
-			// Each rebuild calls LoadingOverlay.Load and puts a full-screen overlay back on
-			// top, which is what forced the player to hit Escape over and over.
+			// Builds only when there is no wrapper at all. Rebuilding whenever the backing UI
+			// had been destroyed was tried and reverted: in game ONI tears its LoadingOverlay
+			// down as fast as we raise it, so the host rebuilt every 5s, each time putting a
+			// fresh full-screen overlay on top of the player.
 			if (overlay == null)
 			{
 				overlay = new MultiplayerOverlay();

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -452,8 +452,24 @@ namespace ONI_Together.Misc
         {
 	        if (!MultiplayerSession.IsHost) return;
 	        if (!Configuration.Instance.PauseSimOnPlayerDisconnect) return;
-	        
+
 	        if(!SpeedControlScreen.Instance.IsPaused)
+				SpeedControlScreen.Instance.TogglePause(false);
+        }
+
+        /// <summary>
+        /// HOST ONLY - Pause the sim when a client joins / starts the ready sync so the
+        /// ready screen reflects a frozen world for everyone. Pausing via TogglePause reuses
+        /// SpeedControlPatch.TogglePause_Postfix, which broadcasts the pause to all peers.
+        /// The !IsPaused guard keeps repeated calls (e.g. reconnect-after-load) a no-op, and
+        /// pausing is never blocked by the resume gate.
+        /// </summary>
+        public static void PauseSimForReadyScreen()
+        {
+	        if (!MultiplayerSession.IsHost) return;
+	        if (SpeedControlScreen.Instance == null) return;
+
+	        if (!SpeedControlScreen.Instance.IsPaused)
 				SpeedControlScreen.Instance.TogglePause(false);
         }
 

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -450,6 +450,9 @@ namespace ONI_Together.Misc
 
         public static void PauseSimOnPlayerLeft()
         {
+	        // Host check first: this also runs on clients (e.g. RiptideClient peer-left), and
+	        // must bail before reading the host-only PauseSimOnPlayerDisconnect config.
+	        if (!MultiplayerSession.IsHost) return;
 	        if (!Configuration.Instance.PauseSimOnPlayerDisconnect) return;
 
 	        PauseSimIfRunning();

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -473,6 +473,8 @@ namespace ONI_Together.Misc
         /// </summary>
         public static void PauseSimForReadyScreen()
         {
+	        using var _ = Profiler.Scope();
+
 	        PauseSimIfRunning();
         }
 
@@ -484,6 +486,8 @@ namespace ONI_Together.Misc
         /// </summary>
         private static void PauseSimIfRunning()
         {
+	        using var _ = Profiler.Scope();
+
 	        if (!MultiplayerSession.IsHost) return;
 	        if (SpeedControlScreen.Instance == null) return;
 

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -475,6 +475,12 @@ namespace ONI_Together.Misc
         {
 	        using var _ = Profiler.Scope();
 
+	        // Mirror the InSession guard that RefreshScreen/RefreshReadyState already use, so a
+	        // connect that happens before the session is established (the host's own loopback
+	        // client on LAN host-start) can never pause the sim — independent of how the caller
+	        // computes its loopback flag.
+	        if (!MultiplayerSession.InSession) return;
+
 	        PauseSimIfRunning();
         }
 

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -460,6 +460,13 @@ namespace ONI_Together.Misc
         /// ready screen reflects a frozen world for everyone. Unlike PauseSimOnPlayerLeft
         /// this is intentionally unconditional (not gated by PauseSimOnPlayerDisconnect):
         /// the ready screen must freeze the world for correctness regardless of host prefs.
+        ///
+        /// Note: this only broadcasts a pause when the host is currently *running* (see the
+        /// !IsPaused guard in PauseSimIfRunning). If the host is already paused, no pause
+        /// packet is sent — the "freeze everyone" guarantee therefore assumes clients already
+        /// mirror the host's paused state (true in normal flow, since client speed tracks the
+        /// host via SpeedChangePacket); it does not retroactively correct a pre-existing
+        /// client/host speed desync.
         /// </summary>
         public static void PauseSimForReadyScreen()
         {

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -450,21 +450,29 @@ namespace ONI_Together.Misc
 
         public static void PauseSimOnPlayerLeft()
         {
-	        if (!MultiplayerSession.IsHost) return;
 	        if (!Configuration.Instance.PauseSimOnPlayerDisconnect) return;
 
-	        if(!SpeedControlScreen.Instance.IsPaused)
-				SpeedControlScreen.Instance.TogglePause(false);
+	        PauseSimIfRunning();
         }
 
         /// <summary>
         /// HOST ONLY - Pause the sim when a client joins / starts the ready sync so the
-        /// ready screen reflects a frozen world for everyone. Pausing via TogglePause reuses
-        /// SpeedControlPatch.TogglePause_Postfix, which broadcasts the pause to all peers.
-        /// The !IsPaused guard keeps repeated calls (e.g. reconnect-after-load) a no-op, and
-        /// pausing is never blocked by the resume gate.
+        /// ready screen reflects a frozen world for everyone. Unlike PauseSimOnPlayerLeft
+        /// this is intentionally unconditional (not gated by PauseSimOnPlayerDisconnect):
+        /// the ready screen must freeze the world for correctness regardless of host prefs.
         /// </summary>
         public static void PauseSimForReadyScreen()
+        {
+	        PauseSimIfRunning();
+        }
+
+        /// <summary>
+        /// HOST ONLY - Pause the sim if it is currently running. Pausing via TogglePause
+        /// reuses SpeedControlPatch.TogglePause_Postfix, which broadcasts the pause to all
+        /// peers. The !IsPaused guard keeps repeated calls (e.g. reconnect-after-load) a
+        /// no-op, and pausing is never blocked by the resume gate.
+        /// </summary>
+        private static void PauseSimIfRunning()
         {
 	        if (!MultiplayerSession.IsHost) return;
 	        if (SpeedControlScreen.Instance == null) return;

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -484,7 +484,7 @@ namespace ONI_Together.Misc
 	        if (!MultiplayerSession.IsHost) return;
 	        if (!Configuration.Instance.PauseSimOnPlayerDisconnect) return;
 
-	        PauseSimIfRunning();
+	        PauseSimIfRunning(false);
         }
 
         /// <summary>
@@ -509,7 +509,9 @@ namespace ONI_Together.Misc
 	        // computes its loopback flag.
 	        if (!MultiplayerSession.InActiveSession) return;
 
-	        PauseSimIfRunning();
+	        // Flagged as ours, so ResumeSimAfterReadyScreen can undo exactly this pause and
+	        // nothing else.
+	        PauseSimIfRunning(true);
         }
 
         /// <summary>
@@ -519,7 +521,7 @@ namespace ONI_Together.Misc
         /// guard keeps repeated calls (e.g. reconnect-after-load) a no-op, and pausing is
         /// never blocked by the resume gate.
         /// </summary>
-        private static void PauseSimIfRunning()
+        private static void PauseSimIfRunning(bool forReadyScreen)
         {
 	        using var _ = Profiler.Scope();
 
@@ -527,7 +529,40 @@ namespace ONI_Together.Misc
 	        if (SpeedControlScreen.Instance == null) return;
 
 	        if (!SpeedControlScreen.Instance.IsPaused)
-				SpeedControlScreen.Instance.TogglePause(false);
+	        {
+		        if (forReadyScreen)
+			        _pausedForReadyScreen = true;
+
+		        SpeedControlScreen.Instance.TogglePause(false);
+	        }
+        }
+
+        private static bool _pausedForReadyScreen;
+
+        /// <summary>
+        /// HOST ONLY - undo the pause the ready screen made, once the gate has opened. Nothing
+        /// did this before: the automatic unpause in AllClientsReadyPacket.ProcessAllReady is
+        /// commented out upstream, so after a join the host was left staring at a frozen world
+        /// and had to toggle the speed itself to get moving again.
+        ///
+        /// Only reverses a pause THIS code made for the ready screen. A host that had paused
+        /// deliberately before anyone joined, or a pause from PauseSimOnPlayerLeft, keeps it -
+        /// resuming those would be overriding the player.
+        /// </summary>
+        public static void ResumeSimAfterReadyScreen()
+        {
+	        using var _ = Profiler.Scope();
+
+	        if (!MultiplayerSession.IsHost) return;
+	        if (!_pausedForReadyScreen) return;
+
+	        _pausedForReadyScreen = false;
+
+	        if (SpeedControlScreen.Instance == null) return;
+	        if (!SpeedControlScreen.Instance.IsPaused) return;
+
+	        DebugConsole.Log("[Utils] Ready gate opened; resuming the sim the ready screen paused");
+	        SpeedControlScreen.Instance.TogglePause(false);
         }
 
         public static string CompressString(string text)

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -18,22 +18,13 @@ namespace ONI_Together.Misc
 {
 	public static class Utils
 	{
-		/// <summary>
-		/// Max size of a single message that we can SEND.
-		/// <para/>
-		/// Note: We might be wiling to receive larger messages, and our peer might, too.
-		/// </summary>
+		/// <summary>Max size of a single message we SEND - receiving may allow larger, on both ends.</summary>
 		public static int MaxSteamNetworkingSocketsMessageSizeSend = 512 * 1024;
 
-		/// <summary>
-		/// Maximum length of a player name sent over the network / shown in UI.
-		/// Longer names are truncated with a "..." suffix.
-		/// </summary>
+		/// <summary>Max player name length on the wire and in UI; longer names get a "..." suffix.</summary>
 		public const int MaxLocalPlayerNameLength = 16;
 
-		/// <summary>
-		/// Force quites the game without the Klei metrics that can cause crashes
-		/// </summary>
+		/// <summary>Force quits the game without the Klei metrics that can cause crashes.</summary>
 		public static void ForceQuitGame()
 		{
 			using var _ = Profiler.Scope();
@@ -163,11 +154,6 @@ namespace ONI_Together.Misc
 				}
 			return chunks;
 		}
-		/// <summary>
-		/// Checks if the mono behavior sits on a duplicant in a host game
-		/// </summary>
-		/// <param name="behavior"></param>
-		/// <returns></returns>
 		public static bool IsHostMinion(MonoBehaviour behavior)
 		{
 			using var _ = Profiler.Scope();
@@ -179,12 +165,10 @@ namespace ONI_Together.Misc
 			return true;
 		}
 		/// <summary>
-		/// Gate for host-originated broadcasts that key off NetId on the wire.
-		/// True only if: in session, is host, behavior alive, attached GameObject has a
-		/// NetworkIdentity with NetId != 0. Rejects ghost/preview/particle GameObjects
-		/// that use shared Klei components (e.g. SymbolOverrideController) but are not
-		/// registered network entities — sending for them would be wasted bandwidth
-		/// (receiver lookup would fail anyway).
+		/// Gate for host-originated broadcasts that key off NetId on the wire. Rejects
+		/// ghost/preview/particle GameObjects that use shared Klei components (e.g.
+		/// SymbolOverrideController) but are not registered network entities - the
+		/// receiver lookup would fail anyway.
 		/// </summary>
 		public static bool IsHostEntityWithNetId(MonoBehaviour behavior, out int netId)
 		{
@@ -280,10 +264,7 @@ namespace ONI_Together.Misc
 			return $"{len:0.##} {sizes[order]}";
 		}
 
-		/// <summary>
-		/// Formats a timespan nicely:
-		/// 45s, 3m 12s, 1h 15m 20s
-		/// </summary>
+		/// <summary>Formats a timespan as 45s / 3m 12s / 1h 15m 20s.</summary>
 		public static string FormatTime(double seconds)
 		{
 			using var _ = Profiler.Scope();
@@ -446,11 +427,7 @@ namespace ONI_Together.Misc
             };
         }
 
-        /// <summary>
-        /// Get a deterministic client id based off a remotes IP and PORT
-        /// </summary>
-        /// <param name="endpoint"></param>
-        /// <returns></returns>
+        /// <summary>Deterministic client id derived from a remote's IP and port.</summary>
         public static ulong GetClientId(IPEndPoint endpoint)
         {
 	        using var _ = Profiler.Scope();
@@ -461,7 +438,6 @@ namespace ONI_Together.Misc
 				ulong hash = 14695981039346656037UL; // FNV-1a 64-bit offset
                 const ulong prime = 1099511628211UL;
 
-                // IP bytes
                 byte[] ipBytes = endpoint.Address.GetAddressBytes();
                 for (int i = 0; i < ipBytes.Length; i++)
                 {
@@ -469,7 +445,6 @@ namespace ONI_Together.Misc
                     hash *= prime;
                 }
 
-                // Port
                 hash ^= (ulong)endpoint.Port;
                 hash *= prime;
 
@@ -488,38 +463,26 @@ namespace ONI_Together.Misc
         }
 
         /// <summary>
-        /// HOST ONLY - Pause the sim when a client joins / starts the ready sync so the
-        /// ready screen reflects a frozen world for everyone. Unlike PauseSimOnPlayerLeft
-        /// this is intentionally unconditional (not gated by PauseSimOnPlayerDisconnect):
-        /// the ready screen must freeze the world for correctness regardless of host prefs.
-        ///
-        /// Note: this only requests a pause when the host is currently *running* (see the
-        /// !IsPaused guard in PauseSimIfRunning). If the host is already paused nothing is
-        /// sent from here, but clients are not left to guess: GameSpeedSyncer re-broadcasts
-        /// the host's speed state on a 2s interval, so a client that is out of step converges
-        /// on the host's paused state on its own.
+        /// HOST ONLY - freeze the world for the ready screen on join. Unconditional, unlike
+        /// PauseSimOnPlayerLeft: correctness, not a pref. An already-paused host sends nothing,
+        /// which is safe - GameSpeedSyncer re-broadcasts the host's speed every 2s.
         /// </summary>
         public static void PauseSimForReadyScreen()
         {
 	        using var _ = Profiler.Scope();
 
-	        // Mirror the InActiveSession guard that RefreshScreen/RefreshReadyState already use, so a
-	        // connect that happens before the session is established (the host's own loopback
-	        // client on LAN host-start) can never pause the sim — independent of how the caller
-	        // computes its loopback flag.
+	        // The host's own loopback client on LAN host-start connects before the session
+	        // exists and must not pause the sim, whatever the caller's loopback flag says.
 	        if (!MultiplayerSession.InActiveSession) return;
 
-	        // Flagged as ours, so ResumeSimAfterReadyScreen can undo exactly this pause and
-	        // nothing else.
+	        // Flagged as ours so ResumeSimAfterReadyScreen undoes exactly this pause.
 	        PauseSimIfRunning(true);
         }
 
         /// <summary>
-        /// HOST ONLY - Pause the sim if it is currently running. Pausing via TogglePause
-        /// reuses the TogglePause postfix in SpeedControlPatch.cs, which hands the new state
-        /// to GameSpeedSyncer.RequestSetSpeed and so fans it out to every client. The !IsPaused
-        /// guard keeps repeated calls (e.g. reconnect-after-load) a no-op, and pausing is
-        /// never blocked by the resume gate.
+        /// HOST ONLY - pause the sim if running. TogglePause goes through the postfix in
+        /// SpeedControlPatch.cs, which fans the new state out via GameSpeedSyncer.RequestSetSpeed.
+        /// The !IsPaused guard keeps repeat calls a no-op; the resume gate never blocks a pause.
         /// </summary>
         private static void PauseSimIfRunning(bool forReadyScreen)
         {
@@ -540,14 +503,9 @@ namespace ONI_Together.Misc
         private static bool _pausedForReadyScreen;
 
         /// <summary>
-        /// HOST ONLY - undo the pause the ready screen made, once the gate has opened. Nothing
-        /// did this before: the automatic unpause in AllClientsReadyPacket.ProcessAllReady is
-        /// commented out upstream, so after a join the host was left staring at a frozen world
-        /// and had to toggle the speed itself to get moving again.
-        ///
-        /// Only reverses a pause THIS code made for the ready screen. A host that had paused
-        /// deliberately before anyone joined, or a pause from PauseSimOnPlayerLeft, keeps it -
-        /// resuming those would be overriding the player.
+        /// HOST ONLY - undo the ready-screen pause once the gate opens; the automatic unpause in
+        /// AllClientsReadyPacket.ProcessAllReady is commented out upstream. Only reverses a pause
+        /// THIS code made - a deliberate host pause or one from PauseSimOnPlayerLeft stays put.
         /// </summary>
         public static void ResumeSimAfterReadyScreen()
         {
@@ -593,7 +551,6 @@ namespace ONI_Together.Misc
 	        
 	        try
 	        {
-		        //return compressedText.Trim('`');
 		        byte[] gZipBuffer = Convert.FromBase64String(compressedText);
 		        using (var memoryStream = new MemoryStream())
 		        {

--- a/ONI_Together/Misc/Utils.cs
+++ b/ONI_Together/Misc/Utils.cs
@@ -479,10 +479,54 @@ namespace ONI_Together.Misc
 
         public static void PauseSimOnPlayerLeft()
         {
+	        // Host check first: this also runs on clients (e.g. RiptideClient peer-left), and
+	        // must bail before reading the host-only PauseSimOnPlayerDisconnect config.
 	        if (!MultiplayerSession.IsHost) return;
 	        if (!Configuration.Instance.PauseSimOnPlayerDisconnect) return;
-	        
-	        if(!SpeedControlScreen.Instance.IsPaused)
+
+	        PauseSimIfRunning();
+        }
+
+        /// <summary>
+        /// HOST ONLY - Pause the sim when a client joins / starts the ready sync so the
+        /// ready screen reflects a frozen world for everyone. Unlike PauseSimOnPlayerLeft
+        /// this is intentionally unconditional (not gated by PauseSimOnPlayerDisconnect):
+        /// the ready screen must freeze the world for correctness regardless of host prefs.
+        ///
+        /// Note: this only requests a pause when the host is currently *running* (see the
+        /// !IsPaused guard in PauseSimIfRunning). If the host is already paused nothing is
+        /// sent from here, but clients are not left to guess: GameSpeedSyncer re-broadcasts
+        /// the host's speed state on a 2s interval, so a client that is out of step converges
+        /// on the host's paused state on its own.
+        /// </summary>
+        public static void PauseSimForReadyScreen()
+        {
+	        using var _ = Profiler.Scope();
+
+	        // Mirror the InActiveSession guard that RefreshScreen/RefreshReadyState already use, so a
+	        // connect that happens before the session is established (the host's own loopback
+	        // client on LAN host-start) can never pause the sim — independent of how the caller
+	        // computes its loopback flag.
+	        if (!MultiplayerSession.InActiveSession) return;
+
+	        PauseSimIfRunning();
+        }
+
+        /// <summary>
+        /// HOST ONLY - Pause the sim if it is currently running. Pausing via TogglePause
+        /// reuses the TogglePause postfix in SpeedControlPatch.cs, which hands the new state
+        /// to GameSpeedSyncer.RequestSetSpeed and so fans it out to every client. The !IsPaused
+        /// guard keeps repeated calls (e.g. reconnect-after-load) a no-op, and pausing is
+        /// never blocked by the resume gate.
+        /// </summary>
+        private static void PauseSimIfRunning()
+        {
+	        using var _ = Profiler.Scope();
+
+	        if (!MultiplayerSession.IsHost) return;
+	        if (SpeedControlScreen.Instance == null) return;
+
+	        if (!SpeedControlScreen.Instance.IsPaused)
 				SpeedControlScreen.Instance.TogglePause(false);
         }
 

--- a/ONI_Together/Misc/World/GameServerHardSync.cs
+++ b/ONI_Together/Misc/World/GameServerHardSync.cs
@@ -38,11 +38,9 @@ namespace ONI_Together.Networking
 			}
 
 			// A closed resume gate means a client is mid-join or mid-load. A hard sync fired
-			// into that window starts a SECOND save transfer to a client already downloading
-			// one and reloads it twice - measured in a Steam session, where the cycle-start
-			// auto sync (GameClockPatch queues it on a 5s realtime delay, so it lands even
-			// after the join paused the sim) hit 8s into a join. hardSyncDoneThisCycle is
-			// deliberately left false: skipping is a postponement, not this cycle's sync.
+			// into that window starts a second save transfer to a client already downloading
+			// one and reloads it twice. hardSyncDoneThisCycle stays false: skipping is a
+			// postponement, not this cycle's sync.
 			if (MultiplayerSession.IsHost && !ReadyManager.CanHostResume())
 			{
 				DebugConsole.LogWarning(
@@ -51,10 +49,9 @@ namespace ONI_Together.Networking
 			}
 
 			// Through the ready-screen bookkeeping, not a bare Pause: this pause has no
-			// matching Unpause of its own anywhere (the automatic one in ProcessAllReady is
-			// commented out upstream), so it leaked one pause level per hard sync and left
-			// the host hammering the pause button afterwards. Flagged this way,
-			// ResumeSimAfterReadyScreen reverses it when the gate reopens.
+			// matching Unpause of its own anywhere, so a bare call leaks one pause level per
+			// hard sync. Flagged this way, ResumeSimAfterReadyScreen reverses it when the
+			// gate reopens.
 			Misc.Utils.PauseSimForReadyScreen();
 			MultiplayerOverlay.Show(STRINGS.UI.MP_OVERLAY.SYNC.HARDSYNC_INPROGRESS);
 

--- a/ONI_Together/Misc/World/GameServerHardSync.cs
+++ b/ONI_Together/Misc/World/GameServerHardSync.cs
@@ -37,7 +37,25 @@ namespace ONI_Together.Networking
 				return;
 			}
 
-			SpeedControlScreen.Instance?.Pause(false); // Pause the game
+			// A closed resume gate means a client is mid-join or mid-load. A hard sync fired
+			// into that window starts a SECOND save transfer to a client already downloading
+			// one and reloads it twice - measured in a Steam session, where the cycle-start
+			// auto sync (GameClockPatch queues it on a 5s realtime delay, so it lands even
+			// after the join paused the sim) hit 8s into a join. hardSyncDoneThisCycle is
+			// deliberately left false: skipping is a postponement, not this cycle's sync.
+			if (MultiplayerSession.IsHost && !ReadyManager.CanHostResume())
+			{
+				DebugConsole.LogWarning(
+					"[HardSync] Skipped: a client is still joining or loading (resume gate closed)");
+				return;
+			}
+
+			// Through the ready-screen bookkeeping, not a bare Pause: this pause has no
+			// matching Unpause of its own anywhere (the automatic one in ProcessAllReady is
+			// commented out upstream), so it leaked one pause level per hard sync and left
+			// the host hammering the pause button afterwards. Flagged this way,
+			// ResumeSimAfterReadyScreen reverses it when the gate reopens.
+			Misc.Utils.PauseSimForReadyScreen();
 			MultiplayerOverlay.Show(STRINGS.UI.MP_OVERLAY.SYNC.HARDSYNC_INPROGRESS);
 
             numberOfClientsAtTimeOfSync = MultiplayerSession.ConnectedPlayers.Count;

--- a/ONI_Together/MultiplayerMod.cs
+++ b/ONI_Together/MultiplayerMod.cs
@@ -41,6 +41,28 @@ namespace ONI_Together
         public static int MainThreadId { get; private set; }
         public static SynchronizationContext MainThread { get; private set; }
 
+        /// <summary>
+        /// Best-effort checkpoint trace. The file sits in the game install directory and is
+        /// opened, appended to and closed once per checkpoint, seven times in quick
+        /// succession - which loses races with on-access virus scanners often enough to
+        /// matter. Those writes used to run bare inside OnLoad's try, so a single
+        /// IOException on the trace file aborted the rest of initialisation: the
+        /// Multiplayer_Modules object and every component below it were never created, the
+        /// mod came up dead, and the log blamed whatever the aborted thread happened to be
+        /// parsing at the time. A diagnostic must never be able to do that.
+        /// </summary>
+        private static void TraceCheckpoint(string logPath, string message)
+        {
+            try
+            {
+                System.IO.File.AppendAllText(logPath, message);
+            }
+            catch (Exception ex)
+            {
+                DebugConsole.LogWarning($"[ONI_Together] Could not write startup trace: {ex.Message}");
+            }
+        }
+
         public override void OnLoad(Harmony harmony)
 		{
 			using var _ = Profiler.Scope();
@@ -61,20 +83,20 @@ namespace ONI_Together
 				DebugConsole.Log("[ONI_Together] Loaded Oxygen Not Included Together Multiplayer Mod.");
 
                 // CHECKPOINT 1
-                System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 1: Pre-DebugMenu\n");
+                TraceCheckpoint(logPath, "[Trace] Checkpoint 1: Pre-DebugMenu\n");
 				DebugMenu.Init();
 
                 // CHECKPOINT 2
-                System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 2: Pre-SteamLobby\n");
+                TraceCheckpoint(logPath, "[Trace] Checkpoint 2: Pre-SteamLobby\n");
 				SteamLobby.Initialize();
 
 				// CHECKPOINT 3
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 3: Pre-GameObjects\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 3: Pre-GameObjects\n");
 				var go = new GameObject("Multiplayer_Modules");
 				UnityEngine.Object.DontDestroyOnLoad(go);
 
 				// CHECKPOINT 4
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 4: Pre-Components\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 4: Pre-Components\n");
 				go.AddComponent<NetworkingComponent>();
 				go.AddComponent<UIVisibilityController>();
 				go.AddComponent<MainThreadExecutor>();
@@ -93,11 +115,11 @@ namespace ONI_Together
 				go.AddComponent<DiscordRichPresence>();
 
 				// CHECKPOINT 5
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 5: Pre-Listeners\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 5: Pre-Listeners\n");
 				SetupListeners();
 
 				// CHECKPOINT 6
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 6: Pre-ResLoad\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 6: Pre-ResLoad\n");
 				LoadAssetBundles();
 
 				foreach (var res in Assembly.GetExecutingAssembly().GetManifestResourceNames())
@@ -105,7 +127,7 @@ namespace ONI_Together
 					DebugConsole.Log("Embedded Resource: " + res);
 				}
 
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 7: Success\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 7: Success\n");
 			}
 			catch (Exception ex)
 			{

--- a/ONI_Together/MultiplayerMod.cs
+++ b/ONI_Together/MultiplayerMod.cs
@@ -42,14 +42,8 @@ namespace ONI_Together
         public static SynchronizationContext MainThread { get; private set; }
 
         /// <summary>
-        /// Best-effort checkpoint trace. The file sits in the game install directory and is
-        /// opened, appended to and closed once per checkpoint, seven times in quick
-        /// succession - which loses races with on-access virus scanners often enough to
-        /// matter. Those writes used to run bare inside OnLoad's try, so a single
-        /// IOException on the trace file aborted the rest of initialisation: the
-        /// Multiplayer_Modules object and every component below it were never created, the
-        /// mod came up dead, and the log blamed whatever the aborted thread happened to be
-        /// parsing at the time. A diagnostic must never be able to do that.
+        /// Best-effort startup trace. Failures are swallowed (on-access scanners race
+        /// these writes) - a diagnostic must never abort mod initialisation.
         /// </summary>
         private static void TraceCheckpoint(string logPath, string message)
         {

--- a/ONI_Together/Networking/Components/NetworkIdentity.cs
+++ b/ONI_Together/Networking/Components/NetworkIdentity.cs
@@ -22,6 +22,22 @@ namespace ONI_Together.Networking.Components
 			RegisterIdentity();
 		}
 
+		/// <summary>
+		/// Put this identity back into the registry if it is not there. For the registry's
+		/// scene rebuild (see NetworkIdentityRegistry.RebuildFromScene): after a session
+		/// teardown cleared the registry, IsRegistered still says true on every component, so
+		/// a plain RegisterIdentity call would no-op on exactly the entities that need
+		/// re-adding.
+		/// </summary>
+		public void EnsureRegistered()
+		{
+			if (NetId != 0 && NetworkIdentityRegistry.Exists(NetId))
+				return;
+
+			IsRegistered = false;
+			RegisterIdentity();
+		}
+
 		public void RegisterIdentity()
 		{
 			using var _ = Profiler.Scope();

--- a/ONI_Together/Networking/Components/NetworkingComponent.cs
+++ b/ONI_Together/Networking/Components/NetworkingComponent.cs
@@ -1,3 +1,4 @@
+using ONI_Together.Menus;
 using ONI_Together.DebugTools;
 using ONI_Together.Misc;
 using ONI_Together.Networking.States;

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -103,7 +103,15 @@ namespace ONI_Together.Networking
 			NetworkConfig.TransportClient.OnRequestStateOrReturn = () =>
 			{
                 PacketSender.SendToHost(GameStateRequestPacket.CreateClientRequest(MultiplayerSession.LocalUserID));
-                MP_Timer.Instance.StartDelayedAction(10, () => CoroutineRunner.RunOne(ShowMessageAndReturnToTitle()));
+                // Give-up deadline for the host's gamestate reply. 10s proved too tight: on a
+                // real post-load reconnect the reply has been measured at ~20s behind the
+                // world-sync flood, and this deadline quitting to menu would strand the host
+                // on the ready screen just as surely as getting no reply at all.
+                MP_Timer.Instance.StartDelayedAction(30, () =>
+                {
+                    DebugConsole.LogWarning("[GameClient] No gamestate reply from host within 30s - giving up and returning to menu.");
+                    CoroutineRunner.RunOne(ShowMessageAndReturnToTitle());
+                });
             };
             NetworkConfig.TransportClient.Prepare();
             CursorManager.Instance.AssignColor();

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -209,7 +209,17 @@ namespace ONI_Together.Networking
 				if (missingMods.Any())
 					text += string.Format(STRINGS.UI.MP_OVERLAY.SYNC.MODSYNC.MISSING, missingMods.Count) + "\n";
 
-				// Ignore this if we're in game already
+				// Only the menu can act on this. Syncing mods restarts the game, so there is
+				// nothing to offer a client that is already in a world - it must carry on.
+				//
+				// The return used to sit outside this branch, which stranded every post-load
+				// reconnect whose mod list differed from the host's. The client reconnected,
+				// the host answered its state request, and this returned before
+				// ContinueConnectionFlow - so the client never reached InGame and never
+				// reported Ready, the host's gate never opened, and the host sat on the ready
+				// screen for good. Silent, because the only log line here is inside the menu
+				// branch. Deterministic for anyone running a mod the host does not have, on
+				// every transport, which is exactly how it was reported.
 				if (Utils.IsInMenu())
 				{
 					DialogUtil.CreateConfirmDialogFrontend(STRINGS.UI.MP_OVERLAY.SYNC.MODSYNC.TITLE, text,
@@ -220,8 +230,11 @@ namespace ONI_Together.Networking
 					STRINGS.UI.MP_OVERLAY.SYNC.MODSYNC.DENY_SYNC,
 					ContinueConnectionFlow);
 					DebugConsole.Log("mods not synced!");
+					return;
 				}
-				return;
+
+				DebugConsole.LogWarning(
+					"[GameClient] Mod list differs from the host's, but we are already in game - continuing.");
 			}
 
 			ContinueConnectionFlow();

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -404,19 +404,17 @@ namespace ONI_Together.Networking
 		private const float POST_LOAD_RECONNECT_DELAY = 2f;
 
 		/// <summary>
-		/// CLIENT ONLY - a post-load reconnect died on a route/timeout race rather than on a
-		/// real refusal; start another attempt. Returns true if a retry was scheduled, false
-		/// once the attempts are spent, in which case the caller should fall back to its
-		/// normal give-up path.
+		/// CLIENT ONLY, Steamworks - a post-load reconnect died on a route race rather than a
+		/// real refusal; start another attempt. Returns false once the attempts are spent, so
+		/// the caller can fall back to its normal give-up path.
 		///
-		/// Measured in a Steam session: the reconnect after the world finished loading gave up
-		/// with ProblemDetectedLocally after ~31s, while the attempts either side of it reached
-		/// "fully established" in 15s and 25s. Steam had simply not finished finding a route in
-		/// time. Without a retry that single race threw the player back to the menu and out of
-		/// the lobby, with the host still holding a roster entry for them.
+		/// Measured: the reconnect after a world load gave up with ProblemDetectedLocally at
+		/// ~31s, while the attempts either side of it reached "fully established" in 15s and
+		/// 25s - Steam had simply not finished finding a route. That one race threw the player
+		/// back to the menu with the host still holding a roster entry for them.
 		///
-		/// HostUserID is still set at this point (ReconnectFromCache assigns it before it drops
-		/// the cache), so ConnectToHost can retry without the cached info.
+		/// ReconnectFromCache sets HostUserID before it hands off, so the retry can call
+		/// ConnectToHost with no cached info left.
 		/// </summary>
 		public static bool TryRetryPostLoadReconnect()
 		{

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -309,16 +309,6 @@ namespace ONI_Together.Networking
 				{
 					DebugConsole.Log("[GameClient] Requesting save file from host");
 
-					// Arm the host's load-window gate now, while the connection is healthy and
-					// about to stay up for the whole transfer. SaveHelper also sends this
-					// immediately before tearing the connection down, but that one races the
-					// socket close and is regularly lost - observed both ways in a two-instance
-					// session. Marking early is free: PendingLoadingClientCount only counts
-					// loaders that have dropped off the roster, so this has no effect until the
-					// client actually disconnects to load, and it expires on its own if the
-					// client never gets that far.
-					ReadyManager.SendReadyStatusPacket(ClientReadyState.Loading);
-
 					var packet = new SaveFileRequestPacket
 					{
 						Requester = MultiplayerSession.LocalUserID
@@ -406,6 +396,70 @@ namespace ONI_Together.Networking
 		{
 			_autoReconnecting = false;
 			_reconnectAttempt = 0;
+			_postLoadReconnectAttempt = 0;
+		}
+
+		private static int _postLoadReconnectAttempt = 0;
+		private const int MAX_POST_LOAD_RECONNECT_ATTEMPTS = 3;
+		private const float POST_LOAD_RECONNECT_DELAY = 2f;
+
+		/// <summary>
+		/// CLIENT ONLY - a post-load reconnect died on a route/timeout race rather than on a
+		/// real refusal; start another attempt. Returns true if a retry was scheduled, false
+		/// once the attempts are spent, in which case the caller should fall back to its
+		/// normal give-up path.
+		///
+		/// Measured in a Steam session: the reconnect after the world finished loading gave up
+		/// with ProblemDetectedLocally after ~31s, while the attempts either side of it reached
+		/// "fully established" in 15s and 25s. Steam had simply not finished finding a route in
+		/// time. Without a retry that single race threw the player back to the menu and out of
+		/// the lobby, with the host still holding a roster entry for them.
+		///
+		/// HostUserID is still set at this point (ReconnectFromCache assigns it before it drops
+		/// the cache), so ConnectToHost can retry without the cached info.
+		/// </summary>
+		public static bool TryRetryPostLoadReconnect()
+		{
+			using var _ = Profiler.Scope();
+
+			if (_postLoadReconnectAttempt >= MAX_POST_LOAD_RECONNECT_ATTEMPTS)
+			{
+				DebugConsole.LogWarning(
+					$"[GameClient] Post-load reconnect failed {_postLoadReconnectAttempt} times; giving up");
+				_postLoadReconnectAttempt = 0;
+				return false;
+			}
+
+			_postLoadReconnectAttempt++;
+			DebugConsole.Log(
+				$"[GameClient] Post-load reconnect failed; retry " +
+				$"{_postLoadReconnectAttempt}/{MAX_POST_LOAD_RECONNECT_ATTEMPTS} " +
+				$"in {POST_LOAD_RECONNECT_DELAY}s");
+			MultiplayerOverlay.Show(
+				$"Reconnecting... {_postLoadReconnectAttempt}/{MAX_POST_LOAD_RECONNECT_ATTEMPTS}");
+
+			CoroutineRunner.RunOne(RetryPostLoadReconnectCoroutine());
+			return true;
+		}
+
+		private static IEnumerator RetryPostLoadReconnectCoroutine()
+		{
+			yield return new WaitForSecondsRealtime(POST_LOAD_RECONNECT_DELAY);
+
+			if (!Utils.IsInGame())
+			{
+				DebugConsole.Log("[GameClient] No longer in game, abandoning post-load reconnect");
+				_postLoadReconnectAttempt = 0;
+				yield break;
+			}
+
+			ConnectToHost(false);
+		}
+
+		/// <summary>CLIENT ONLY - a reconnect landed; stop counting failures.</summary>
+		public static void NotifyReconnectSucceeded()
+		{
+			_postLoadReconnectAttempt = 0;
 		}
 
 		private static IEnumerator ShowMessageAndReturnToTitle(string reason = "", string message = "")

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -417,13 +417,9 @@ namespace ONI_Together.Networking
 
 		/// <summary>
 		/// CLIENT ONLY, Steamworks - a post-load reconnect died on a route race rather than a
-		/// real refusal; start another attempt. Returns false once the attempts are spent, so
-		/// the caller can fall back to its normal give-up path.
-		///
-		/// Measured: the reconnect after a world load gave up with ProblemDetectedLocally at
-		/// ~31s, while the attempts either side of it reached "fully established" in 15s and
-		/// 25s - Steam had simply not finished finding a route. That one race threw the player
-		/// back to the menu with the host still holding a roster entry for them.
+		/// real refusal; start another attempt. Steam's route setup can outlast the failure
+		/// callback, so one local failure is not a refusal. Returns false once the attempts
+		/// are spent, so the caller can fall back to its normal give-up path.
 		///
 		/// ReconnectFromCache sets HostUserID before it hands off, so the retry can call
 		/// ConnectToHost with no cached info left.

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -483,6 +483,13 @@ namespace ONI_Together.Networking
 
 		private static IEnumerator ShowMessageAndReturnToTitle(string reason = "", string message = "")
 		{
+			// This path ejects the player to the menu; it must never run silently. It is
+			// also the proof the coroutine started at all - its schedulers go through
+			// CoroutineRunner, whose failure would otherwise be indistinguishable from
+			// never having been scheduled.
+			DebugConsole.LogWarning(
+				$"[GameClient] Returning to title. Reason: '{reason}' Message: '{message}'");
+
 			// Auto-reconnect if still in game and under max attempts
 			//if (Utils.IsInGame() && _reconnectAttempt < MAX_RECONNECT_ATTEMPTS)
 			//{

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -308,6 +308,17 @@ namespace ONI_Together.Networking
 				if (!IsHardSyncInProgress)
 				{
 					DebugConsole.Log("[GameClient] Requesting save file from host");
+
+					// Arm the host's load-window gate now, while the connection is healthy and
+					// about to stay up for the whole transfer. SaveHelper also sends this
+					// immediately before tearing the connection down, but that one races the
+					// socket close and is regularly lost - observed both ways in a two-instance
+					// session. Marking early is free: PendingLoadingClientCount only counts
+					// loaders that have dropped off the roster, so this has no effect until the
+					// client actually disconnects to load, and it expires on its own if the
+					// client never gets that far.
+					ReadyManager.SendReadyStatusPacket(ClientReadyState.Loading);
+
 					var packet = new SaveFileRequestPacket
 					{
 						Requester = MultiplayerSession.LocalUserID

--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -103,10 +103,9 @@ namespace ONI_Together.Networking
 			NetworkConfig.TransportClient.OnRequestStateOrReturn = () =>
 			{
                 PacketSender.SendToHost(GameStateRequestPacket.CreateClientRequest(MultiplayerSession.LocalUserID));
-                // Give-up deadline for the host's gamestate reply. 10s proved too tight: on a
-                // real post-load reconnect the reply has been measured at ~20s behind the
-                // world-sync flood, and this deadline quitting to menu would strand the host
-                // on the ready screen just as surely as getting no reply at all.
+                // Give-up deadline for the host's gamestate reply. Post-load replies have
+                // been measured at ~20s behind the world-sync flood, so anything tighter
+                // ejects a healthy client mid-handshake.
                 MP_Timer.Instance.StartDelayedAction(30, () =>
                 {
                     DebugConsole.LogWarning("[GameClient] No gamestate reply from host within 30s - giving up and returning to menu.");
@@ -217,17 +216,9 @@ namespace ONI_Together.Networking
 				if (missingMods.Any())
 					text += string.Format(STRINGS.UI.MP_OVERLAY.SYNC.MODSYNC.MISSING, missingMods.Count) + "\n";
 
-				// Only the menu can act on this. Syncing mods restarts the game, so there is
-				// nothing to offer a client that is already in a world - it must carry on.
-				//
-				// The return used to sit outside this branch, which stranded every post-load
-				// reconnect whose mod list differed from the host's. The client reconnected,
-				// the host answered its state request, and this returned before
-				// ContinueConnectionFlow - so the client never reached InGame and never
-				// reported Ready, the host's gate never opened, and the host sat on the ready
-				// screen for good. Silent, because the only log line here is inside the menu
-				// branch. Deterministic for anyone running a mod the host does not have, on
-				// every transport, which is exactly how it was reported.
+				// Only the menu can act on a mismatch - syncing restarts the game. An
+				// in-game client must carry on: returning here would kill the post-load
+				// reconnect before the Ready send and leave the host's gate closed forever.
 				if (Utils.IsInMenu())
 				{
 					DialogUtil.CreateConfirmDialogFrontend(STRINGS.UI.MP_OVERLAY.SYNC.MODSYNC.TITLE, text,
@@ -483,10 +474,8 @@ namespace ONI_Together.Networking
 
 		private static IEnumerator ShowMessageAndReturnToTitle(string reason = "", string message = "")
 		{
-			// This path ejects the player to the menu; it must never run silently. It is
-			// also the proof the coroutine started at all - its schedulers go through
-			// CoroutineRunner, whose failure would otherwise be indistinguishable from
-			// never having been scheduled.
+			// Every ejection to the menu funnels through here; log before acting so
+			// this path can never run silently.
 			DebugConsole.LogWarning(
 				$"[GameClient] Returning to title. Reason: '{reason}' Message: '{message}'");
 

--- a/ONI_Together/Networking/GameServer.cs
+++ b/ONI_Together/Networking/GameServer.cs
@@ -71,11 +71,9 @@ namespace ONI_Together.Networking
 			NetworkConfig.TransportServer.Start();
 
 			// Ending a session clears NetworkIdentityRegistry, but the world stays loaded and
-			// no OnSpawn runs again - so hosting a SECOND session on the same world served it
-			// from an empty registry. Measured on a LAN re-host: the previous session ran with
-			// 11,106 entries, the new one at "Count: 0" with 3,500+ NetId lookup failures in
-			// seconds - connected, but nothing entity-based synced. The NetIds themselves are
-			// still on the NetworkIdentity components ([Serialize]), so re-scan the scene.
+			// no OnSpawn runs again - hosting a second session on the same world would serve
+			// it from an empty registry. The NetIds are still on the NetworkIdentity
+			// components ([Serialize]), so re-scan the scene.
 			if (Misc.Utils.IsInGame())
 				NetworkIdentityRegistry.RebuildFromScene();
 

--- a/ONI_Together/Networking/GameServer.cs
+++ b/ONI_Together/Networking/GameServer.cs
@@ -70,6 +70,15 @@ namespace ONI_Together.Networking
 			MultiplayerSession.IsHost = true;
 			NetworkConfig.TransportServer.Start();
 
+			// Ending a session clears NetworkIdentityRegistry, but the world stays loaded and
+			// no OnSpawn runs again - so hosting a SECOND session on the same world served it
+			// from an empty registry. Measured on a LAN re-host: the previous session ran with
+			// 11,106 entries, the new one at "Count: 0" with 3,500+ NetId lookup failures in
+			// seconds - connected, but nothing entity-based synced. The NetIds themselves are
+			// still on the NetworkIdentity components ([Serialize]), so re-scan the scene.
+			if (Misc.Utils.IsInGame())
+				NetworkIdentityRegistry.RebuildFromScene();
+
 			DebugConsole.Log("[GameServer] Game Server started!");
 			//MultiplayerSession.InSession = true;
 			Game.Instance?.Trigger(MP_HASHES.OnConnected);
@@ -84,6 +93,10 @@ namespace ONI_Together.Networking
 			using var _ = Profiler.Scope();
 
 			SetState(ServerState.Stopped);
+
+			// A transfer that was mid-flight when the session ended has no client left to ACK
+			// it; without this its retry loop kept resending into the void.
+			SaveFileTransferManager.CancelAll();
 
 			NetworkConfig.TransportServer.CloseConnections();
 			NetworkConfig.TransportServer.Stop();

--- a/ONI_Together/Networking/MultiplayerPlayer.cs
+++ b/ONI_Together/Networking/MultiplayerPlayer.cs
@@ -15,7 +15,9 @@ public class MultiplayerPlayer
 	public bool IsConnected => Connection != null;
 	public bool ProtocolVerified { get; set; }
 
-	public ClientReadyState readyState = ClientReadyState.Ready;
+	// Default to Unready: a freshly created/recreated player (e.g. on connect or
+	// reconnect-for-load) must never read as ready until it explicitly says so.
+	public ClientReadyState readyState = ClientReadyState.Unready;
 
     public MultiplayerPlayer(ulong playerId)
 	{

--- a/ONI_Together/Networking/MultiplayerPlayer.cs
+++ b/ONI_Together/Networking/MultiplayerPlayer.cs
@@ -20,6 +20,12 @@ public class MultiplayerPlayer
 	public ClientReadyState readyState = ClientReadyState.Unready;
 
 	/// <summary>
+	/// Unscaled time of the last not-ready transition; -1 while Ready. Feeds the host's
+	/// ready timeout (TransportServer.ExpireNeverReadyClients).
+	/// </summary>
+	public float UnreadySince = UnityEngine.Time.unscaledTime;
+
+	/// <summary>
 	/// Whether chat has already said this player joined. Lives on the roster entry so it dies
 	/// with it: a player who leaves and comes back is a new join and gets announced again, while
 	/// a client that merely disconnected to load the level does not.

--- a/ONI_Together/Networking/MultiplayerPlayer.cs
+++ b/ONI_Together/Networking/MultiplayerPlayer.cs
@@ -19,6 +19,13 @@ public class MultiplayerPlayer
 	// reconnect-for-load) must never read as ready until it explicitly says so.
 	public ClientReadyState readyState = ClientReadyState.Unready;
 
+	/// <summary>
+	/// Whether chat has already said this player joined. Lives on the roster entry so it dies
+	/// with it: a player who leaves and comes back is a new join and gets announced again, while
+	/// a client that merely disconnected to load the level does not.
+	/// </summary>
+	public bool JoinAnnounced { get; set; }
+
     public MultiplayerPlayer(ulong playerId)
 	{
 		PlayerId = playerId;

--- a/ONI_Together/Networking/NetworkConfig.cs
+++ b/ONI_Together/Networking/NetworkConfig.cs
@@ -113,11 +113,8 @@ namespace ONI_Together.Networking
                     StopRaw();
                     break;
             }
-            // The session is over, so there is nothing left to wait for. Nobody was closing this:
-            // GameServer has its Close call commented out and the lobby dialog's End Session
-            // button only calls Stop, so ending a session left the ready screen up for good -
-            // the host sat looking at "waiting for players" with no session to wait for and no
-            // way back. Closing here covers every exit path and both roles.
+            // The session is over, so there is nothing left to wait for. No individual exit
+            // path closes this reliably; closing here covers them all, for both roles.
             MultiplayerOverlay.Close();
 
             Game.Instance?.Trigger(MP_HASHES.OnDisconnected);

--- a/ONI_Together/Networking/NetworkConfig.cs
+++ b/ONI_Together/Networking/NetworkConfig.cs
@@ -1,3 +1,4 @@
+using ONI_Together.Menus;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -112,6 +113,13 @@ namespace ONI_Together.Networking
                     StopRaw();
                     break;
             }
+            // The session is over, so there is nothing left to wait for. Nobody was closing this:
+            // GameServer has its Close call commented out and the lobby dialog's End Session
+            // button only calls Stop, so ending a session left the ready screen up for good -
+            // the host sat looking at "waiting for players" with no session to wait for and no
+            // way back. Closing here covers every exit path and both roles.
+            MultiplayerOverlay.Close();
+
             Game.Instance?.Trigger(MP_HASHES.OnDisconnected);
         }
 

--- a/ONI_Together/Networking/NetworkIdentityRegistry.cs
+++ b/ONI_Together/Networking/NetworkIdentityRegistry.cs
@@ -72,6 +72,25 @@ namespace ONI_Together.Networking
 				DebugConsole.Log($"[NetEntityRegistry] Registered overridden NetId {netId} for {entity.name}");
 			}
 		}
+		/// <summary>
+		/// Re-register every NetworkIdentity alive in the scene. For hosting again on a world
+		/// that stayed loaded: session teardown cleared this registry, and OnSpawn - the only
+		/// other registration path - never runs again for existing entities.
+		/// </summary>
+		public static void RebuildFromScene()
+		{
+			using var _ = Profiler.Scope();
+
+			int before = Count;
+			var found = UnityEngine.Object.FindObjectsByType<NetworkIdentity>(FindObjectsSortMode.None);
+			foreach (var identity in found)
+				identity.EnsureRegistered();
+
+			DebugConsole.Log(
+				$"[NetEntityRegistry] Rebuilt from scene: {before} -> {Count} entries " +
+				$"({found.Length} identities in scene)");
+		}
+
 		public static bool Exists(int netId) => identities.ContainsKey(netId);
 
 

--- a/ONI_Together/Networking/OxySync/Components/GameSpeedSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/GameSpeedSyncer.cs
@@ -1,3 +1,4 @@
+using ONI_Together.DebugTools;
 using KSerialization;
 using ONI_Together.Patches;
 using Shared.OxySync;
@@ -54,7 +55,33 @@ namespace ONI_Together.Networking.OxySync.Components
         [Command]
         private void CmdSetSpeed(int speed)
         {
-            ApplyAndBroadcast((SpeedState)speed);
+            var requested = (SpeedState)speed;
+
+            // Authority choke point for a client-originated resume. This method is the only
+            // way a client can change the sim speed (CommandPacket.OnDispatched -> host ->
+            // InvokeCommand), and rejecting here covers both halves in one place: the host
+            // neither applies the speed locally nor fans it out via RpcApplySpeed, because
+            // ApplyAndBroadcast does both. Pausing is always allowed - only resume is gated.
+            //
+            // The host's own resume attempts are already stopped upstream by the
+            // SpeedControlPatch prefixes, so this is a second, independent layer rather than
+            // a duplicate: both resolve through the single ReadyManager.CanHostResume()
+            // predicate, and a blocked call here simply leaves the sim as it was.
+            if (requested != SpeedState.Paused && !ReadyManager.CanHostResume())
+            {
+                DebugConsole.Log(
+                    $"[GameSpeedSyncer] Rejected remote resume to {requested}: not all players are ready");
+                ReadyManager.RefreshScreen();
+
+                // The requesting client already applied the resume to its own screen before
+                // asking (the postfix runs after the original). Re-assert the authoritative
+                // state now instead of letting it run until the next force-sync tick, so the
+                // rejection lands within a round trip rather than up to FORCE_SYNC_INTERVAL.
+                CallClientRpc(nameof(RpcApplySpeed), (int)_currentState);
+                return;
+            }
+
+            ApplyAndBroadcast(requested);
         }
 
         private void ApplyAndBroadcast(SpeedState state)

--- a/ONI_Together/Networking/OxySync/Components/GameSpeedSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/GameSpeedSyncer.cs
@@ -57,16 +57,11 @@ namespace ONI_Together.Networking.OxySync.Components
         {
             var requested = (SpeedState)speed;
 
-            // Authority choke point for a client-originated resume. This method is the only
-            // way a client can change the sim speed (CommandPacket.OnDispatched -> host ->
-            // InvokeCommand), and rejecting here covers both halves in one place: the host
-            // neither applies the speed locally nor fans it out via RpcApplySpeed, because
-            // ApplyAndBroadcast does both. Pausing is always allowed - only resume is gated.
-            //
-            // The host's own resume attempts are already stopped upstream by the
-            // SpeedControlPatch prefixes, so this is a second, independent layer rather than
-            // a duplicate: both resolve through the single ReadyManager.CanHostResume()
-            // predicate, and a blocked call here simply leaves the sim as it was.
+            // Authority choke point for a client-originated resume: the only path a client
+            // can change sim speed (CommandPacket -> host -> InvokeCommand), and rejecting
+            // here covers apply and broadcast in one place. Pausing is always allowed - only
+            // resume is gated. The host's own resumes are stopped by the SpeedControlPatch
+            // prefixes; both layers resolve through ReadyManager.CanHostResume().
             if (requested != SpeedState.Paused && !ReadyManager.CanHostResume())
             {
                 DebugConsole.Log(
@@ -74,9 +69,8 @@ namespace ONI_Together.Networking.OxySync.Components
                 ReadyManager.RefreshScreen();
 
                 // The requesting client already applied the resume to its own screen before
-                // asking (the postfix runs after the original). Re-assert the authoritative
-                // state now instead of letting it run until the next force-sync tick, so the
-                // rejection lands within a round trip rather than up to FORCE_SYNC_INTERVAL.
+                // asking. Re-assert the authoritative state now, so the rejection lands
+                // within a round trip instead of at the next force-sync tick.
                 CallClientRpc(nameof(RpcApplySpeed), (int)_currentState);
                 return;
             }

--- a/ONI_Together/Networking/Packets/Architecture/IHostRelayGate.cs
+++ b/ONI_Together/Networking/Packets/Architecture/IHostRelayGate.cs
@@ -1,0 +1,24 @@
+namespace ONI_Together.Networking.Packets.Architecture
+{
+	/// <summary>
+	/// Implemented by packets that the host must be able to veto at the relay choke point
+	/// (<see cref="ONI_Together.Networking.Packets.Core.HostBroadcastPacket"/>). When a
+	/// client wraps a packet for the host to fan out, the host first asks
+	/// <see cref="HostShouldProcess"/>; if it returns false the host neither applies the
+	/// packet locally nor rebroadcasts it to the other clients.
+	///
+	/// This exists because the resume gate (see SpeedChangePacket / SpeedControlPatch) lived
+	/// inside the inner packet's OnDispatched and only protected the host's local apply — the
+	/// generic relay would still fan a rejected resume out to every other client, letting one
+	/// client flip the others' pause state while the host stayed paused. Gating here covers
+	/// both apply and fan-out from a single authoritative point.
+	/// </summary>
+	public interface IHostRelayGate
+	{
+		/// <summary>
+		/// HOST - return false to have the relay drop this packet entirely (no local apply,
+		/// no rebroadcast).
+		/// </summary>
+		bool HostShouldProcess();
+	}
+}

--- a/ONI_Together/Networking/Packets/Architecture/PacketSender.cs
+++ b/ONI_Together/Networking/Packets/Architecture/PacketSender.cs
@@ -250,7 +250,17 @@ namespace ONI_Together.Networking
 
 			if (!MultiplayerSession.ConnectedPlayers.TryGetValue(steamID, out var player) || player.Connection == null)
 			{
-				DebugConsole.LogWarning($"[PacketSender] No connection found for SteamID {steamID}");
+				// A client that is mid load-reconnect keeps a Connection==null placeholder in
+				// the roster for the whole load window - that is by design on Steamworks, see
+				// TransportServer.PendingLoadingClientCount. Sends to it are expected to fail
+				// until it comes back, and warning once per call turned a normal 30s load into
+				// hundreds of log lines a second in a real session. Stay quiet for a known
+				// loader; keep warning for anyone else, where this really is unexpected.
+				// Name the packet type: it is the only clue to WHICH system is still sending
+				// to a player who is gone.
+				if (NetworkConfig.TransportServer?.IsClientLoading(steamID) != true)
+					DebugConsole.LogWarning(
+						$"[PacketSender] No connection found for SteamID {steamID} (packet {packet.GetType().Name})");
 				return false;
 			}
 

--- a/ONI_Together/Networking/Packets/Architecture/PacketSender.cs
+++ b/ONI_Together/Networking/Packets/Architecture/PacketSender.cs
@@ -250,11 +250,9 @@ namespace ONI_Together.Networking
 
 			if (!MultiplayerSession.ConnectedPlayers.TryGetValue(steamID, out var player) || player.Connection == null)
 			{
-				// A client that is mid load-reconnect keeps a Connection==null placeholder in
-				// the roster for the whole load window - that is by design on Steamworks, see
-				// TransportServer.PendingLoadingClientCount. Sends to it are expected to fail
-				// until it comes back, and warning once per call turned a normal 30s load into
-				// hundreds of log lines a second in a real session. Stay quiet for a known
+				// A client mid load-reconnect keeps a Connection==null roster placeholder for
+				// the whole load window (see TransportServer.PendingLoadingClientCount), so
+				// sends to it are expected to fail until it returns. Stay quiet for a known
 				// loader; keep warning for anyone else, where this really is unexpected.
 				// Name the packet type: it is the only clue to WHICH system is still sending
 				// to a player who is gone.

--- a/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
@@ -125,28 +125,36 @@ namespace ONI_Together.Networking.Packets.Core
             ReadyManager.SetPlayerReadyState(player, Status);
 			DebugConsole.Log($"[ClientReadyStatusPacket] {SenderId} marked as {Status}");
 
-			if (NetworkConfig.IsLanConfig() && nameChanged)
+			if (nameChanged)
 			{
+				// Consume on every transport, not just LAN. The flag is one-shot and only the
+				// LAN path prints the joined line, so gating the consume on IsLanConfig left
+				// Steam entries standing for the life of the session. Harmless in size - a set
+				// keyed by client id holds at most one entry per player - but it made
+				// ConsumeReconnectFromLoad answer about a reconnect that happened long ago.
 				bool isLoadingReconnect =
 					NetworkConfig.TransportServer?.ConsumeReconnectFromLoad(SenderId) == true;
 
-				if (!isLoadingReconnect)
+				if (NetworkConfig.IsLanConfig())
 				{
-					OxySyncChat.AddSystemMessage(
-						string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_JOINED, player.PlayerName));
+					if (!isLoadingReconnect)
+					{
+						OxySyncChat.AddSystemMessage(
+							string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_JOINED, player.PlayerName));
+					}
+
+					PacketSender.SendToAllClients(new ClientReadyStatusPacket
+					{
+						SenderId = MultiplayerSession.HostUserID,
+						PlayerName = Utils.GetLocalPlayerName()
+					});
+
+					PacketSender.SendToAllClients(new ClientReadyStatusPacket
+					{
+						SenderId = SenderId,
+						PlayerName = player.PlayerName
+					});
 				}
-
-				PacketSender.SendToAllClients(new ClientReadyStatusPacket
-				{
-					SenderId = MultiplayerSession.HostUserID,
-					PlayerName = Utils.GetLocalPlayerName()
-				});
-
-				PacketSender.SendToAllClients(new ClientReadyStatusPacket
-				{
-					SenderId = SenderId,
-					PlayerName = player.PlayerName
-				});
 			}
 
 			ReadyManager.RefreshScreen();

--- a/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
@@ -83,24 +83,19 @@ namespace ONI_Together.Networking.Packets.Core
 
 			if (Status == ClientReadyState.Loading)
 			{
-				// Tracked on the base transport, not on one concrete server: the client is
-				// about to drop its connection to load, and every transport needs the host to
-				// keep it gated until it comes back.
-				//
-				// Handled BEFORE the roster lookup on purpose. The client sends this
-				// immediately before closing its connection, so the notice regularly arrives
-				// after the transport has already removed it from ConnectedPlayers - the
-				// disconnect and this packet land microseconds apart. Requiring a live roster
-				// entry here dropped the notice on exactly the path it exists for, leaving
-				// PendingLoadingClientCount at zero for the whole load window.
+				// Tracked on the base transport, not on one concrete server: every transport
+				// needs the host to keep this client gated until it comes back. Must run
+				// BEFORE the roster lookup - the client sends this immediately before closing
+				// its connection, so it often arrives after the transport already dropped it
+				// from ConnectedPlayers, and requiring a live roster entry here killed the
+				// notice on exactly the path it exists for.
 				NetworkConfig.TransportServer?.MarkClientLoading(SenderId);
 				DebugConsole.Log(
 					$"[ClientReadyStatusPacket] {SenderId} marked as Loading (pending off-roster loads: " +
 					$"{NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0})");
 
-				// The disconnect that follows (or already happened) drives its own
-				// RefreshReadyState. If it ran first it saw only the host left and took the
-				// "everyone is ready" shortcut, closing the ready screen and opening the
+				// The disconnect drives its own RefreshReadyState, but if it ran first it saw
+				// only the host left, took the "everyone is ready" shortcut and opened the
 				// resume gate. Recompute now that the pending load is on record.
 				ReadyManager.RefreshScreen();
 				ReadyManager.RefreshReadyState();
@@ -125,15 +120,10 @@ namespace ONI_Together.Networking.Packets.Core
             ReadyManager.SetPlayerReadyState(player, Status);
 			DebugConsole.Log($"[ClientReadyStatusPacket] {SenderId} marked as {Status}");
 
-			// Announce the join when the player is actually in, not when they first appear.
-			// Steam used to say it on lobby entry (SteamLobby), which is a whole join ahead of
-			// the truth - measured at 06:57:40 entering the lobby against 06:58:18 reaching the
-			// world, so the line landed while they were still watching the ready screen. Ready
-			// is the first moment the statement is true.
-			//
-			// JoinAnnounced keeps a returning loader quiet: it is already set from their first
-			// join, and it is cleared only by the roster entry being dropped, which is what
-			// leaving for real does.
+			// Ready is the first moment "joined" is true. Do not move this back to Steam lobby
+			// entry (SteamLobby): that announces a whole join early, while the player is still
+			// watching the ready screen. JoinAnnounced keeps a returning loader quiet - it is
+			// cleared only by the roster entry being dropped, i.e. by leaving for real.
 			if (!NetworkConfig.IsLanConfig()
 				&& Status == ClientReadyState.Ready
 				&& !player.JoinAnnounced)
@@ -146,10 +136,8 @@ namespace ONI_Together.Networking.Packets.Core
 			if (nameChanged)
 			{
 				// Consume on every transport, not just LAN. The flag is one-shot and only the
-				// LAN path prints the joined line, so gating the consume on IsLanConfig left
-				// Steam entries standing for the life of the session. Harmless in size - a set
-				// keyed by client id holds at most one entry per player - but it made
-				// ConsumeReconnectFromLoad answer about a reconnect that happened long ago.
+				// LAN branch below prints a joined line, so gating the consume on IsLanConfig
+				// left Steam entries standing all session, answering about a stale reconnect.
 				bool isLoadingReconnect =
 					NetworkConfig.TransportServer?.ConsumeReconnectFromLoad(SenderId) == true;
 

--- a/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
@@ -81,19 +81,38 @@ namespace ONI_Together.Networking.Packets.Core
 				return;
 			}
 
+			if (Status == ClientReadyState.Loading)
+			{
+				// Tracked on the base transport, not on one concrete server: the client is
+				// about to drop its connection to load, and every transport needs the host to
+				// keep it gated until it comes back.
+				//
+				// Handled BEFORE the roster lookup on purpose. The client sends this
+				// immediately before closing its connection, so the notice regularly arrives
+				// after the transport has already removed it from ConnectedPlayers - the
+				// disconnect and this packet land microseconds apart. Requiring a live roster
+				// entry here dropped the notice on exactly the path it exists for, leaving
+				// PendingLoadingClientCount at zero for the whole load window.
+				NetworkConfig.TransportServer?.MarkClientLoading(SenderId);
+				DebugConsole.Log(
+					$"[ClientReadyStatusPacket] {SenderId} marked as Loading (pending off-roster loads: " +
+					$"{NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0})");
+
+				// The disconnect that follows (or already happened) drives its own
+				// RefreshReadyState. If it ran first it saw only the host left and took the
+				// "everyone is ready" shortcut, closing the ready screen and opening the
+				// resume gate. Recompute now that the pending load is on record.
+				ReadyManager.RefreshScreen();
+				ReadyManager.RefreshReadyState();
+				return;
+			}
+
 			MultiplayerPlayer player;
 			MultiplayerSession.ConnectedPlayers.TryGetValue(SenderId, out player);
 
 			if (player == null)
 			{
 				DebugConsole.LogError("Tried to update ready state for a null player", false);
-				return;
-			}
-
-			if (Status == ClientReadyState.Loading)
-			{
-				var server = NetworkConfig.TransportServer as LiteNetLibServer;
-				server?.MarkClientLoading(SenderId);
 				return;
 			}
 
@@ -108,8 +127,8 @@ namespace ONI_Together.Networking.Packets.Core
 
 			if (NetworkConfig.IsLanConfig() && nameChanged)
 			{
-				var server = NetworkConfig.TransportServer as LiteNetLibServer;
-				bool isLoadingReconnect = server != null && server.ConsumeReconnectFromLoad(SenderId);
+				bool isLoadingReconnect =
+					NetworkConfig.TransportServer?.ConsumeReconnectFromLoad(SenderId) == true;
 
 				if (!isLoadingReconnect)
 				{

--- a/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
@@ -83,12 +83,10 @@ namespace ONI_Together.Networking.Packets.Core
 
 			if (Status == ClientReadyState.Loading)
 			{
-				// Tracked on the base transport, not on one concrete server: every transport
-				// needs the host to keep this client gated until it comes back. Must run
-				// BEFORE the roster lookup - the client sends this immediately before closing
-				// its connection, so it often arrives after the transport already dropped it
-				// from ConnectedPlayers, and requiring a live roster entry here killed the
-				// notice on exactly the path it exists for.
+				// Tracked on the base transport: every transport needs the host to keep this
+				// client gated until it comes back. Must run BEFORE the roster lookup - the
+				// client sends this immediately before closing its connection, so it often
+				// arrives after the transport already dropped it from ConnectedPlayers.
 				NetworkConfig.TransportServer?.MarkClientLoading(SenderId);
 				DebugConsole.Log(
 					$"[ClientReadyStatusPacket] {SenderId} marked as Loading (pending off-roster loads: " +

--- a/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
@@ -125,6 +125,24 @@ namespace ONI_Together.Networking.Packets.Core
             ReadyManager.SetPlayerReadyState(player, Status);
 			DebugConsole.Log($"[ClientReadyStatusPacket] {SenderId} marked as {Status}");
 
+			// Announce the join when the player is actually in, not when they first appear.
+			// Steam used to say it on lobby entry (SteamLobby), which is a whole join ahead of
+			// the truth - measured at 06:57:40 entering the lobby against 06:58:18 reaching the
+			// world, so the line landed while they were still watching the ready screen. Ready
+			// is the first moment the statement is true.
+			//
+			// JoinAnnounced keeps a returning loader quiet: it is already set from their first
+			// join, and it is cleared only by the roster entry being dropped, which is what
+			// leaving for real does.
+			if (!NetworkConfig.IsLanConfig()
+				&& Status == ClientReadyState.Ready
+				&& !player.JoinAnnounced)
+			{
+				player.JoinAnnounced = true;
+				OxySyncChat.AddSystemMessage(
+					string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_JOINED, player.PlayerName));
+			}
+
 			if (nameChanged)
 			{
 				// Consume on every transport, not just LAN. The flag is one-shot and only the

--- a/ONI_Together/Networking/Packets/Core/HostBroadcastPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/HostBroadcastPacket.cs
@@ -64,6 +64,16 @@ namespace ONI_Together.Networking.Packets.Core
 			//this packet should only be sent by clients to the host
 			if (MultiplayerSession.IsHost)
 			{
+				// Authoritative choke point: let the inner packet veto being relayed/applied
+				// (e.g. a client-originated resume while not all players are ready). Without
+				// this the host would fan a rejected resume out to the other clients even
+				// though it refuses to resume its own sim.
+				if (innerPacket is IHostRelayGate gate && !gate.HostShouldProcess())
+				{
+					DebugConsole.Log($"[HostBroadcastPacket] dropped gated {innerPacket.GetType().Name} relay from {SenderId}");
+					return; //neither apply nor rebroadcast
+				}
+
 				//trigger it on the host
 				innerPacket.OnDispatched();
 				//send it to all other clients except the sender

--- a/ONI_Together/Networking/Packets/Social/ChatHistorySyncPacket.cs
+++ b/ONI_Together/Networking/Packets/Social/ChatHistorySyncPacket.cs
@@ -58,7 +58,9 @@ namespace ONI_Together.Networking.Packets.Social
 
 			if (UnityChatBoxUI.Instance != null)
 			{
-				var ts = DateTimeOffset.FromUnixTimeMilliseconds(0).DateTime.ToString("HH:mm", CultureInfo.InvariantCulture);
+				// Stamp "chat initialized" with the local clock. It used to render epoch zero
+				// ("00:00"), which read like a message from midnight.
+				var ts = System.DateTime.Now.ToString("HH:mm", CultureInfo.InvariantCulture);
 				UnityChatBoxUI.Instance.SendNewChatMessage("System", ts, STRINGS.UI.MP_CHATWINDOW.CHAT_INITIALIZED);
 			}
 

--- a/ONI_Together/Networking/Packets/Social/ChatHistorySyncPacket.cs
+++ b/ONI_Together/Networking/Packets/Social/ChatHistorySyncPacket.cs
@@ -58,8 +58,7 @@ namespace ONI_Together.Networking.Packets.Social
 
 			if (UnityChatBoxUI.Instance != null)
 			{
-				// Stamp "chat initialized" with the local clock. It used to render epoch zero
-				// ("00:00"), which read like a message from midnight.
+				// Stamp "chat initialized" with the local clock, not epoch zero ("00:00").
 				var ts = System.DateTime.Now.ToString("HH:mm", CultureInfo.InvariantCulture);
 				UnityChatBoxUI.Instance.SendNewChatMessage("System", ts, STRINGS.UI.MP_CHATWINDOW.CHAT_INITIALIZED);
 			}

--- a/ONI_Together/Networking/Packets/Tools/Dig/DiggablePacket.cs
+++ b/ONI_Together/Networking/Packets/Tools/Dig/DiggablePacket.cs
@@ -1,4 +1,6 @@
-﻿using ONI_Together.Networking.Packets.Architecture;
+﻿using ONI_Together.DebugTools;
+using ONI_Together.Misc;
+using ONI_Together.Networking.Packets.Architecture;
 using System.IO;
 using Shared.Profiling;
 using UnityEngine;
@@ -54,6 +56,24 @@ namespace ONI_Together.Networking.Packets.Tools.Dig
         public void OnDispatched()
         {
             using var _ = Profiler.Scope();
+
+            // A client still in the menu, or part way through downloading the save, has no world
+            // yet and DigTool.PlaceDig throws straight through it. Measured over one join: 64
+            // "Failed to handle incoming packet: NullReferenceException at DigTool.PlaceDig"
+            // before this guard, 0 after - with the guard itself hit 78 times, so the condition
+            // is just as frequent either way.
+            //
+            // The dig order is lost either way, and nothing else is: PacketHandler.HandleIncoming
+            // is called inside a per-message try/catch (SteamworksClient.ProcessIncomingMessages),
+            // so a throwing packet costs only itself. What this buys is a one-line warning in
+            // place of a multi-frame stack dump, and an explicit statement that dropping the
+            // order is the intended behaviour rather than an accident.
+            if (!Utils.IsInGame() || !Grid.IsValidCell(Cell))
+            {
+                DebugConsole.LogWarning(
+                    $"[DiggablePacket] Dropped dig for cell {Cell}: no world loaded yet");
+                return;
+            }
 
             GameObject game_object;
             ProcessingIncoming = true;

--- a/ONI_Together/Networking/Packets/Tools/Dig/DiggablePacket.cs
+++ b/ONI_Together/Networking/Packets/Tools/Dig/DiggablePacket.cs
@@ -57,17 +57,9 @@ namespace ONI_Together.Networking.Packets.Tools.Dig
         {
             using var _ = Profiler.Scope();
 
-            // A client still in the menu, or part way through downloading the save, has no world
-            // yet and DigTool.PlaceDig throws straight through it. Measured over one join: 64
-            // "Failed to handle incoming packet: NullReferenceException at DigTool.PlaceDig"
-            // before this guard, 0 after - with the guard itself hit 78 times, so the condition
-            // is just as frequent either way.
-            //
-            // The dig order is lost either way, and nothing else is: PacketHandler.HandleIncoming
-            // is called inside a per-message try/catch (SteamworksClient.ProcessIncomingMessages),
-            // so a throwing packet costs only itself. What this buys is a one-line warning in
-            // place of a multi-frame stack dump, and an explicit statement that dropping the
-            // order is the intended behaviour rather than an accident.
+            // A client still in the menu or mid save-download has no world yet, and
+            // DigTool.PlaceDig throws straight through it. Dropping the order is intended:
+            // a one-line warning instead of a per-packet stack dump.
             if (!Utils.IsInGame() || !Grid.IsValidCell(Cell))
             {
                 DebugConsole.LogWarning(

--- a/ONI_Together/Networking/Packets/World/Buildings/OperationalStatePacket.cs
+++ b/ONI_Together/Networking/Packets/World/Buildings/OperationalStatePacket.cs
@@ -60,9 +60,7 @@ namespace ONI_Together.Networking.Packets.World.Buildings
 			if (!entity.TryGetComponent<ClientReceiver_Operational>(out var client))
 				return;
 
-			client.IsFunctional = IsFunctional;
-			client.IsOperational = IsOperational;
-			client.IsActive = IsActive;
+			client.ApplyHostState(IsOperational, IsFunctional, IsActive);
 		}
 	}
 }

--- a/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections;
 using System.IO;
 using Shared.Profiling;
-using ONI_Together.Menus;
+
 
 namespace ONI_Together.Networking.Packets.World
 {

--- a/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
@@ -40,7 +40,7 @@ namespace ONI_Together.Networking.Packets.World
 				return;
 
 			DebugConsole.Log($"[Packets/SaveFileRequest] Received request from {Requester}");
-			MultiplayerOverlay.Show(STRINGS.UI.MP_OVERLAY.HOST.SEND_SAVE_FILE);
+			// The ready screen (shown on connect) stays up here; no separate "sending save" overlay.
 			SendSaveFile(Requester);
 		}
 

--- a/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
@@ -9,7 +9,6 @@ using System.Collections;
 using System.IO;
 using Shared.Profiling;
 
-
 namespace ONI_Together.Networking.Packets.World
 {
 	public class SaveFileRequestPacket : IPacket

--- a/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
@@ -52,15 +52,10 @@ namespace ONI_Together.Networking.Packets.World
 
 			// Handing a client a save is the host's own proof that this client is about to
 			// disconnect and load, so arm the load-window gate here rather than trusting the
-			// client to say so. The client's own Loading notice is sent immediately before it
-			// tears the socket down and is regularly lost - a two-instance capture showed the
-			// client sending it twice and the host recording only the earlier one. On a hard
-			// sync that late notice is the ONLY signal (GameServerHardSync pushes saves
-			// without any client request), so losing it left the host with no pending entry:
-			// the client dropped off the roster, RefreshReadyState saw "only the host left"
-			// and resumed the sim while the client was still 20-30s into loading.
-			// Marking is idempotent and costs nothing early - PendingLoadingClientCount only
-			// counts loaders that have already left the roster.
+			// client to say so: its Loading notice goes out just before the socket drops and
+			// is regularly lost, and on a hard sync (saves pushed with no client request)
+			// that notice is the only other signal. Marking is idempotent and costs nothing
+			// early - PendingLoadingClientCount only counts loaders already off the roster.
 			NetworkConfig.TransportServer?.MarkClientLoading(requester);
 
 			try
@@ -153,12 +148,9 @@ namespace ONI_Together.Networking.Packets.World
 
 			for (int offset = 0; offset < data.Length; /* increments manually */)
 			{
-				// Die with the registration. Without this the loop's retry branch spun forever
-				// after a session ended (~60 sends/s of SecureTransferPacket into the void,
-				// measured for 4+ minutes), and worse: when the same client rejoined a NEW
-				// session, the old coroutine's sends started SUCCEEDING again and interleaved
-				// a second chunk stream into the new transfer under the same TransferId - the
-				// client's download hung at 30% on exactly that.
+				// Die with the registration: a coroutine that outlives it resends into the
+				// void after the session ends, and when the same client rejoins it interleaves
+				// a second chunk stream under the same TransferId, stalling the download.
 				if (!MultiplayerSession.InActiveSession
 					|| !SaveFileTransferManager.IsTransferCurrent(transferToken))
 				{

--- a/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
@@ -149,10 +149,25 @@ namespace ONI_Together.Networking.Packets.World
 
 			// SUA IDEIA: Registra transferência no manager para rastrear ACKs
 			string transferId = fileName.Replace(" ", "_").Replace(".sav", "");
-			SaveFileTransferManager.StartTransfer(steamID, transferId, fileName, data, chunkSize);
+			object transferToken = SaveFileTransferManager.StartTransfer(steamID, transferId, fileName, data, chunkSize);
 
 			for (int offset = 0; offset < data.Length; /* increments manually */)
 			{
+				// Die with the registration. Without this the loop's retry branch spun forever
+				// after a session ended (~60 sends/s of SecureTransferPacket into the void,
+				// measured for 4+ minutes), and worse: when the same client rejoined a NEW
+				// session, the old coroutine's sends started SUCCEEDING again and interleaved
+				// a second chunk stream into the new transfer under the same TransferId - the
+				// client's download hung at 30% on exactly that.
+				if (!MultiplayerSession.InActiveSession
+					|| !SaveFileTransferManager.IsTransferCurrent(transferToken))
+				{
+					DebugConsole.LogWarning(
+						$"[SaveFileRequest] Aborting transfer of '{fileName}' to {steamID} at offset {offset}: " +
+						"session ended or transfer superseded");
+					yield break;
+				}
+
 				int size = Math.Min(chunkSize, data.Length - offset);
 				byte[] chunk = new byte[size];
 				Buffer.BlockCopy(data, offset, chunk, 0, size);

--- a/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections;
 using System.IO;
 using Shared.Profiling;
-using ONI_Together.Menus;
 
 namespace ONI_Together.Networking.Packets.World
 {
@@ -40,7 +39,7 @@ namespace ONI_Together.Networking.Packets.World
 				return;
 
 			DebugConsole.Log($"[Packets/SaveFileRequest] Received request from {Requester}");
-			MultiplayerOverlay.Show(STRINGS.UI.MP_OVERLAY.HOST.SEND_SAVE_FILE);
+			// The ready screen (shown on connect) stays up here; no separate "sending save" overlay.
 			SendSaveFile(Requester);
 		}
 
@@ -50,6 +49,19 @@ namespace ONI_Together.Networking.Packets.World
 
 			if (!MultiplayerSession.IsHost)
 				return;
+
+			// Handing a client a save is the host's own proof that this client is about to
+			// disconnect and load, so arm the load-window gate here rather than trusting the
+			// client to say so. The client's own Loading notice is sent immediately before it
+			// tears the socket down and is regularly lost - a two-instance capture showed the
+			// client sending it twice and the host recording only the earlier one. On a hard
+			// sync that late notice is the ONLY signal (GameServerHardSync pushes saves
+			// without any client request), so losing it left the host with no pending entry:
+			// the client dropped off the roster, RefreshReadyState saw "only the host left"
+			// and resumed the sim while the client was still 20-30s into loading.
+			// Marking is idempotent and costs nothing early - PendingLoadingClientCount only
+			// counts loaders that have already left the roster.
+			NetworkConfig.TransportServer?.MarkClientLoading(requester);
 
 			try
 			{

--- a/ONI_Together/Networking/Packets/World/SpeedChangePacket.cs
+++ b/ONI_Together/Networking/Packets/World/SpeedChangePacket.cs
@@ -7,7 +7,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.World
 {
-	public class SpeedChangePacket : IPacket
+	public class SpeedChangePacket : IPacket, IHostRelayGate
 	{
 		[Flags]
 		public enum SpeedState : int
@@ -92,5 +92,15 @@ namespace ONI_Together.Networking.Packets.World
 
 			DebugConsole.Log($"[SpeedChnagePacket] SpeedChangePacket received: Speed set to {Speed}");
 		}
+
+		/// <summary>
+		/// Relay gate (host side): a pause is always allowed, but a resume may only be
+		/// applied AND relayed to the other clients once everyone is ready. This stops the
+		/// host from fanning a client-originated resume out to other clients while it
+		/// correctly refuses to resume its own sim. Mirrors the inline check in
+		/// <see cref="OnDispatched"/>, which stays as defense-in-depth for the direct path.
+		/// </summary>
+		public bool HostShouldProcess()
+			=> Speed == SpeedState.Paused || ReadyManager.CanHostResume();
 	}
 }

--- a/ONI_Together/Networking/Packets/World/SpeedChangePacket.cs
+++ b/ONI_Together/Networking/Packets/World/SpeedChangePacket.cs
@@ -50,6 +50,19 @@ namespace ONI_Together.Networking.Packets.World
 			if (SpeedControlScreen.Instance == null)
 				return;
 
+			// Authority: the host must never apply a remote resume while a player is
+			// unready — even though this runs under IsSyncing. Without this, a client that
+			// originated a resume (its own SetSpeed/TogglePause isn't gated) would resume
+			// the host mid-load via this packet, bypassing the SpeedControlScreen gate.
+			// Pause packets are always honoured; only resume is rejected.
+			if (MultiplayerSession.IsHost
+				&& Speed != SpeedState.Paused
+				&& !ReadyManager.CanHostResume())
+			{
+				DebugConsole.Log("[SpeedChangePacket] Ignored remote resume: not all players are ready");
+				return;
+			}
+
 			SpeedControlScreen_SendSpeedPacketPatch.IsSyncing = true;
 			try
 			{

--- a/ONI_Together/Networking/Packets/World/SpeedChangePacket.cs
+++ b/ONI_Together/Networking/Packets/World/SpeedChangePacket.cs
@@ -50,14 +50,13 @@ namespace ONI_Together.Networking.Packets.World
 			if (SpeedControlScreen.Instance == null)
 				return;
 
-			// Authority: the host must never apply a remote resume while a player is
-			// unready — even though this runs under IsSyncing. Without this, a client that
-			// originated a resume (its own SetSpeed/TogglePause isn't gated) would resume
-			// the host mid-load via this packet, bypassing the SpeedControlScreen gate.
-			// Pause packets are always honoured; only resume is rejected.
-			if (MultiplayerSession.IsHost
-				&& Speed != SpeedState.Paused
-				&& !ReadyManager.CanHostResume())
+			// Authority (direct/defense-in-depth path): the host must never apply a remote
+			// resume while a player is unready — even though this runs under IsSyncing. The
+			// resume rule lives in one predicate, HostShouldProcess(): HostBroadcastPacket
+			// uses it to veto the wrapped relay path (where this re-check then can't fire),
+			// and SpeedControlPatch.ResumeBlocked() guards local host actions — all three
+			// resolve through ReadyManager.CanHostResume(). Pause packets are always honoured.
+			if (MultiplayerSession.IsHost && !HostShouldProcess())
 			{
 				DebugConsole.Log("[SpeedChangePacket] Ignored remote resume: not all players are ready");
 				return;

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -128,7 +128,9 @@ namespace ONI_Together.Networking
 			int count = 0;
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				if (player.readyState.Equals(ClientReadyState.Ready))
+				// The host is always considered ready regardless of its stored flag.
+				if (player.PlayerId == MultiplayerSession.HostUserID
+					|| player.readyState.Equals(ClientReadyState.Ready))
 				{
 					count++;
 				}
@@ -162,6 +164,21 @@ namespace ONI_Together.Networking
 		}
 
 		/// <summary>
+		/// The authority gate for resuming the sim. The host may only resume/unpause
+		/// when every connected player is ready. Outside a session there is nothing to
+		/// gate. This is the real safety — UI visibility must never permit resume.
+		/// </summary>
+		public static bool CanHostResume()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!MultiplayerSession.InSession)
+				return true;
+
+			return IsEveryoneReady();
+		}
+
+		/// <summary>
 		/// HOST ONLY - Check if all connected clients are ready
 		/// </summary>
 		/// <returns></returns>
@@ -172,6 +189,10 @@ namespace ONI_Together.Networking
 			bool result = true;
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
+				// The host is always considered ready regardless of its stored flag.
+				if (player.PlayerId == MultiplayerSession.HostUserID)
+					continue;
+
 				if (player.readyState == ClientReadyState.Unready)
 				{
 					result = false;

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -222,6 +222,14 @@ namespace ONI_Together.Networking
 			if (!MultiplayerSession.InSession)
 				return true;
 
+			// A client that disconnected to load the level can be removed from the live
+			// roster (Riptide reconnects it under a new id) — IsEveryoneReady would then
+			// stop seeing it and the gate would wrongly open mid-load. Keep gated while any
+			// load is in flight. (Steamworks keeps a Connection==null placeholder instead,
+			// so it reports no pending loads and relies on IsEveryoneReady below.)
+			if (NetworkConfig.TransportServer?.HasPendingLoadingClients == true)
+				return false;
+
 			return IsEveryoneReady();
 		}
 
@@ -249,13 +257,20 @@ namespace ONI_Together.Networking
 				return;
 
 			DebugConsole.Log("Refreshing ready state...");
-			if (MultiplayerSession.ConnectedPlayers.Count <= 1)
+
+			// A client mid load-reconnect has dropped off the roster (Riptide) but is not
+			// gone. Don't take the "only host left -> all ready" shortcut and don't let the
+			// all-ready close fire while a load is in flight, or the ready screen would
+			// vanish (and the gate open) before the client finishes loading.
+			bool loadingPending = NetworkConfig.TransportServer?.HasPendingLoadingClients == true;
+
+			if (!loadingPending && MultiplayerSession.ConnectedPlayers.Count <= 1)
 			{
 				AllClientsReadyPacket.ProcessAllReady();//bypass sending packet if its just the host left
 				return;
 			}
 
-			bool allReady = ReadyManager.IsEveryoneReady();
+			bool allReady = !loadingPending && ReadyManager.IsEveryoneReady();
 			if (allReady)
 			{
 				ReadyManager.SendAllReadyPacket();

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -116,14 +116,33 @@ namespace ONI_Together.Networking
 			string message = string.Format(STRINGS.UI.MP_OVERLAY.SYNC.WAITING_FOR_PLAYERS_SYNC, readyCount, maxPlayers);
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				// The host is always considered ready; show that regardless of the stored
-				// flag so the line matches the count (which also treats the host as ready).
-				ClientReadyState displayState = player.PlayerId == MultiplayerSession.HostUserID
+				// Show the same readiness the count/gate use (host always reads ready).
+				ClientReadyState displayState = IsConsideredReady(player)
 					? ClientReadyState.Ready
-					: player.readyState;
+					: ClientReadyState.Unready;
 				message += $"{player.PlayerName}: {GetReadyText(displayState)}\n";
 			}
 			return message;
+		}
+
+		/// <summary>
+		/// Single source of truth for "is this player ready" used by the overlay text, the
+		/// ready count and the resume gate. The host is always considered ready regardless
+		/// of its stored flag.
+		///
+		/// NOTE: a disconnected client (Connection == null) is deliberately NOT skipped /
+		/// treated as ready. Clients drop their socket precisely *while loading the level*,
+		/// and the host must stay gated through that window — Connection == null cannot tell
+		/// "loading" apart from "crashed". A client that has truly left is removed from
+		/// ConnectedPlayers by the transport / Steam-lobby leave handlers, which clears the
+		/// gate; on a hard crash that removal is just delayed until lobby eviction.
+		/// </summary>
+		private static bool IsConsideredReady(MultiplayerPlayer player)
+		{
+			if (player.PlayerId == MultiplayerSession.HostUserID)
+				return true;
+
+			return player.readyState == ClientReadyState.Ready;
 		}
 
 		private static int GetReadyCount()
@@ -133,12 +152,8 @@ namespace ONI_Together.Networking
 			int count = 0;
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				// The host is always considered ready regardless of its stored flag.
-				if (player.PlayerId == MultiplayerSession.HostUserID
-					|| player.readyState.Equals(ClientReadyState.Ready))
-				{
+				if (IsConsideredReady(player))
 					count++;
-				}
 			}
 			return count;
 		}
@@ -191,21 +206,12 @@ namespace ONI_Together.Networking
 		{
 			using var _ = Profiler.Scope();
 
-			bool result = true;
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				// The host is always considered ready regardless of its stored flag.
-				if (player.PlayerId == MultiplayerSession.HostUserID)
-					continue;
-
-				if (player.readyState == ClientReadyState.Unready)
-				{
-					result = false;
-
-					break;
-				}
+				if (!IsConsideredReady(player))
+					return false;
 			}
-			return result;
+			return true;
 		}
 
 		internal static void RefreshReadyState()

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -22,6 +22,25 @@ namespace ONI_Together.Networking
 			SteamLobby.OnLobbyMembersRefreshed += UpdateReadyStateTracking;
 		}
 
+		/// <summary>
+		/// HOST - shared "a client (re)connected" resync, invoked from both transports'
+		/// connect callbacks (which run on the main thread): freeze the world for the ready
+		/// screen and rebroadcast roster/ready state (show/hide + text) to everyone. The
+		/// caller is responsible for marking the (re)connecting player Unready first.
+		/// </summary>
+		public static void OnClientConnected()
+		{
+			using var _ = Profiler.Scope();
+
+			// A joining client must not leave the rest of the table running while it loads:
+			// pause the sim (broadcast to all peers) so the ready screen freezes the world.
+			Utils.PauseSimForReadyScreen();
+
+			// Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
+			RefreshScreen();
+			RefreshReadyState();
+		}
+
 		public static void SendAllReadyPacket()
 		{
 			using var _ = Profiler.Scope();

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -27,14 +27,20 @@ namespace ONI_Together.Networking
 		/// connect callbacks (which run on the main thread): freeze the world for the ready
 		/// screen and rebroadcast roster/ready state (show/hide + text) to everyone. The
 		/// caller is responsible for marking the (re)connecting player Unready first.
+		///
+		/// <paramref name="isHostLoopback"/> is true for the LAN host's own local client
+		/// connecting to its own server on start; in that case we skip the sim-pause (there
+		/// is no remote player to wait on) but still refresh the roster.
 		/// </summary>
-		public static void OnClientConnected()
+		public static void HandleClientConnected(bool isHostLoopback = false)
 		{
 			using var _ = Profiler.Scope();
 
-			// A joining client must not leave the rest of the table running while it loads:
-			// pause the sim (broadcast to all peers) so the ready screen freezes the world.
-			Utils.PauseSimForReadyScreen();
+			// A remote joining client must not leave the rest of the table running while it
+			// loads: pause the sim (broadcast to all peers) so the ready screen freezes the
+			// world. The host's own loopback connect must not pause the sim on host start.
+			if (!isHostLoopback)
+				Utils.PauseSimForReadyScreen();
 
 			// Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
 			RefreshScreen();

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -30,9 +30,11 @@ namespace ONI_Together.Networking
 		///
 		/// <paramref name="isHostLoopback"/> is true for the LAN host's own local client
 		/// connecting to its own server on start; in that case we skip the sim-pause (there
-		/// is no remote player to wait on) but still refresh the roster.
+		/// is no remote player to wait on) but still refresh the roster. The flag is required
+		/// (no default) so every transport must consciously decide whether its connection can
+		/// be a host loopback rather than silently inheriting the "remote" behaviour.
 		/// </summary>
-		public static void HandleClientConnected(bool isHostLoopback = false)
+		public static void HandleClientConnected(bool isHostLoopback)
 		{
 			using var _ = Profiler.Scope();
 

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -116,7 +116,12 @@ namespace ONI_Together.Networking
 			string message = string.Format(STRINGS.UI.MP_OVERLAY.SYNC.WAITING_FOR_PLAYERS_SYNC, readyCount, maxPlayers);
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				message += $"{player.PlayerName}: {GetReadyText(player.readyState)}\n";
+				// The host is always considered ready; show that regardless of the stored
+				// flag so the line matches the count (which also treats the host as ready).
+				ClientReadyState displayState = player.PlayerId == MultiplayerSession.HostUserID
+					? ClientReadyState.Ready
+					: player.readyState;
+				message += $"{player.PlayerName}: {GetReadyText(displayState)}\n";
 			}
 			return message;
 		}

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -139,7 +139,11 @@ namespace ONI_Together.Networking
 			using var _ = Profiler.Scope();
 
 			int readyCount = GetReadyCount();
-			int maxPlayers = MultiplayerSession.ConnectedPlayers.Values.Count;
+			// A client mid load-reconnect is off the roster (Riptide) but still expected, so
+			// add it to the total — otherwise the overlay reads e.g. "2/2" while we are
+			// (correctly) still waiting on the loader.
+			int pendingLoads = NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0;
+			int maxPlayers = MultiplayerSession.ConnectedPlayers.Values.Count + pendingLoads;
 			string message = string.Format(STRINGS.UI.MP_OVERLAY.SYNC.WAITING_FOR_PLAYERS_SYNC, readyCount, maxPlayers);
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -252,11 +252,8 @@ namespace ONI_Together.Networking
 			bool canResume = CanHostResume();
 
 			// Whether the host counts itself in ConnectedPlayers differs per transport:
-			// LiteNetLibServer inserts it as ConnectedPlayers[1]; a Steam host is absent from
-			// its own roster (measured - one client connected logs "roster: 1, others: 1").
-			// Raw roster size therefore cannot answer "is anyone else here", and reading it
-			// that way let a Steam host with one client resume alone, never send the all-ready
-			// broadcast, and strand that client on the ready screen.
+			// LiteNetLibServer inserts it as ConnectedPlayers[1]; a Steam host is absent
+			// from its own roster. Raw roster size cannot answer "is anyone else here".
 			int otherPlayers = MultiplayerSession.ConnectedPlayers.Count
 				- (MultiplayerSession.ConnectedPlayers.ContainsKey(MultiplayerSession.HostUserID) ? 1 : 0);
 

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -19,6 +19,27 @@ namespace ONI_Together.Networking
 			SteamLobby.OnLobbyMembersRefreshed += UpdateReadyStateTracking;
 		}
 
+		/// <summary>
+		/// HOST - shared "a client (re)connected" resync, invoked from every transport's
+		/// connect callback (which run on the main thread): freeze the world for the ready
+		/// screen and rebroadcast roster/ready state (show/hide + text) to everyone. The
+		/// caller is responsible for marking the (re)connecting player Unready first.
+		/// </summary>
+		public static void HandleClientConnected()
+		{
+			using var _ = Profiler.Scope();
+
+			// A joining client must not leave the rest of the table running while it loads:
+			// pause the sim (broadcast to all peers) so the ready screen freezes the world.
+			// The host's own loopback connect on LAN host-start happens before the session is
+			// established, and PauseSimForReadyScreen's own InActiveSession guard drops it.
+			Utils.PauseSimForReadyScreen();
+
+			// Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
+			RefreshScreen();
+			RefreshReadyState();
+		}
+
 		public static void SendAllReadyPacket()
 		{
 			using var _ = Profiler.Scope();
@@ -61,6 +82,12 @@ namespace ONI_Together.Networking
 				PlayerName = Utils.GetLocalPlayerName()
 			};
 			PacketSender.SendToHost(packet);
+
+			// The Loading notice is what arms the host's load-window gate, and it is sent
+			// moments before this client tears its connection down. Log the send so a lost
+			// one can be told apart from one that was never sent.
+			if (state == ClientReadyState.Loading)
+				DebugConsole.Log($"[ReadyManager] Sent Loading notice to host as {packet.SenderId}");
 		}
 
 		public static void MarkAllAsUnready()
@@ -70,11 +97,10 @@ namespace ONI_Together.Networking
 			if (!MultiplayerSession.IsHost)
 				return;
 
-			if (MultiplayerSession.ConnectedPlayers.TryGetValue(MultiplayerSession.HostUserID, out var host))
-				host.readyState = ClientReadyState.Ready; // Host is always ready
-
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
+				// The host's stored readyState is never read - IsConsideredReady short-circuits
+				// on the host id before touching the field - so leave it untouched.
 				if (player.PlayerId == MultiplayerSession.HostUserID)
 					continue;
 
@@ -109,13 +135,41 @@ namespace ONI_Together.Networking
 			using var _ = Profiler.Scope();
 
 			int readyCount = GetReadyCount();
-			int maxPlayers = MultiplayerSession.ConnectedPlayers.Values.Count;
+			// A client mid load-reconnect is off the roster (Riptide) but still expected, so
+			// add it to the total — otherwise the overlay reads e.g. "2/2" while we are
+			// (correctly) still waiting on the loader.
+			int pendingLoads = NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0;
+			int maxPlayers = MultiplayerSession.ConnectedPlayers.Values.Count + pendingLoads;
 			string message = string.Format(STRINGS.UI.MP_OVERLAY.SYNC.WAITING_FOR_PLAYERS_SYNC, readyCount, maxPlayers);
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				message += $"{player.PlayerName}: {GetReadyText(player.readyState)}\n";
+				// Show the same readiness the count/gate use (host always reads ready).
+				ClientReadyState displayState = IsConsideredReady(player)
+					? ClientReadyState.Ready
+					: ClientReadyState.Unready;
+				message += $"{player.PlayerName}: {GetReadyText(displayState)}\n";
 			}
 			return message;
+		}
+
+		/// <summary>
+		/// Single source of truth for "is this player ready" used by the overlay text, the
+		/// ready count and the resume gate. The host is always considered ready regardless
+		/// of its stored flag.
+		///
+		/// NOTE: a disconnected client (Connection == null) is deliberately NOT skipped /
+		/// treated as ready. Clients drop their socket precisely *while loading the level*,
+		/// and the host must stay gated through that window — Connection == null cannot tell
+		/// "loading" apart from "crashed". A client that has truly left is removed from
+		/// ConnectedPlayers by the transport / Steam-lobby leave handlers, which clears the
+		/// gate; on a hard crash that removal is just delayed until lobby eviction.
+		/// </summary>
+		private static bool IsConsideredReady(MultiplayerPlayer player)
+		{
+			if (player.PlayerId == MultiplayerSession.HostUserID)
+				return true;
+
+			return player.readyState == ClientReadyState.Ready;
 		}
 
 		private static int GetReadyCount()
@@ -125,10 +179,8 @@ namespace ONI_Together.Networking
 			int count = 0;
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				if (player.readyState.Equals(ClientReadyState.Ready))
-				{
+				if (IsConsideredReady(player))
 					count++;
-				}
 			}
 			return count;
 		}
@@ -159,6 +211,29 @@ namespace ONI_Together.Networking
 		}
 
 		/// <summary>
+		/// The authority gate for resuming the sim. The host may only resume/unpause
+		/// when every connected player is ready. Outside a session there is nothing to
+		/// gate. This is the real safety — UI visibility must never permit resume.
+		/// </summary>
+		public static bool CanHostResume()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!MultiplayerSession.InActiveSession)
+				return true;
+
+			// Both LAN transports remove a client from ConnectedPlayers when it disconnects to
+			// load the level, so IsEveryoneReady stops seeing it and the gate would wrongly
+			// open mid-load. Keep gated while any load is in flight. (Steamworks instead keeps
+			// a Connection==null placeholder in the roster, so it reports no pending loads and
+			// is covered by IsEveryoneReady below.)
+			if (NetworkConfig.TransportServer?.HasPendingLoadingClients == true)
+				return false;
+
+			return IsEveryoneReady();
+		}
+
+		/// <summary>
 		/// HOST ONLY - Check if all connected clients are ready
 		/// </summary>
 		/// <returns></returns>
@@ -166,17 +241,12 @@ namespace ONI_Together.Networking
 		{
 			using var _ = Profiler.Scope();
 
-			bool result = true;
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				if (player.readyState == ClientReadyState.Unready)
-				{
-					result = false;
-
-					break;
-				}
+				if (!IsConsideredReady(player))
+					return false;
 			}
-			return result;
+			return true;
 		}
 
 		internal static void RefreshReadyState()
@@ -189,15 +259,28 @@ namespace ONI_Together.Networking
 			if (MultiplayerSession.IsQuitting)
 				return;
 
-			DebugConsole.Log("Refreshing ready state...");
-			if (MultiplayerSession.ConnectedPlayers.Count <= 1)
+			// A client mid load-reconnect has dropped off the roster but is not gone. Don't
+			// take the "only host left -> all ready" shortcut and don't let the all-ready
+			// close fire while a load is in flight, or the ready screen would vanish (and the
+			// gate open) before the client finishes loading.
+			int pendingLoads = NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0;
+			bool canResume = CanHostResume();
+
+			// Log the inputs, not just that a refresh happened. Every failure of this gate so
+			// far has been invisible: the broken and the working path both printed a bare
+			// "Refreshing ready state..." and nothing else, so a load window that wrongly
+			// opened the gate looked exactly like one that held.
+			DebugConsole.Log(
+				$"[ReadyManager] Refreshing ready state... (roster: {MultiplayerSession.ConnectedPlayers.Count}, " +
+				$"pending loads: {pendingLoads}, gate: {(canResume ? "OPEN" : "CLOSED")})");
+
+			if (canResume && MultiplayerSession.ConnectedPlayers.Count <= 1)
 			{
 				AllClientsReadyPacket.ProcessAllReady();//bypass sending packet if its just the host left
 				return;
 			}
 
-			bool allReady = ReadyManager.IsEveryoneReady();
-			if (allReady)
+			if (canResume)
 			{
 				ReadyManager.SendAllReadyPacket();
 			}

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -77,10 +77,11 @@ namespace ONI_Together.Networking
 			};
 			PacketSender.SendToHost(packet);
 
-			// The Loading notice arms the host's load-window gate and goes out moments before
-			// this client tears its connection down; log it so a lost one is distinguishable.
-			if (state == ClientReadyState.Loading)
-				DebugConsole.Log($"[ReadyManager] Sent Loading notice to host as {packet.SenderId}");
+			// Every status transition matters when reading a report's log: Loading arms the
+			// host's load-window gate moments before this client tears its connection down,
+			// and Ready is the only thing that ever opens the gate after the reload - its
+			// absence from a client log is how a stuck host gets diagnosed.
+			DebugConsole.Log($"[ReadyManager] Sent {state} notice to host as {packet.SenderId}");
 		}
 
 		public static void MarkAllAsUnready()

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -77,10 +77,9 @@ namespace ONI_Together.Networking
 			};
 			PacketSender.SendToHost(packet);
 
-			// Every status transition matters when reading a report's log: Loading arms the
-			// host's load-window gate moments before this client tears its connection down,
-			// and Ready is the only thing that ever opens the gate after the reload - its
-			// absence from a client log is how a stuck host gets diagnosed.
+			// Log every send: Loading goes out just before this client drops its
+			// connection to load, and Ready is the only thing that opens the host's
+			// gate after the reload.
 			DebugConsole.Log($"[ReadyManager] Sent {state} notice to host as {packet.SenderId}");
 		}
 

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -126,10 +126,14 @@ namespace ONI_Together.Networking
 			if (!MultiplayerSession.InActiveSession)
 				return;
 
-			string text = GetScreenText();
-			MultiplayerOverlay.Show(text);
+			MultiplayerOverlay.Show(GetScreenText());
 		}
 
+		/// <summary>
+		/// The whole overlay body, suffix included, for both the host's own screen and the
+		/// copy shipped to clients in <see cref="ClientReadyStatusUpdatePacket"/> - the two
+		/// sides must read the same, so only one place builds it.
+		/// </summary>
 		private static string GetScreenText()
 		{
 			using var _ = Profiler.Scope();
@@ -149,7 +153,11 @@ namespace ONI_Together.Networking
 					: ClientReadyState.Unready;
 				message += $"{player.PlayerName}: {GetReadyText(displayState)}\n";
 			}
-			return message;
+
+			// Say why the tools stopped responding. A refusal with no explanation is
+			// indistinguishable from the game having frozen, and the player's next move is
+			// alt-F4.
+			return message + STRINGS.UI.MP_OVERLAY.SYNC.INPUT_LOCKED_WHILE_WAITING;
 		}
 
 		/// <summary>
@@ -266,15 +274,34 @@ namespace ONI_Together.Networking
 			int pendingLoads = NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0;
 			bool canResume = CanHostResume();
 
+			// How many players are here besides us. Whether the host counts itself in
+			// ConnectedPlayers differs per transport - LiteNetLibServer inserts the host as
+			// ConnectedPlayers[1], Steamworks never adds it - so the raw roster size does not
+			// answer "is anyone else here". Reading it as if it did meant that on Steam, with
+			// exactly one client connected, the host took the "only me left" shortcut below,
+			// resumed alone, and never sent the all-ready broadcast; the client was left on the
+			// ready screen with no way off it. HostUserID is the host's own id on both
+			// (measured: "Host set to: 1" on LAN, "Host set to: 76561198367584567" on Steam).
+			int otherPlayers = MultiplayerSession.ConnectedPlayers.Count
+				- (MultiplayerSession.ConnectedPlayers.ContainsKey(MultiplayerSession.HostUserID) ? 1 : 0);
+
 			// Log the inputs, not just that a refresh happened. Every failure of this gate so
 			// far has been invisible: the broken and the working path both printed a bare
 			// "Refreshing ready state..." and nothing else, so a load window that wrongly
-			// opened the gate looked exactly like one that held.
+			// opened the gate looked exactly like one that held. "others" is separate from
+			// "roster" because the difference between them is where the shortcut bug hid.
 			DebugConsole.Log(
 				$"[ReadyManager] Refreshing ready state... (roster: {MultiplayerSession.ConnectedPlayers.Count}, " +
-				$"pending loads: {pendingLoads}, gate: {(canResume ? "OPEN" : "CLOSED")})");
+				$"others: {otherPlayers}, pending loads: {pendingLoads}, " +
+				$"gate: {(canResume ? "OPEN" : "CLOSED")})");
 
-			if (canResume && MultiplayerSession.ConnectedPlayers.Count <= 1)
+			// The world was frozen for the ready screen; hand it back now the gate has opened.
+			// Without this the host was left in front of a stopped world after every join and
+			// had to toggle the speed itself before the play button would do anything.
+			if (canResume)
+				Utils.ResumeSimAfterReadyScreen();
+
+			if (canResume && otherPlayers == 0)
 			{
 				AllClientsReadyPacket.ProcessAllReady();//bypass sending packet if its just the host left
 				return;

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -20,22 +20,17 @@ namespace ONI_Together.Networking
 		}
 
 		/// <summary>
-		/// HOST - shared "a client (re)connected" resync, invoked from every transport's
-		/// connect callback (which run on the main thread): freeze the world for the ready
-		/// screen and rebroadcast roster/ready state (show/hide + text) to everyone. The
-		/// caller is responsible for marking the (re)connecting player Unready first.
+		/// HOST - shared "a client (re)connected" resync, called from every transport's connect
+		/// callback. The caller must mark the (re)connecting player Unready first.
 		/// </summary>
 		public static void HandleClientConnected()
 		{
 			using var _ = Profiler.Scope();
 
-			// A joining client must not leave the rest of the table running while it loads:
-			// pause the sim (broadcast to all peers) so the ready screen freezes the world.
 			// The host's own loopback connect on LAN host-start happens before the session is
-			// established, and PauseSimForReadyScreen's own InActiveSession guard drops it.
+			// established; PauseSimForReadyScreen's own InActiveSession guard drops that one.
 			Utils.PauseSimForReadyScreen();
 
-			// Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
 			RefreshScreen();
 			RefreshReadyState();
 		}
@@ -47,7 +42,6 @@ namespace ONI_Together.Networking
 			if (!MultiplayerSession.IsHost)
 				return;
 
-			//CoroutineRunner.RunOne(DelayAllReadyBroadcast());
 			PacketSender.SendToAllClients(new AllClientsReadyPacket());
 			AllClientsReadyPacket.ProcessAllReady();
 		}
@@ -83,9 +77,8 @@ namespace ONI_Together.Networking
 			};
 			PacketSender.SendToHost(packet);
 
-			// The Loading notice is what arms the host's load-window gate, and it is sent
-			// moments before this client tears its connection down. Log the send so a lost
-			// one can be told apart from one that was never sent.
+			// The Loading notice arms the host's load-window gate and goes out moments before
+			// this client tears its connection down; log it so a lost one is distinguishable.
 			if (state == ClientReadyState.Loading)
 				DebugConsole.Log($"[ReadyManager] Sent Loading notice to host as {packet.SenderId}");
 		}
@@ -99,8 +92,7 @@ namespace ONI_Together.Networking
 
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				// The host's stored readyState is never read - IsConsideredReady short-circuits
-				// on the host id before touching the field - so leave it untouched.
+				// IsConsideredReady short-circuits on the host id, so its stored state is dead.
 				if (player.PlayerId == MultiplayerSession.HostUserID)
 					continue;
 
@@ -130,47 +122,37 @@ namespace ONI_Together.Networking
 		}
 
 		/// <summary>
-		/// The whole overlay body, suffix included, for both the host's own screen and the
-		/// copy shipped to clients in <see cref="ClientReadyStatusUpdatePacket"/> - the two
-		/// sides must read the same, so only one place builds it.
+		/// The whole overlay body, suffix included - the host's own screen and the copy shipped
+		/// to clients in <see cref="ClientReadyStatusUpdatePacket"/> must read the same.
 		/// </summary>
 		private static string GetScreenText()
 		{
 			using var _ = Profiler.Scope();
 
 			int readyCount = GetReadyCount();
-			// A client mid load-reconnect is off the roster (Riptide) but still expected, so
-			// add it to the total — otherwise the overlay reads e.g. "2/2" while we are
-			// (correctly) still waiting on the loader.
+			// A client mid load-reconnect is off the roster but still expected, so add it to the
+			// total — otherwise the overlay reads "2/2" while we are still waiting on the loader.
 			int pendingLoads = NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0;
 			int maxPlayers = MultiplayerSession.ConnectedPlayers.Values.Count + pendingLoads;
 			string message = string.Format(STRINGS.UI.MP_OVERLAY.SYNC.WAITING_FOR_PLAYERS_SYNC, readyCount, maxPlayers);
 			foreach (MultiplayerPlayer player in MultiplayerSession.ConnectedPlayers.Values)
 			{
-				// Show the same readiness the count/gate use (host always reads ready).
 				ClientReadyState displayState = IsConsideredReady(player)
 					? ClientReadyState.Ready
 					: ClientReadyState.Unready;
 				message += $"{player.PlayerName}: {GetReadyText(displayState)}\n";
 			}
 
-			// Say why the tools stopped responding. A refusal with no explanation is
-			// indistinguishable from the game having frozen, and the player's next move is
-			// alt-F4.
+			// Say why the tools stopped responding, or a silent refusal reads as a frozen game.
 			return message + STRINGS.UI.MP_OVERLAY.SYNC.INPUT_LOCKED_WHILE_WAITING;
 		}
 
 		/// <summary>
-		/// Single source of truth for "is this player ready" used by the overlay text, the
-		/// ready count and the resume gate. The host is always considered ready regardless
-		/// of its stored flag.
-		///
-		/// NOTE: a disconnected client (Connection == null) is deliberately NOT skipped /
-		/// treated as ready. Clients drop their socket precisely *while loading the level*,
-		/// and the host must stay gated through that window — Connection == null cannot tell
-		/// "loading" apart from "crashed". A client that has truly left is removed from
-		/// ConnectedPlayers by the transport / Steam-lobby leave handlers, which clears the
-		/// gate; on a hard crash that removal is just delayed until lobby eviction.
+		/// Single source of truth for "is this player ready" - overlay text, ready count and
+		/// resume gate. The host always reads ready regardless of its stored flag.
+		/// NOTE: a disconnected client (Connection == null) is deliberately NOT treated as ready.
+		/// Clients drop their socket precisely *while loading the level*, so it cannot be told
+		/// apart from a crash; one that truly left is removed from ConnectedPlayers instead.
 		/// </summary>
 		private static bool IsConsideredReady(MultiplayerPlayer player)
 		{
@@ -219,9 +201,8 @@ namespace ONI_Together.Networking
 		}
 
 		/// <summary>
-		/// The authority gate for resuming the sim. The host may only resume/unpause
-		/// when every connected player is ready. Outside a session there is nothing to
-		/// gate. This is the real safety — UI visibility must never permit resume.
+		/// The authority gate for resuming the sim: the host may only resume when every connected
+		/// player is ready. This is the real safety — UI visibility must never permit resume.
 		/// </summary>
 		public static bool CanHostResume()
 		{
@@ -231,10 +212,9 @@ namespace ONI_Together.Networking
 				return true;
 
 			// Both LAN transports remove a client from ConnectedPlayers when it disconnects to
-			// load the level, so IsEveryoneReady stops seeing it and the gate would wrongly
-			// open mid-load. Keep gated while any load is in flight. (Steamworks instead keeps
-			// a Connection==null placeholder in the roster, so it reports no pending loads and
-			// is covered by IsEveryoneReady below.)
+			// load the level, so IsEveryoneReady stops seeing it and the gate would wrongly open
+			// mid-load. Steamworks instead keeps a Connection==null placeholder in the roster, so
+			// it reports no pending loads and is covered by IsEveryoneReady below.
 			if (NetworkConfig.TransportServer?.HasPendingLoadingClients == true)
 				return false;
 
@@ -244,7 +224,6 @@ namespace ONI_Together.Networking
 		/// <summary>
 		/// HOST ONLY - Check if all connected clients are ready
 		/// </summary>
-		/// <returns></returns>
 		public static bool IsEveryoneReady()
 		{
 			using var _ = Profiler.Scope();
@@ -267,37 +246,28 @@ namespace ONI_Together.Networking
 			if (MultiplayerSession.IsQuitting)
 				return;
 
-			// A client mid load-reconnect has dropped off the roster but is not gone. Don't
-			// take the "only host left -> all ready" shortcut and don't let the all-ready
-			// close fire while a load is in flight, or the ready screen would vanish (and the
-			// gate open) before the client finishes loading.
+			// A client mid load-reconnect is off the roster but not gone: don't take the "only
+			// host left -> all ready" shortcut, or the gate opens before it finishes loading.
 			int pendingLoads = NetworkConfig.TransportServer?.PendingLoadingClientCount ?? 0;
 			bool canResume = CanHostResume();
 
-			// How many players are here besides us. Whether the host counts itself in
-			// ConnectedPlayers differs per transport - LiteNetLibServer inserts the host as
-			// ConnectedPlayers[1], Steamworks never adds it - so the raw roster size does not
-			// answer "is anyone else here". Reading it as if it did meant that on Steam, with
-			// exactly one client connected, the host took the "only me left" shortcut below,
-			// resumed alone, and never sent the all-ready broadcast; the client was left on the
-			// ready screen with no way off it. HostUserID is the host's own id on both
-			// (measured: "Host set to: 1" on LAN, "Host set to: 76561198367584567" on Steam).
+			// Whether the host counts itself in ConnectedPlayers differs per transport:
+			// LiteNetLibServer inserts it as ConnectedPlayers[1]; a Steam host is absent from
+			// its own roster (measured - one client connected logs "roster: 1, others: 1").
+			// Raw roster size therefore cannot answer "is anyone else here", and reading it
+			// that way let a Steam host with one client resume alone, never send the all-ready
+			// broadcast, and strand that client on the ready screen.
 			int otherPlayers = MultiplayerSession.ConnectedPlayers.Count
 				- (MultiplayerSession.ConnectedPlayers.ContainsKey(MultiplayerSession.HostUserID) ? 1 : 0);
 
-			// Log the inputs, not just that a refresh happened. Every failure of this gate so
-			// far has been invisible: the broken and the working path both printed a bare
-			// "Refreshing ready state..." and nothing else, so a load window that wrongly
-			// opened the gate looked exactly like one that held. "others" is separate from
-			// "roster" because the difference between them is where the shortcut bug hid.
+			// Log the inputs, not just that a refresh happened - a load window that wrongly
+			// opened the gate otherwise looks exactly like one that held.
 			DebugConsole.Log(
 				$"[ReadyManager] Refreshing ready state... (roster: {MultiplayerSession.ConnectedPlayers.Count}, " +
 				$"others: {otherPlayers}, pending loads: {pendingLoads}, " +
 				$"gate: {(canResume ? "OPEN" : "CLOSED")})");
 
 			// The world was frozen for the ready screen; hand it back now the gate has opened.
-			// Without this the host was left in front of a stopped world after every join and
-			// had to toggle the speed itself before the play button would do anything.
 			if (canResume)
 				Utils.ResumeSimAfterReadyScreen();
 
@@ -313,7 +283,6 @@ namespace ONI_Together.Networking
 			}
 			else
 			{
-				// Broadcast updated overlay message to all clients
 				ReadyManager.SendStatusUpdatePacketToClients();
 			}
 		}

--- a/ONI_Together/Networking/ReadyManager.cs
+++ b/ONI_Together/Networking/ReadyManager.cs
@@ -109,6 +109,10 @@ namespace ONI_Together.Networking
 				return;
 
 			player.readyState = state;
+
+			// Any not-ready transition restarts the ready-timeout clock, so each join phase
+			// (connect, save hand-out, post-load reconnect) gets a full window of its own.
+			player.UnreadySince = state == ClientReadyState.Ready ? -1f : UnityEngine.Time.unscaledTime;
 		}
 
 		public static void RefreshScreen()

--- a/ONI_Together/Networking/SaveFileTransferManager.cs
+++ b/ONI_Together/Networking/SaveFileTransferManager.cs
@@ -30,6 +30,10 @@ namespace ONI_Together.Networking
             public int HighestAckReceived = -1; // Last sequential ACK received
             public System.DateTime LastActivity = System.DateTime.Now;
 
+            /// <summary>Our own key into ActiveTransfers, so IsTransferCurrent - called once
+            /// per chunk - does not rebuild it every time.</summary>
+            public string Key;
+
             public ClientTransfer(ulong clientID, string transferId, string fileName, byte[] data, int chunkSize)
             {
                 using var _ = Profiler.Scope();
@@ -57,17 +61,35 @@ namespace ONI_Together.Networking
         }
 
         /// <summary>
-        /// Register new transfer and track chunks
+        /// Register new transfer and track chunks. Returns an opaque token identifying THIS
+        /// registration - the streaming coroutine holds it and checks IsTransferCurrent each
+        /// iteration, so a coroutine whose registration was cancelled or replaced stops
+        /// instead of streaming on.
         /// </summary>
-        public static void StartTransfer(ulong clientID, string transferId, string fileName, byte[] data, int chunkSize)
+        public static object StartTransfer(ulong clientID, string transferId, string fileName, byte[] data, int chunkSize)
         {
             using var _ = Profiler.Scope();
 
             string key = GetTransferKey(clientID, transferId);
-            var transfer = new ClientTransfer(clientID, transferId, fileName, data, chunkSize);
+            var transfer = new ClientTransfer(clientID, transferId, fileName, data, chunkSize) { Key = key };
             ActiveTransfers[key] = transfer;
 
             DebugConsole.Log($"[TransferManager] Started transfer {transferId} to {clientID} - {transfer.TotalChunks} chunks");
+            return transfer;
+        }
+
+        /// <summary>
+        /// True while the given registration token is still the live transfer for this
+        /// client+file. Identity, not key, on purpose: a rejoin re-registers under the SAME
+        /// key, and a key check would let the previous session's zombie coroutine resume the
+        /// moment the client reconnects - measured as two interleaved chunk streams with one
+        /// TransferId, which stalled the client's download for good.
+        /// </summary>
+        public static bool IsTransferCurrent(object token)
+        {
+            return token is ClientTransfer mine
+                && ActiveTransfers.TryGetValue(mine.Key, out var live)
+                && ReferenceEquals(live, mine);
         }
 
         /// <summary>
@@ -124,6 +146,20 @@ namespace ONI_Together.Networking
                     ActiveTransfers.Remove(key);
                 }
             }
+        }
+
+        /// <summary>
+        /// HOST ONLY - drop every in-flight transfer. Call when the server stops: nothing else
+        /// ends a transfer whose client never ACKs again, so a shutdown mid-transfer left the
+        /// retry loop sending chunks to a session that no longer existed.
+        /// </summary>
+        public static void CancelAll()
+        {
+            if (ActiveTransfers.Count == 0)
+                return;
+
+            DebugConsole.Log($"[TransferManager] Cancelling {ActiveTransfers.Count} in-flight transfer(s) (server stopping)");
+            ActiveTransfers.Clear();
         }
 
         /// <summary>
@@ -188,9 +224,11 @@ namespace ONI_Together.Networking
 
                 PacketSender.SendToPlayer(transfer.ClientID, securePacket);
 
-                // Update send timestamp
+                // Update send timestamp. Deliberately NOT LastActivity: that must only move on
+                // evidence the CLIENT is alive (an ACK). Refreshing it on our own resend meant
+                // the 2-minute timeout below never fired - a transfer to a dead client resent
+                // forever, measured as 4+ minutes of send attempts after a session had ended.
                 transfer.ChunkSentTime[chunkIndex] = System.DateTime.Now;
-                transfer.LastActivity = System.DateTime.Now;
 
                 DebugConsole.Log($"[TransferManager] Resent chunk {chunkIndex} to {transfer.ClientID}");
             }

--- a/ONI_Together/Networking/SaveFileTransferManager.cs
+++ b/ONI_Together/Networking/SaveFileTransferManager.cs
@@ -81,9 +81,8 @@ namespace ONI_Together.Networking
         /// <summary>
         /// True while the given registration token is still the live transfer for this
         /// client+file. Identity, not key, on purpose: a rejoin re-registers under the SAME
-        /// key, and a key check would let the previous session's zombie coroutine resume the
-        /// moment the client reconnects - measured as two interleaved chunk streams with one
-        /// TransferId, which stalled the client's download for good.
+        /// key, and a key check would let the previous session's zombie coroutine resume
+        /// the moment the client reconnects.
         /// </summary>
         public static bool IsTransferCurrent(object token)
         {
@@ -149,9 +148,8 @@ namespace ONI_Together.Networking
         }
 
         /// <summary>
-        /// HOST ONLY - drop every in-flight transfer. Call when the server stops: nothing else
-        /// ends a transfer whose client never ACKs again, so a shutdown mid-transfer left the
-        /// retry loop sending chunks to a session that no longer existed.
+        /// HOST ONLY - drop every in-flight transfer. Call when the server stops: nothing
+        /// else ends a transfer whose client never ACKs again.
         /// </summary>
         public static void CancelAll()
         {
@@ -224,10 +222,9 @@ namespace ONI_Together.Networking
 
                 PacketSender.SendToPlayer(transfer.ClientID, securePacket);
 
-                // Update send timestamp. Deliberately NOT LastActivity: that must only move on
-                // evidence the CLIENT is alive (an ACK). Refreshing it on our own resend meant
-                // the 2-minute timeout below never fired - a transfer to a dead client resent
-                // forever, measured as 4+ minutes of send attempts after a session had ended.
+                // Update send timestamp. Deliberately NOT LastActivity: that must only move
+                // on evidence the CLIENT is alive (an ACK), or the 2-minute timeout below
+                // never fires and a transfer to a dead client resends forever.
                 transfer.ChunkSentTime[chunkIndex] = System.DateTime.Now;
 
                 DebugConsole.Log($"[TransferManager] Resent chunk {chunkIndex} to {transfer.ClientID}");

--- a/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibServer.cs
+++ b/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibServer.cs
@@ -316,6 +316,7 @@ namespace ONI_Together.Networking.Transport.Lan
             OnMessageRecieved();
             UpdateMetrics();
             ExpireStaleLoadingClients();
+            ExpireNeverReadyClients();
         }
 
         public override void OnMessageRecieved()

--- a/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibServer.cs
+++ b/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibServer.cs
@@ -218,8 +218,8 @@ namespace ONI_Together.Networking.Transport.Lan
             if (!ClientList.Contains(clientId))
                 ClientList.Add(clientId);
 
-            // OnConnectionRequest echoes back the persistent id the client supplied, so a
-            // returning loader arrives under the id it left with and matches exactly.
+            // The id here comes from the peer handle, so a returning loader does not arrive
+            // under the id it left with - see ClaimLoadingReconnect for what that costs.
             ClaimLoadingReconnect(clientId);
 
             DebugConsole.Log("[LiteNetLibServer] Remote client connected: " + clientId + " (" + peer.Address + ":" + peer.Port + ")");

--- a/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibServer.cs
+++ b/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibServer.cs
@@ -36,9 +36,6 @@ namespace ONI_Together.Networking.Transport.Lan
         public int ConnectedClientCount => _server != null ? _server.ConnectedPeersCount : 0;
         public TcpFileTransferServer TcpTransfer => _tcpTransfer;
 
-        public void MarkClientLoading(ulong clientId) { }
-        public bool ConsumeReconnectFromLoad(ulong clientId) { return false; }
-
         public List<ulong> ClientList { get; internal set; } = new List<ulong>();
 
         // Bandwidth and PPS tracking
@@ -212,10 +209,22 @@ namespace ONI_Together.Networking.Transport.Lan
             }
             player.Connection = peer;
 
+            // Authority: a (re)connecting client is loading and must be forced Unready the
+            // moment it begins connecting — not just at object creation. This keeps the
+            // host's all-ready check from transiently passing while the client loads.
+            // SetPlayerReadyState safely no-ops for the host's own entry.
+            ReadyManager.SetPlayerReadyState(player, ClientReadyState.Unready);
+
             if (!ClientList.Contains(clientId))
                 ClientList.Add(clientId);
 
+            // OnConnectionRequest echoes back the persistent id the client supplied, so a
+            // returning loader arrives under the id it left with and matches exactly.
+            ClaimLoadingReconnect(clientId);
+
             DebugConsole.Log("[LiteNetLibServer] Remote client connected: " + clientId + " (" + peer.Address + ":" + peer.Port + ")");
+
+            ReadyManager.HandleClientConnected();
         }
 
         private void OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo)
@@ -271,6 +280,7 @@ namespace ONI_Together.Networking.Transport.Lan
             _peersByClientId.Clear();
             _clientIdByPeerId.Clear();
             ClientList.Clear();
+            ClearLoadTracking();
 
             while (_incomingPackets.TryDequeue(out var _)) { }
 
@@ -305,6 +315,7 @@ namespace ONI_Together.Networking.Transport.Lan
             _server.PollEvents();
             OnMessageRecieved();
             UpdateMetrics();
+            ExpireStaleLoadingClients();
         }
 
         public override void OnMessageRecieved()
@@ -335,6 +346,12 @@ namespace ONI_Together.Networking.Transport.Lan
                 _clientIdByPeerId.Remove(peer.Id);
                 ClientList.Remove(clientId);
                 MultiplayerSession.ConnectedPlayers.Remove(clientId);
+
+                // The kick already removed the peer mapping OnPeerDisconnected keys on, so
+                // that handler - and the refresh it carries - will not run for this client.
+                ForgetClientLoading(clientId);
+                ReadyManager.RefreshReadyState();
+
                 DebugConsole.Log("[LiteNetLibServer] Kicked client: " + clientId);
             }
         }

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -157,6 +157,10 @@ namespace ONI_Together.Networking.Transport.Lan
             AddClientToList(e.Client.Id);
             DebugConsole.Log($"New client connected: {clientId}");
 
+            // A joining client must not leave the rest of the table running while it loads:
+            // pause the sim (broadcast to all peers) so the ready screen freezes the world.
+            Utils.PauseSimForReadyScreen();
+
             // Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
             ReadyManager.RefreshScreen();
             ReadyManager.RefreshReadyState();

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -302,7 +302,28 @@ namespace ONI_Together.Networking.Transport.Lan
         // it loads it is invisible to IsEveryoneReady. Surface it here so ReadyManager can
         // keep the host gated, the ready screen open, and the roster total honest through
         // the load window.
-        public override int PendingLoadingClientCount => _loadingClients.Count;
+        //
+        // Only count loaders that have actually dropped off the live roster: a client signals
+        // Loading just *before* it disconnects (SaveHelper.LoadWorldSave), so for that brief
+        // window its id is in both _loadingClients and ConnectedPlayers — where it is already
+        // counted (as Unready). Counting it here too would inflate the ready-screen total
+        // (e.g. "1/3" for a single loading client). Matching ConnectedPlayers keeps this in
+        // step with the documented contract ("dropped off the live roster but NOT gone") and
+        // with the gate: an in-roster loader holds the gate via its Unready state, an
+        // off-roster loader holds it via this count — no double count, no gap.
+        public override int PendingLoadingClientCount
+        {
+            get
+            {
+                int count = 0;
+                foreach (ulong id in _loadingClients.Keys)
+                {
+                    if (!MultiplayerSession.ConnectedPlayers.ContainsKey(id))
+                        count++;
+                }
+                return count;
+            }
+        }
 
         public bool ConsumeReconnectFromLoad(ulong id)
         {

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -4,6 +4,7 @@ using Riptide.Utils;
 using ONI_Together.DebugTools;
 using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.Architecture;
+using ONI_Together.Networking.States;
 using Shared.Profiling;
 using ONI_Together.Networking.Transfer;
 using System.Collections.Generic;
@@ -147,8 +148,18 @@ namespace ONI_Together.Networking.Transport.Lan
                 player.PlayerName = Utils.GetLocalPlayerName();
             }
 
+            // Authority: a (re)connecting client is loading and must be forced Unready the
+            // moment it begins connecting — not just at object creation. This keeps the
+            // host's all-ready check from transiently passing while the client loads.
+            // SetPlayerReadyState safely no-ops for the host's own entry.
+            ReadyManager.SetPlayerReadyState(player, ClientReadyState.Unready);
+
             AddClientToList(e.Client.Id);
             DebugConsole.Log($"New client connected: {clientId}");
+
+            // Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
+            ReadyManager.RefreshScreen();
+            ReadyManager.RefreshReadyState();
         }
 
         private void ServerOnClientDisconnected(object sender, ServerDisconnectedEventArgs e)

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -297,6 +297,12 @@ namespace ONI_Together.Networking.Transport.Lan
             }
         }
 
+        // A loading client disconnects (removed from ConnectedPlayers, see
+        // ServerOnClientDisconnected) and later reconnects with a new Riptide id, so while
+        // it loads it is invisible to IsEveryoneReady. Surface it here so ReadyManager can
+        // keep the host gated and the ready screen open through the load window.
+        public override bool HasPendingLoadingClients => _loadingClients.Count > 0;
+
         public bool ConsumeReconnectFromLoad(ulong id)
         {
             return _reconnectedFromLoad.Remove(id);

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -157,7 +157,7 @@ namespace ONI_Together.Networking.Transport.Lan
             AddClientToList(e.Client.Id);
             DebugConsole.Log($"New client connected: {clientId}");
 
-            ReadyManager.OnClientConnected();
+            ReadyManager.HandleClientConnected(clientId == CLIENT_ID);
         }
 
         private void ServerOnClientDisconnected(object sender, ServerDisconnectedEventArgs e)

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -157,13 +157,7 @@ namespace ONI_Together.Networking.Transport.Lan
             AddClientToList(e.Client.Id);
             DebugConsole.Log($"New client connected: {clientId}");
 
-            // A joining client must not leave the rest of the table running while it loads:
-            // pause the sim (broadcast to all peers) so the ready screen freezes the world.
-            Utils.PauseSimForReadyScreen();
-
-            // Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
-            ReadyManager.RefreshScreen();
-            ReadyManager.RefreshReadyState();
+            ReadyManager.OnClientConnected();
         }
 
         private void ServerOnClientDisconnected(object sender, ServerDisconnectedEventArgs e)

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -157,7 +157,13 @@ namespace ONI_Together.Networking.Transport.Lan
             AddClientToList(e.Client.Id);
             DebugConsole.Log($"New client connected: {clientId}");
 
-            ReadyManager.HandleClientConnected(clientId == CLIENT_ID);
+            // Host loopback = the one connect that happens *before* InSession flips true
+            // (it's the host's own local client, whose OnLocalClientConnected then sets
+            // InSession). Every remote join happens after that. NOTE: we can't use
+            // `clientId == CLIENT_ID` here — CLIENT_ID is only assigned in
+            // OnLocalClientConnected, which fires *after* this server-side accept, so it's
+            // still 0 at this point for the loopback.
+            ReadyManager.HandleClientConnected(isHostLoopback: !MultiplayerSession.InSession);
         }
 
         private void ServerOnClientDisconnected(object sender, ServerDisconnectedEventArgs e)

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -300,8 +300,9 @@ namespace ONI_Together.Networking.Transport.Lan
         // A loading client disconnects (removed from ConnectedPlayers, see
         // ServerOnClientDisconnected) and later reconnects with a new Riptide id, so while
         // it loads it is invisible to IsEveryoneReady. Surface it here so ReadyManager can
-        // keep the host gated and the ready screen open through the load window.
-        public override bool HasPendingLoadingClients => _loadingClients.Count > 0;
+        // keep the host gated, the ready screen open, and the roster total honest through
+        // the load window.
+        public override int PendingLoadingClientCount => _loadingClients.Count;
 
         public bool ConsumeReconnectFromLoad(ulong id)
         {

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -4,6 +4,7 @@ using Riptide.Utils;
 using ONI_Together.DebugTools;
 using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.Architecture;
+using ONI_Together.Networking.States;
 using Shared.Profiling;
 using ONI_Together.Networking.Transfer;
 using System.Collections.Generic;
@@ -21,9 +22,6 @@ namespace ONI_Together.Networking.Transport.Lan
         private static Server _server;
         private static Client _client; // Server client (Other users will use GameClient)
         private TcpFileTransferServer _tcpTransfer;
-        private Dictionary<ulong, float> _loadingClients = new Dictionary<ulong, float>();
-        private List<ulong> _expiredLoadingClients = new List<ulong>();
-        private HashSet<ulong> _reconnectedFromLoad = new HashSet<ulong>();
 
         public TcpFileTransferServer TcpTransfer => _tcpTransfer;
 
@@ -154,8 +152,16 @@ namespace ONI_Together.Networking.Transport.Lan
                 player.PlayerName = Utils.GetLocalPlayerName();
             }
 
+            // Authority: a (re)connecting client is loading and must be forced Unready the
+            // moment it begins connecting — not just at object creation. This keeps the
+            // host's all-ready check from transiently passing while the client loads.
+            // SetPlayerReadyState safely no-ops for the host's own entry.
+            ReadyManager.SetPlayerReadyState(player, ClientReadyState.Unready);
+
             AddClientToList(e.Client.Id);
             DebugConsole.Log($"New client connected: {clientId}");
+
+            ReadyManager.HandleClientConnected();
         }
 
         private void ServerOnClientDisconnected(object sender, ServerDisconnectedEventArgs e)
@@ -283,6 +289,8 @@ namespace ONI_Together.Networking.Transport.Lan
 
             _server.Stop();
             _server = null;
+
+            ClearLoadTracking();
         }
 
         // The server is shutting down so disconnect everyone
@@ -320,32 +328,26 @@ namespace ONI_Together.Networking.Transport.Lan
             _client?.Update();
             UpdateServerBandwidth();
 
-            if (_loadingClients.Count > 0)
-            {
-                float now = UnityEngine.Time.unscaledTime;
-                _expiredLoadingClients.Clear();
-                foreach (var kvp in _loadingClients)
-                {
-                    if (now - kvp.Value > Configuration.Instance.Host.TimeoutSeconds)
-                    {
-                        _expiredLoadingClients.Add(kvp.Key);
-                    }
-                }
-                foreach (var id in _expiredLoadingClients)
-                {
-                    _loadingClients.Remove(id);
-                }
-            }
+            ExpireStaleLoadingClients();
         }
 
-        public bool ConsumeReconnectFromLoad(ulong id)
+        /// <summary>
+        /// Riptide hands a reconnecting client a brand-new id, so an exact match is impossible
+        /// and the choice is between two wrong answers. Leaving the entry pending keeps the
+        /// resume gate closed for the full LOAD_RECONNECT_TIMEOUT after everyone is already
+        /// back; consuming the oldest pending entry can instead open the gate early if the
+        /// connect is a *new* player who joined during someone else's load. The stall is the
+        /// common case and the mis-guess needs two clients moving at once, so we take the
+        /// guess. Sending a persistent id in Riptide's connect payload the way LiteNetLib does
+        /// would remove the choice entirely.
+        /// </summary>
+        public override bool ClaimLoadingReconnect(ulong clientId)
         {
-            return _reconnectedFromLoad.Remove(id);
-        }
+            if (base.ClaimLoadingReconnect(clientId))
+                return true;
 
-        public void MarkClientLoading(ulong id)
-        {
-            _loadingClients[id] = UnityEngine.Time.unscaledTime;
+            ClaimOldestLoadingReconnect(clientId);
+            return true;
         }
 
         public void AddClientToList(ulong id)
@@ -357,14 +359,8 @@ namespace ONI_Together.Networking.Transport.Lan
 
             ClientList.Add(id);
 
-            // A loading client reconnects with a new Riptide ID, so we consume one loading entry
-            if (_loadingClients.Count > 0)
-            {
-                var enumerator = _loadingClients.GetEnumerator();
-                enumerator.MoveNext();
-                _loadingClients.Remove(enumerator.Current.Key);
-                _reconnectedFromLoad.Add(id);
-			}
+            ClaimLoadingReconnect(id);
+
 			var boxedId = Boxed<ulong>.Get(id);
 			Game.Instance?.Trigger(MP_HASHES.OnPlayerJoined,boxedId);
             boxedId.Release();
@@ -379,7 +375,7 @@ namespace ONI_Together.Networking.Transport.Lan
 
             ClientList.Remove(id);
 
-            if (!_loadingClients.ContainsKey(id))
+            if (!IsClientLoading(id))
             {
                 string name = MultiplayerSession.GetPlayer(id)?.PlayerName ?? $"Player {id}";
                 OxySyncChat.AddSystemMessage(string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_LEFT, name));
@@ -422,6 +418,10 @@ namespace ONI_Together.Networking.Transport.Lan
                 }
 
                 DebugConsole.Log($"[RiptideServer] Kicking client {clientId}");
+
+                // A kicked client is not coming back, so its pending load must not keep
+                // holding the gate. The disconnect event below carries the refresh.
+                ForgetClientLoading(clientId);
                 _server.DisconnectClient(conn);
 
                 // OnClientDisconnected should disconnect so we shouldn't need to cleanup here

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -331,25 +331,6 @@ namespace ONI_Together.Networking.Transport.Lan
             ExpireStaleLoadingClients();
         }
 
-        /// <summary>
-        /// Riptide hands a reconnecting client a brand-new id, so an exact match is impossible
-        /// and the choice is between two wrong answers. Leaving the entry pending keeps the
-        /// resume gate closed for the full LOAD_RECONNECT_TIMEOUT after everyone is already
-        /// back; consuming the oldest pending entry can instead open the gate early if the
-        /// connect is a *new* player who joined during someone else's load. The stall is the
-        /// common case and the mis-guess needs two clients moving at once, so we take the
-        /// guess. Sending a persistent id in Riptide's connect payload the way LiteNetLib does
-        /// would remove the choice entirely.
-        /// </summary>
-        public override bool ClaimLoadingReconnect(ulong clientId)
-        {
-            if (base.ClaimLoadingReconnect(clientId))
-                return true;
-
-            ClaimOldestLoadingReconnect(clientId);
-            return true;
-        }
-
         public void AddClientToList(ulong id)
         {
             using var _ = Profiler.Scope();

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -329,6 +329,7 @@ namespace ONI_Together.Networking.Transport.Lan
             UpdateServerBandwidth();
 
             ExpireStaleLoadingClients();
+            ExpireNeverReadyClients();
         }
 
         public void AddClientToList(ulong id)

--- a/ONI_Together/Networking/Transport/Steamworks/SteamLobby.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamLobby.cs
@@ -30,10 +30,8 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
 		public static int MaxLobbySize { get; private set; } = 0;
 
-		// Lobby code for the current lobby
 		public static string CurrentLobbyCode { get; private set; } = "";
 
-		// Lobby browser callback
 		private static CallResult<LobbyMatchList_t> _lobbyListCallResult;
 		private static Action<List<LobbyListEntry>> _onLobbyListReceived;
 
@@ -147,12 +145,10 @@ namespace ONI_Together.Networking.Transport.Steamworks
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "visibility", isPrivate ? "private" : "public");
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "is_spacedout", DlcManager.IsExpansion1Active() ? "1" : "0");
 
-				// Generate and store lobby code
 				CurrentLobbyCode = LobbyCodeHelper.GenerateCode(CurrentLobby.m_SteamID);
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "lobby_code", CurrentLobbyCode);
 				DebugConsole.Log($"[SteamLobby] Lobby code: {CurrentLobbyCode}");
 
-				// Store lobby settings from config
 				var lobbySettings = Configuration.Instance.Host.Lobby;
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "password_hash", lobbySettings.PasswordHash);
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "has_password", lobbySettings.RequirePassword ? "1" : "0");
@@ -166,7 +162,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 				_onLobbyCreatedSuccess?.Invoke();
 				_onLobbyCreatedSuccess = null;
 
-                // Update game info if available
                 UpdateGameInfo();
 
 				//CursorManager.Instance.AssignColor();
@@ -198,7 +193,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
             yield return new WaitForSeconds(0.5f);
 
-            // Check if lobby requires password
             string hasPassword = SteamMatchmaking.GetLobbyData(lobbyId, "has_password");
 
             if (hasPassword == "1")
@@ -208,7 +202,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
             }
             else
             {
-                // No password needed, join directly
                 JoinLobby(lobbyId);
             }
         }
@@ -261,10 +254,8 @@ namespace ONI_Together.Networking.Transport.Steamworks
                     MultiplayerSession.ConnectedPlayers.Add(userId, new MultiplayerPlayer(user.m_SteamID));
                 }
 
-				// No chat line here on purpose. Entering the lobby is the start of a join, not
-				// the end of one - the player still has to download the save, load it and
-				// reconnect, which measured 38s. ClientReadyStatusPacket says it when they are
-				// actually in.
+				// No chat line here on purpose: entering the lobby is the start of a join, not
+				// the end of one. ClientReadyStatusPacket announces them once they are in.
 				DebugConsole.Log($"[SteamLobby] {name} joined the lobby.");
                 var boxedId = Boxed<ulong>.Get(userId);
 				Game.Instance?.Trigger(MP_HASHES.OnPlayerJoined, boxedId);
@@ -280,24 +271,17 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
 				MultiplayerSession.ConnectedPlayers.Remove(userId);
 
-				// Someone who leaves the lobby is not coming back from a load, so their pending
-				// load entry has to go with them. Leaving it behind is worse than useless: the
-				// moment they drop off the roster that entry starts counting (see
-				// PendingLoadingClientCount) and holds the resume gate closed on behalf of a
-				// player who is already gone. A Steam session sat frozen for 5m24s on exactly
-				// that - the client left at 05:14:04 with one pending load and the gate only
-				// reopened at 05:19:28, on the 120s expiry.
+				// Someone who leaves is not coming back from a load, so drop their pending load
+				// entry too: off the roster it still counts (see PendingLoadingClientCount) and
+				// holds the resume gate closed on behalf of a player who is already gone, until
+				// the 120s expiry. Whether they were mid-load also picks the chat line -
+				// vanishing while loading is a failed join, not a choice to leave.
 				//
 				// NOTE: every transport calls ForgetClientLoading from its KICK path, but only
-				// Steam clears it on a voluntary leave. LiteNetLibServer.OnPeerDisconnected and
-				// RiptideServer.ServerOnClientDisconnected do not, so a LAN client that drops
-				// mid-load and never returns still holds the gate for the full timeout. Not
-				// fixed here because it has not been reproduced on LAN - the LAN reconnect
-				// arrives under a NEW client id and ClaimOldestLoadingReconnect consumes the
-				// entry, which is why the window has stayed invisible there.
-				//
-				// Whether they were mid-load also decides what the rest of the table is told:
-				// vanishing while loading is a failed join, not someone choosing to leave.
+				// Steam clears it on a voluntary leave - LiteNetLibServer.OnPeerDisconnected and
+				// RiptideServer.ServerOnClientDisconnected do not. Left unfixed because it stays
+				// invisible on LAN: a returning loader arrives under a NEW client id, so
+				// ClaimOldestLoadingReconnect consumes the entry anyway.
 				bool failedWhileJoining = false;
 				if (MultiplayerSession.IsHost)
 				{
@@ -307,11 +291,10 @@ namespace ONI_Together.Networking.Transport.Steamworks
 				}
 
 				RefreshLobbyMembers();
-				// Log the raw state-change flag: Left is a voluntary leave (the Steam client
-				// also reports Left on behalf of a killed game process), Disconnected means
-				// Steam lost the whole client, Kicked is ours. Together with the connection
-				// close reason logged by SteamworksServer this is the record of HOW a player
-				// went away, not just that they did.
+				// Log the raw flag - with SteamworksServer's close reason it records HOW a
+				// player went away: Left is a voluntary leave (the Steam client also reports
+				// Left on behalf of a killed game process), Disconnected means Steam lost the
+				// whole client, Kicked is ours.
 				DebugConsole.Log(
 					$"[SteamLobby] {name} left the lobby (state change: {stateChange}" +
 					$"{(failedWhileJoining ? "; still loading - treating as a failed join" : "")}).");
@@ -395,9 +378,7 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
         #region Lobby Code & Password
 
-		/// <summary>
-		/// Join a lobby by its lobby code.
-		/// </summary>
+		/// <summary>Join a lobby by its lobby code.</summary>
 		public static void JoinLobbyByCode(string code, string password = null, Action<CSteamID> onJoined = null, Action<string> onError = null)
 		{
 			using var _ = Profiler.Scope();
@@ -415,7 +396,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 				return;
 			}
 
-			// Try to parse the code directly to a lobby ID
 			if (LobbyCodeHelper.TryParseCode(code, out ulong lobbyId))
 			{
 				DebugConsole.Log($"[SteamLobby] Joining lobby by code: {code} => {lobbyId}");
@@ -427,9 +407,7 @@ namespace ONI_Together.Networking.Transport.Steamworks
 			}
 		}
 
-		/// <summary>
-		/// Check if the current lobby requires a password.
-		/// </summary>
+		/// <summary>True if the given lobby advertises a password requirement.</summary>
 		public static bool LobbyRequiresPassword(CSteamID lobbyId)
 		{
 			using var _ = Profiler.Scope();
@@ -438,9 +416,7 @@ namespace ONI_Together.Networking.Transport.Steamworks
 			return hasPassword == "1";
 		}
 
-		/// <summary>
-		/// Validate a password against the lobby's stored hash.
-		/// </summary>
+		/// <summary>Validate a password against the lobby's stored hash.</summary>
 		public static bool ValidateLobbyPassword(ulong lobbyId, string password)
 		{
 			using var _ = Profiler.Scope();
@@ -455,9 +431,7 @@ namespace ONI_Together.Networking.Transport.Steamworks
 			return PasswordHelper.VerifyPassword(password, storedHash);
 		}
 
-		/// <summary>
-		/// Set the lobby password (host only).
-		/// </summary>
+		/// <summary>HOST ONLY - set the lobby password.</summary>
 		public static void SetLobbyPassword(string password)
 		{
 			using var _ = Profiler.Scope();
@@ -472,7 +446,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 			SteamMatchmaking.SetLobbyData(CurrentLobby, "password_hash", hash);
 			SteamMatchmaking.SetLobbyData(CurrentLobby, "has_password", string.IsNullOrEmpty(hash) ? "0" : "1");
 
-			// Also update config
 			Configuration.Instance.Host.Lobby.PasswordHash = hash;
 			Configuration.Instance.Host.Lobby.RequirePassword = !string.IsNullOrEmpty(hash);
 			Configuration.Instance.Save();
@@ -480,9 +453,7 @@ namespace ONI_Together.Networking.Transport.Steamworks
 			DebugConsole.Log($"[SteamLobby] Lobby password {(string.IsNullOrEmpty(hash) ? "removed" : "set")}");
 		}
 
-		/// <summary>
-		/// Set the lobby visibility (public or friends only). TODO: Later allow invite only
-		/// </summary>
+		/// <summary>HOST ONLY - set visibility to public or friends only. TODO: invite only.</summary>
 		public static void SetLobbyVisibility(bool isPrivate)
 		{
 			using var _ = Profiler.Scope();
@@ -497,33 +468,26 @@ namespace ONI_Together.Networking.Transport.Steamworks
 			SteamMatchmaking.SetLobbyType(CurrentLobby, lobbyType);
 			SteamMatchmaking.SetLobbyData(CurrentLobby, "visibility", isPrivate ? "private" : "public");
 
-			// Update config
 			Configuration.Instance.Host.Lobby.IsPrivate = isPrivate;
 			Configuration.Instance.Save();
 
 			DebugConsole.Log($"[SteamLobby] Lobby visibility set to: {(isPrivate ? "Friends Only" : "Public")}");
 		}
 
-		/// <summary>
-		/// Get the local user's region code.
-		/// </summary>
+		/// <summary>The configured region code, or "AUTO" when unset.</summary>
 		public static string GetLocalRegion()
 		{
 			using var _ = Profiler.Scope();
 
-			// Try to get from config first
 			string configRegion = Configuration.Instance.Host.Lobby.Region;
 			if (!string.IsNullOrEmpty(configRegion))
 				return configRegion;
 
-			// Default fallback
 			return "AUTO";
 		}
 
-		/// <summary>
-		/// Update the lobby with current game info (colony name, cycle, duplicants).
-		/// Should be called periodically by the host while in-game.
-		/// </summary>
+		/// <summary>HOST ONLY - publish colony name, cycle and duplicant counts to lobby data.
+		/// Call periodically while in-game.</summary>
 		public static void UpdateGameInfo()
 		{
 			using var _ = Profiler.Scope();
@@ -536,15 +500,12 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
 			try
 			{
-				// Get colony name
 				string colonyName = SaveGame.Instance?.BaseName ?? "Unknown Colony";
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "colony_name", colonyName);
 
-				// Get current cycle
 				int cycle = GameClock.Instance != null ? GameClock.Instance.GetCycle() : 0;
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "cycle", cycle.ToString());
 
-				// Get duplicant counts (alive vs total)
 				int aliveCount = global::Components.LiveMinionIdentities?.Count ?? 0;
 				int totalCount = global::Components.MinionIdentities?.Count ?? 0;
 				SteamMatchmaking.SetLobbyData(CurrentLobby, "duplicant_alive", aliveCount.ToString());
@@ -556,9 +517,8 @@ namespace ONI_Together.Networking.Transport.Steamworks
                     return;
 				}
 
-				// Steam utils not in use outside steam relay
-
-                // Store host's ping location for client ping estimation
+                // Steam utils are not in use outside the steam relay - hence the early return
+                // above. Clients estimate ping to the host from this stored location.
                 float age = SteamNetworkingUtils.GetLocalPingLocation(out SteamNetworkPingLocation_t pingLocation);
 				if (age >= 0)
 				{
@@ -579,9 +539,7 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
         #region Lobby Browser
 
-		/// <summary>
-		/// Request a list of public lobbies for the browser.
-		/// </summary>
+		/// <summary>Request a list of public lobbies for the browser.</summary>
 		public static void RequestLobbyList(Action<List<LobbyListEntry>> onComplete)
 		{
 			using var _ = Profiler.Scope();
@@ -594,7 +552,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
 			_onLobbyListReceived = onComplete;
 
-			// Filter for ONI Multiplayer lobbies only
 			SteamMatchmaking.AddRequestLobbyListStringFilter("game_id", "oni_multiplayer", ELobbyComparison.k_ELobbyComparisonEqual);
 
 			// Limit results
@@ -628,7 +585,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 				if (!lobbyId.IsValid())
 					continue;
 
-				// Get host Steam ID
 				CSteamID hostSteamId = CSteamID.Nil;
 				string hostStr = SteamMatchmaking.GetLobbyData(lobbyId, "host");
 				if (ulong.TryParse(hostStr, out ulong hostId))
@@ -636,7 +592,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 					hostSteamId = new CSteamID(hostId);
 				}
 
-				// Check if host is a friend
 				bool isFriend = hostSteamId.IsValid() && SteamFriends.HasFriend(hostSteamId, EFriendFlags.k_EFriendFlagImmediate);
 
                 // Failsafe ignore "private" lobbies unless we're friends with the host
@@ -644,7 +599,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
                 if (visibility.Equals("private") && !isFriend)
                     continue;
 
-                // Estimate ping to host using their stored ping location
                 int pingMs = -1;
 				string hostPingLocation = SteamMatchmaking.GetLobbyData(lobbyId, "host_ping_location");
 				if (!string.IsNullOrEmpty(hostPingLocation))
@@ -674,7 +628,6 @@ namespace ONI_Together.Networking.Transport.Steamworks
 					IsLan = SteamMatchmaking.GetLobbyData(lobbyId, "relay") == "1",
 					LanAddress = SteamMatchmaking.GetLobbyData(lobbyId, "lan_address"),
 					PingMs = pingMs,
-					// Game info
 					ColonyName = SteamMatchmaking.GetLobbyData(lobbyId, "colony_name"),
 					Cycle = int.TryParse(SteamMatchmaking.GetLobbyData(lobbyId, "cycle"), out int cycle) ? cycle : 0,
 					DuplicantAlive = int.TryParse(SteamMatchmaking.GetLobbyData(lobbyId, "duplicant_alive"), out int alive) ? alive : 0,
@@ -708,12 +661,11 @@ namespace ONI_Together.Networking.Transport.Steamworks
 				bool isFriend = hostSteamId.IsValid() && SteamFriends.HasFriend(hostSteamId, EFriendFlags.k_EFriendFlagImmediate);
 				if (isFriend)
 				{
-					// Return the name the user has on our friends list
+					// The name as it appears on our friends list, not the published one.
 					return SteamFriends.GetFriendPersonaName(new CSteamID(hostId));
                 }
 			}
 
-			// Displays the users public username
             string hostname = SteamMatchmaking.GetLobbyData(lobbyId, "hostname");
 			if(!string.IsNullOrEmpty(hostname))
 			{

--- a/ONI_Together/Networking/Transport/Steamworks/SteamLobby.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamLobby.cs
@@ -271,17 +271,15 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
 				MultiplayerSession.ConnectedPlayers.Remove(userId);
 
-				// Someone who leaves is not coming back from a load, so drop their pending load
-				// entry too: off the roster it still counts (see PendingLoadingClientCount) and
-				// holds the resume gate closed on behalf of a player who is already gone, until
-				// the 120s expiry. Whether they were mid-load also picks the chat line -
-				// vanishing while loading is a failed join, not a choice to leave.
+				// Someone who leaves is not coming back from a load, so drop their pending
+				// load entry too - off the roster it still counts (see
+				// PendingLoadingClientCount) and holds the gate for a player who is gone.
+				// Whether they were mid-load also picks the chat line: vanishing while
+				// loading is a failed join, not a choice to leave.
 				//
-				// NOTE: every transport calls ForgetClientLoading from its KICK path, but only
-				// Steam clears it on a voluntary leave - LiteNetLibServer.OnPeerDisconnected and
-				// RiptideServer.ServerOnClientDisconnected do not. Left unfixed because it stays
-				// invisible on LAN: a returning loader arrives under a NEW client id, so
-				// ClaimOldestLoadingReconnect consumes the entry anyway.
+				// Only Steam clears this on a voluntary leave; the LAN transports clear it
+				// only on kick - invisible there, because a returning loader arrives under a
+				// new id and ClaimOldestLoadingReconnect consumes the entry anyway.
 				bool failedWhileJoining = false;
 				if (MultiplayerSession.IsHost)
 				{

--- a/ONI_Together/Networking/Transport/Steamworks/SteamLobby.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamLobby.cs
@@ -261,8 +261,11 @@ namespace ONI_Together.Networking.Transport.Steamworks
                     MultiplayerSession.ConnectedPlayers.Add(userId, new MultiplayerPlayer(user.m_SteamID));
                 }
 
+				// No chat line here on purpose. Entering the lobby is the start of a join, not
+				// the end of one - the player still has to download the save, load it and
+				// reconnect, which measured 38s. ClientReadyStatusPacket says it when they are
+				// actually in.
 				DebugConsole.Log($"[SteamLobby] {name} joined the lobby.");
-				OxySyncChat.AddSystemMessage(string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_JOINED, name));
                 var boxedId = Boxed<ulong>.Get(userId);
 				Game.Instance?.Trigger(MP_HASHES.OnPlayerJoined, boxedId);
 				boxedId.Release();
@@ -277,9 +280,46 @@ namespace ONI_Together.Networking.Transport.Steamworks
 
 				MultiplayerSession.ConnectedPlayers.Remove(userId);
 
+				// Someone who leaves the lobby is not coming back from a load, so their pending
+				// load entry has to go with them. Leaving it behind is worse than useless: the
+				// moment they drop off the roster that entry starts counting (see
+				// PendingLoadingClientCount) and holds the resume gate closed on behalf of a
+				// player who is already gone. A Steam session sat frozen for 5m24s on exactly
+				// that - the client left at 05:14:04 with one pending load and the gate only
+				// reopened at 05:19:28, on the 120s expiry.
+				//
+				// NOTE: every transport calls ForgetClientLoading from its KICK path, but only
+				// Steam clears it on a voluntary leave. LiteNetLibServer.OnPeerDisconnected and
+				// RiptideServer.ServerOnClientDisconnected do not, so a LAN client that drops
+				// mid-load and never returns still holds the gate for the full timeout. Not
+				// fixed here because it has not been reproduced on LAN - the LAN reconnect
+				// arrives under a NEW client id and ClaimOldestLoadingReconnect consumes the
+				// entry, which is why the window has stayed invisible there.
+				//
+				// Whether they were mid-load also decides what the rest of the table is told:
+				// vanishing while loading is a failed join, not someone choosing to leave.
+				bool failedWhileJoining = false;
+				if (MultiplayerSession.IsHost)
+				{
+					failedWhileJoining =
+						NetworkConfig.TransportServer?.IsClientLoading(userId) == true;
+					NetworkConfig.TransportServer?.ForgetClientLoading(userId);
+				}
+
 				RefreshLobbyMembers();
-				DebugConsole.Log($"[SteamLobby] {name} left the lobby.");
-                OxySyncChat.AddSystemMessage(string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_LEFT, name));
+				// Log the raw state-change flag: Left is a voluntary leave (the Steam client
+				// also reports Left on behalf of a killed game process), Disconnected means
+				// Steam lost the whole client, Kicked is ours. Together with the connection
+				// close reason logged by SteamworksServer this is the record of HOW a player
+				// went away, not just that they did.
+				DebugConsole.Log(
+					$"[SteamLobby] {name} left the lobby (state change: {stateChange}" +
+					$"{(failedWhileJoining ? "; still loading - treating as a failed join" : "")}).");
+                OxySyncChat.AddSystemMessage(string.Format(
+					failedWhileJoining
+						? STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_FAILED
+						: STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_LEFT,
+					name));
                 Utils.PauseSimOnPlayerLeft();
 				var boxedId = Boxed<ulong>.Get(userId);
 				Game.Instance?.Trigger(MP_HASHES.OnPlayerLeft, boxedId);

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksClient.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksClient.cs
@@ -220,6 +220,10 @@ namespace ONI_Together.Networking.Transport.Steam
 
             DebugConsole.Log("[GameClient] Connection to host established!");
 
+            // A reconnect landed - stop counting post-load failures so a later, unrelated
+            // load starts from a full retry budget.
+            GameClient.NotifyReconnectSucceeded();
+
             // Skip mod verification if we are the host
 			if (MultiplayerSession.IsHost)
 			{
@@ -255,7 +259,14 @@ namespace ONI_Together.Networking.Transport.Steam
                     }
                     break;
                 case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
-                    // Something went wrong locally
+                    // Something went wrong locally. In game this is usually the post-load
+                    // reconnect losing a race against Steam's route setup rather than a real
+                    // refusal, so retry before throwing the player out - see
+                    // GameClient.TryRetryPostLoadReconnect for the measurements. A failure
+                    // outside a session still surfaces immediately.
+                    if (Utils.IsInGame() && GameClient.TryRetryPostLoadReconnect())
+                        break;
+
                     NetworkConfig.TransportClient.OnReturnToMenu.Invoke(STRINGS.UI.MP_OVERLAY.CLIENT.STEAMWORKS.LOCAL_PROBLEM, STRINGS.UI.MP_OVERLAY.CLIENT.STEAMWORKS.LOCAL_PROBLEM_DESC);
                     break;
             }

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -234,7 +234,17 @@ namespace ONI_Together.Networking.Transport.Steam
             }
             player.Connection = conn;
 
+            // Authority: a (re)connecting client is loading and must be forced Unready the
+            // moment it begins connecting — not just at object creation. This keeps the
+            // host's all-ready check from transiently passing while the client loads.
+            // SetPlayerReadyState safely no-ops for the host's own entry.
+            ReadyManager.SetPlayerReadyState(player, ClientReadyState.Unready);
+
             DebugConsole.Log($"[GameServer] Connection to {clientId} fully established!");
+
+            // Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
+            ReadyManager.RefreshScreen();
+            ReadyManager.RefreshReadyState();
             //SaveFileRequestPacket.SendSaveFile(clientId); // Old method
             //GoogleDriveUtils.UploadAndSendToClient(clientId); // Upload to googledrive and send to the client
         }

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using ONI_Together.DebugTools;
+using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.Architecture;
 using Shared.Profiling;
 using ONI_Together.Networking.States;
@@ -241,6 +242,10 @@ namespace ONI_Together.Networking.Transport.Steam
             ReadyManager.SetPlayerReadyState(player, ClientReadyState.Unready);
 
             DebugConsole.Log($"[GameServer] Connection to {clientId} fully established!");
+
+            // A joining client must not leave the rest of the table running while it loads:
+            // pause the sim (broadcast to all peers) so the ready screen freezes the world.
+            Utils.PauseSimForReadyScreen();
 
             // Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
             ReadyManager.RefreshScreen();

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -244,7 +244,7 @@ namespace ONI_Together.Networking.Transport.Steam
 
             // Steam P2P: the host is never added through this remote-connection path, so
             // this is always a remote client — no host-loopback case to exclude.
-            ReadyManager.HandleClientConnected();
+            ReadyManager.HandleClientConnected(isHostLoopback: false);
             //SaveFileRequestPacket.SendSaveFile(clientId); // Old method
             //GoogleDriveUtils.UploadAndSendToClient(clientId); // Upload to googledrive and send to the client
         }

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using ONI_Together.DebugTools;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.Architecture;
 using Shared.Profiling;
 using ONI_Together.Networking.States;
@@ -243,13 +242,7 @@ namespace ONI_Together.Networking.Transport.Steam
 
             DebugConsole.Log($"[GameServer] Connection to {clientId} fully established!");
 
-            // A joining client must not leave the rest of the table running while it loads:
-            // pause the sim (broadcast to all peers) so the ready screen freezes the world.
-            Utils.PauseSimForReadyScreen();
-
-            // Host owns the roster/visibility: recompute and rebroadcast show/hide + text.
-            ReadyManager.RefreshScreen();
-            ReadyManager.RefreshReadyState();
+            ReadyManager.OnClientConnected();
             //SaveFileRequestPacket.SendSaveFile(clientId); // Old method
             //GoogleDriveUtils.UploadAndSendToClient(clientId); // Upload to googledrive and send to the client
         }

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -242,7 +242,9 @@ namespace ONI_Together.Networking.Transport.Steam
 
             DebugConsole.Log($"[GameServer] Connection to {clientId} fully established!");
 
-            ReadyManager.OnClientConnected();
+            // Steam P2P: the host is never added through this remote-connection path, so
+            // this is always a remote client — no host-loopback case to exclude.
+            ReadyManager.HandleClientConnected();
             //SaveFileRequestPacket.SendSaveFile(clientId); // Old method
             //GoogleDriveUtils.UploadAndSendToClient(clientId); // Upload to googledrive and send to the client
         }

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -213,12 +213,10 @@ namespace ONI_Together.Networking.Transport.Steam
 
                 case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer:
                 case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
-                    // The end reason is the only signal that tells a deliberate quit from a
-                    // killed process or a timeout: our own client closes with the debug string
-                    // "Client disconnecting" (App range, 1xxx), while a dead process is closed
-                    // by the Steam client on its behalf and a vanished peer shows up as a Misc
-                    // (5xxx) reason. Kept as a log for now; measured values decide whether chat
-                    // should tell "left" apart from "lost connection".
+                    // The end reason is the only signal telling a deliberate quit from a dead
+                    // process or a vanished peer: our client closes with "Client disconnecting"
+                    // (App range, 1xxx), the Steam client closes on a dead process's behalf,
+                    // and a vanished peer shows a Misc (5xxx) reason.
                     DebugConsole.Log(
                         $"[GameServer] Close reason for {clientId}: " +
                         $"{data.m_info.m_eEndReason} \"{data.m_info.m_szEndDebug}\"");
@@ -310,13 +308,10 @@ namespace ONI_Together.Networking.Transport.Steam
         }
 
         /// <summary>
-        /// Steam matches returning loaders by id and never guesses. Both sides of the match are
-        /// the same account's 64-bit SteamID - the client reports its own via
-        /// NetworkConfig.GetLocalID (SteamUser.GetSteamID().m_SteamID) when it is marked, and
-        /// the host claims with the connecting peer's CSteamID - so the exact branch always
-        /// hits. Inheriting the LAN fallback would only let a wrong entry be released here, and
-        /// silently: a fallback hit on Steam means the mark went missing, which is a bug to see
-        /// rather than to paper over.
+        /// Steam matches returning loaders by id and never guesses: both sides of the match
+        /// are the same account's 64-bit SteamID, so the exact branch always hits.
+        /// Inheriting the LAN fallback would only let a wrong entry be released silently -
+        /// a fallback hit on Steam means the mark went missing, a bug to see, not paper over.
         /// </summary>
         public override bool ClaimLoadingReconnect(ulong clientId)
         {

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -213,6 +213,15 @@ namespace ONI_Together.Networking.Transport.Steam
 
                 case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer:
                 case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
+                    // The end reason is the only signal that tells a deliberate quit from a
+                    // killed process or a timeout: our own client closes with the debug string
+                    // "Client disconnecting" (App range, 1xxx), while a dead process is closed
+                    // by the Steam client on its behalf and a vanished peer shows up as a Misc
+                    // (5xxx) reason. Kept as a log for now; measured values decide whether chat
+                    // should tell "left" apart from "lost connection".
+                    DebugConsole.Log(
+                        $"[GameServer] Close reason for {clientId}: " +
+                        $"{data.m_info.m_eEndReason} \"{data.m_info.m_szEndDebug}\"");
                     OnClientClosed(conn, clientId);
                     break;
             }
@@ -298,6 +307,20 @@ namespace ONI_Together.Networking.Transport.Steam
             ReadyManager.HandleClientConnected();
             //SaveFileRequestPacket.SendSaveFile(clientId); // Old method
             //GoogleDriveUtils.UploadAndSendToClient(clientId); // Upload to googledrive and send to the client
+        }
+
+        /// <summary>
+        /// Steam matches returning loaders by id and never guesses. Both sides of the match are
+        /// the same account's 64-bit SteamID - the client reports its own via
+        /// NetworkConfig.GetLocalID (SteamUser.GetSteamID().m_SteamID) when it is marked, and
+        /// the host claims with the connecting peer's CSteamID - so the exact branch always
+        /// hits. Inheriting the LAN fallback would only let a wrong entry be released here, and
+        /// silently: a fallback hit on Steam means the mark went missing, which is a bug to see
+        /// rather than to paper over.
+        /// </summary>
+        public override bool ClaimLoadingReconnect(ulong clientId)
+        {
+            return ClaimExactLoadingReconnect(clientId);
         }
 
         private static void OnClientClosed(HSteamNetConnection conn, CSteamID clientId)

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -92,6 +92,8 @@ namespace ONI_Together.Networking.Transport.Steam
             if (ListenSocket.m_HSteamListenSocket != 0)
                 SteamNetworkingSockets.CloseListenSocket(ListenSocket);
 
+            ClearLoadTracking();
+
             MultiplayerSession.InActiveSession = false;
         }
 
@@ -121,6 +123,7 @@ namespace ONI_Together.Networking.Transport.Steam
             SteamAPI.RunCallbacks();
             SteamNetworkingSockets.RunCallbacks();
             UpdateServerBandwidth();
+            ExpireStaleLoadingClients();
         }
 
         private void UpdateServerBandwidth()
@@ -278,7 +281,21 @@ namespace ONI_Together.Networking.Transport.Steam
             }
             player.Connection = conn;
 
+            // Authority: a (re)connecting client is loading and must be forced Unready the
+            // moment it begins connecting — not just at object creation. This keeps the
+            // host's all-ready check from transiently passing while the client loads.
+            // SetPlayerReadyState safely no-ops for the host's own entry.
+            ReadyManager.SetPlayerReadyState(player, ClientReadyState.Unready);
+
+            // A SteamID is stable across a load-reconnect, so a returning loader matches its
+            // pending entry exactly. Clearing it here keeps the entry from lingering until it
+            // times out - which would count against the gate if the client later left for
+            // real and dropped off the roster.
+            NetworkConfig.TransportServer?.ClaimLoadingReconnect(clientId.m_SteamID);
+
             DebugConsole.Log($"[GameServer] Connection to {clientId} fully established!");
+
+            ReadyManager.HandleClientConnected();
             //SaveFileRequestPacket.SendSaveFile(clientId); // Old method
             //GoogleDriveUtils.UploadAndSendToClient(clientId); // Upload to googledrive and send to the client
         }
@@ -323,6 +340,9 @@ namespace ONI_Together.Networking.Transport.Steam
             {
                 DebugConsole.Log($"[GameServer] Kicking client {clientId}");
 
+                // A kicked client is not coming back, so its pending load must not keep
+                // holding the gate. OnClientClosed below carries the refresh.
+                ForgetClientLoading(clientId);
                 SteamNetworkingSockets.CloseConnection(conn, 0, "Kicked by host", false);
                 // The connection closed callback will handle cleanup
             }

--- a/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
+++ b/ONI_Together/Networking/Transport/Steamworks/SteamworksServer.cs
@@ -124,6 +124,7 @@ namespace ONI_Together.Networking.Transport.Steam
             SteamNetworkingSockets.RunCallbacks();
             UpdateServerBandwidth();
             ExpireStaleLoadingClients();
+            ExpireNeverReadyClients();
         }
 
         private void UpdateServerBandwidth()

--- a/ONI_Together/Networking/Transport/TransportServer.cs
+++ b/ONI_Together/Networking/Transport/TransportServer.cs
@@ -23,5 +23,15 @@ namespace ONI_Together.Networking.Transport
         public abstract void OnMessageRecieved();
 
         public abstract void KickClient(ulong clientId);
+
+        /// <summary>
+        /// HOST - true while one or more clients are mid "disconnect-to-load-then-reconnect"
+        /// and have therefore dropped off the live roster but are NOT gone (they reconnect
+        /// with a fresh transport id). The resume gate and the ready screen must keep
+        /// treating them as unready until they return. Transports that instead keep a
+        /// Connection==null placeholder in ConnectedPlayers during load (Steamworks) have
+        /// nothing extra to report and leave this false.
+        /// </summary>
+        public virtual bool HasPendingLoadingClients => false;
     }
 }

--- a/ONI_Together/Networking/Transport/TransportServer.cs
+++ b/ONI_Together/Networking/Transport/TransportServer.cs
@@ -25,13 +25,16 @@ namespace ONI_Together.Networking.Transport
         public abstract void KickClient(ulong clientId);
 
         /// <summary>
-        /// HOST - true while one or more clients are mid "disconnect-to-load-then-reconnect"
-        /// and have therefore dropped off the live roster but are NOT gone (they reconnect
-        /// with a fresh transport id). The resume gate and the ready screen must keep
-        /// treating them as unready until they return. Transports that instead keep a
-        /// Connection==null placeholder in ConnectedPlayers during load (Steamworks) have
-        /// nothing extra to report and leave this false.
+        /// HOST - how many clients are mid "disconnect-to-load-then-reconnect" and have
+        /// therefore dropped off the live roster but are NOT gone (they reconnect with a
+        /// fresh transport id). The resume gate and the ready screen must keep treating
+        /// them as unready/expected until they return. Transports that instead keep a
+        /// Connection==null placeholder in ConnectedPlayers during load (Steamworks) track
+        /// them in the roster and report 0 here.
         /// </summary>
-        public virtual bool HasPendingLoadingClients => false;
+        public virtual int PendingLoadingClientCount => 0;
+
+        /// <summary>HOST - true while any client is mid load-reconnect (see <see cref="PendingLoadingClientCount"/>).</summary>
+        public bool HasPendingLoadingClients => PendingLoadingClientCount > 0;
     }
 }

--- a/ONI_Together/Networking/Transport/TransportServer.cs
+++ b/ONI_Together/Networking/Transport/TransportServer.cs
@@ -34,51 +34,39 @@ namespace ONI_Together.Networking.Transport
 
         #region Load-in-flight tracking
 
-        // A client disconnects to load the level and then reconnects. While it is gone the
-        // host must keep treating it as unready, or the resume gate opens and the ready
-        // screen closes mid-load. This bookkeeping lives on the base class rather than in one
-        // transport because the signal that starts it (ClientReadyState.Loading, sent from
-        // GameClient when the save is requested and again from SaveHelper before the
-        // disconnect) is transport-agnostic and every transport needs the same answer.
-        //
-        // clientId -> unscaledTime at which the client reported it started loading.
+        // A client disconnects to load the level and then reconnects. While it is gone the host
+        // must keep treating it as unready, or the resume gate opens and the ready screen closes
+        // mid-load. Lives on the base class because both start signals (host hands out a save;
+        // client sends ClientReadyState.Loading) are transport-agnostic.
+
+        // clientId -> unscaledTime at which the load was recorded.
         private readonly Dictionary<ulong, float> _loadingClients = new Dictionary<ulong, float>();
 
-        // Clients whose reconnect was matched back to a pending load, so callers can tell a
-        // returning loader apart from a genuinely new join (used to suppress the duplicate
-        // "joined" chat line). Consumed once per entry.
+        // Reconnects matched back to a pending load, so a returning loader can be told apart
+        // from a new join (suppresses a duplicate "joined" chat line). Consumed once.
         private readonly HashSet<ulong> _reconnectedFromLoad = new HashSet<ulong>();
 
         private readonly List<ulong> _expiredLoadingClients = new List<ulong>();
 
-        // A load entry is only ever dropped by a matching reconnect or by this timeout. It has
-        // to outlast a legitimately slow load, so it cannot reuse Host.TimeoutSeconds: that is
-        // a socket timeout, defaults to 30s and is floored at 30s, while a large-colony
-        // rebuild measured 20-30s on its own. Expiring at the same order as a healthy load
-        // would open the gate on exactly the client this class exists to wait for. This is a
-        // last-resort release for a client that hard crashed and is never coming back, so it
-        // is sized well past any real load rather than tuned.
+        // Entries are dropped by a matching reconnect or by this timeout. It cannot reuse
+        // Host.TimeoutSeconds (a socket timeout, defaulted and floored at 30s) because a
+        // large-colony load takes 20-30s on its own - expiring there would open the gate on
+        // exactly the client this class waits for. Sized well past any real load, not tuned.
         private const float LOAD_RECONNECT_TIMEOUT_SECONDS = 120f;
 
-        /// <summary>
-        /// HOST ONLY - record that a client reported it is loading the level (and is therefore
-        /// about to drop its connection). Repeated calls just refresh the timestamp.
-        /// </summary>
+        /// <summary>HOST ONLY - record that a client is loading the level and is about to drop
+        /// its connection. Repeated calls refresh the timestamp.</summary>
         public void MarkClientLoading(ulong clientId)
         {
-            // Logged because this lifecycle decides which chat line a departure gets (failed
-            // join vs left) and whether the gate holds through a load window - and its main
-            // caller, SaveFileRequestPacket, was otherwise silent about it.
+            // Logged: this lifecycle picks the departure chat line and holds the resume gate.
             DebugConsole.Log(
                 $"[TransportServer] {clientId} marked loading " +
                 $"(was {(_loadingClients.ContainsKey(clientId) ? "already marked" : "unmarked")})");
             _loadingClients[clientId] = UnityEngine.Time.unscaledTime;
         }
 
-        /// <summary>
-        /// HOST ONLY - true (once) if this client's connect was matched back to a pending load,
-        /// i.e. it is a returning loader rather than a new join.
-        /// </summary>
+        /// <summary>HOST ONLY - true (once) if this client's connect was matched back to a
+        /// pending load, i.e. a returning loader rather than a new join.</summary>
         public bool ConsumeReconnectFromLoad(ulong clientId)
         {
             return _reconnectedFromLoad.Remove(clientId);
@@ -91,34 +79,22 @@ namespace ONI_Together.Networking.Transport
         }
 
         /// <summary>
-        /// HOST ONLY - called from a transport's client-connected path to match a fresh
-        /// connection against the pending loads. Returns true if this connect was a returning
-        /// loader.
-        ///
-        /// Only Steamworks can match by id: it keys on the SteamID. Neither LAN transport can -
-        /// both derive the client id from the peer handle, and a returning loader is measured
-        /// to come back under a new one (a client that left as id 2 returned as id 3). So the
-        /// LAN case falls back to releasing the longest-pending entry.
-        ///
-        /// That fallback is a guess, and the guess is wrong when a brand-new client connects
-        /// while someone else is loading: it releases the loader's entry, and the gate is then
-        /// held only by the new client's Unready flag, so it opens as soon as that client
-        /// reports Ready. It needs two clients moving at once to bite, and the alternative -
-        /// leaving the entry alone - stalls the gate for the full timeout after every single
-        /// load. Restoring a stable client id across a reconnect would remove the choice.
-        ///
-        /// This base implementation is the LAN one. SteamworksServer overrides it to drop the
-        /// fallback, so the guess cannot fire on a transport that does not need it.
+        /// HOST ONLY - match a fresh connection against the pending loads; true if this connect
+        /// was a returning loader. Only Steamworks matches by id (keyed on the SteamID); both
+        /// LAN transports derive the client id from the peer handle, so a returning loader
+        /// arrives under a new id and they fall back to releasing the longest-pending entry.
+        /// That guess is wrong when a new client connects while someone else is loading, leaving
+        /// the gate held only by the new client's Unready flag - but do not "fix" it by keeping
+        /// the entry, which stalls the gate for the full timeout after every load.
+        /// SteamworksServer overrides out the fallback.
         /// </summary>
         public virtual bool ClaimLoadingReconnect(ulong clientId)
         {
             return ClaimExactLoadingReconnect(clientId) || ClaimOldestLoadingReconnect(clientId);
         }
 
-        /// <summary>
-        /// HOST ONLY - release the pending load recorded under this exact client id. Only
-        /// meaningful on a transport whose client id survives a reconnect.
-        /// </summary>
+        /// <summary>HOST ONLY - release the pending load under this exact client id. Only
+        /// meaningful on a transport whose client id survives a reconnect.</summary>
         protected bool ClaimExactLoadingReconnect(ulong clientId)
         {
             if (!_loadingClients.Remove(clientId))
@@ -129,11 +105,8 @@ namespace ONI_Together.Networking.Transport
             return true;
         }
 
-        /// <summary>
-        /// HOST ONLY - release the longest-pending load entry and credit it to
-        /// <paramref name="clientId"/>. See the warning on
-        /// <see cref="ClaimLoadingReconnect"/> for what this costs when the guess is wrong.
-        /// </summary>
+        /// <summary>HOST ONLY - release the longest-pending load entry and credit it to
+        /// <paramref name="clientId"/>. See <see cref="ClaimLoadingReconnect"/> for the cost.</summary>
         protected bool ClaimOldestLoadingReconnect(ulong clientId)
         {
             if (_loadingClients.Count == 0)
@@ -153,9 +126,7 @@ namespace ONI_Together.Networking.Transport
             _loadingClients.Remove(oldest);
             _reconnectedFromLoad.Add(clientId);
 
-            // The only branch in this mechanism that guesses. Worth a line in the log: when
-            // the gate misbehaves, this tells you whether an entry was released by an id match
-            // or by assumption, and which entry got consumed.
+            // The only branch that guesses - log it so a bad gate traces back to the assumption.
             DebugConsole.Log(
                 $"[TransportServer] {clientId} has no pending load of its own; assuming it is " +
                 $"returning loader {oldest} (pending loads left: {_loadingClients.Count}). " +
@@ -164,12 +135,9 @@ namespace ONI_Together.Networking.Transport
             return true;
         }
 
-        /// <summary>
-        /// HOST ONLY - drop a client's pending load without crediting it as a returning
-        /// loader. For a client that is not coming back: a kicked client would otherwise hold
-        /// the gate until the timeout, and its own disconnect event cannot clear it (the kick
-        /// has already removed the peer mapping that event is keyed on).
-        /// </summary>
+        /// <summary>HOST ONLY - drop a pending load without crediting a returning loader. A
+        /// kicked client would otherwise hold the gate until the timeout, and its own disconnect
+        /// event cannot clear it: the kick already removed the peer mapping that event keys on.</summary>
         public void ForgetClientLoading(ulong clientId)
         {
             if (_loadingClients.Remove(clientId))
@@ -177,23 +145,17 @@ namespace ONI_Together.Networking.Transport
             _reconnectedFromLoad.Remove(clientId);
         }
 
-        /// <summary>
-        /// HOST ONLY - drop all load bookkeeping. Call when the server stops: the transport
-        /// instance outlives a session (NetworkConfig only replaces it when the transport
-        /// itself changes), so without this a client that was mid-load when the host shut
-        /// down still holds the gate closed in the *next* session until it ages out.
-        /// </summary>
+        /// <summary>HOST ONLY - drop all load bookkeeping when the server stops. The transport
+        /// instance outlives a session (NetworkConfig replaces it only when the transport itself
+        /// changes), so a client left mid-load would hold the *next* session's gate closed.</summary>
         protected void ClearLoadTracking()
         {
             _loadingClients.Clear();
             _reconnectedFromLoad.Clear();
         }
 
-        /// <summary>
-        /// HOST ONLY - drop load entries that never came back, so a client that timed out or
-        /// hard crashed mid-load cannot hold the resume gate closed forever. Call from
-        /// Update().
-        /// </summary>
+        /// <summary>HOST ONLY - drop load entries that never came back, so a client that timed
+        /// out or crashed mid-load cannot hold the resume gate closed forever. Call from Update().</summary>
         protected void ExpireStaleLoadingClients()
         {
             if (_loadingClients.Count == 0)
@@ -214,20 +176,14 @@ namespace ONI_Together.Networking.Transport
             foreach (ulong id in _expiredLoadingClients)
                 _loadingClients.Remove(id);
 
-            // Dropping the entry is not enough on its own. Nothing else recomputes the gate on
-            // a timer, so without this refresh the safety net silently frees the count and the
-            // host still sits on the ready screen until some unrelated event happens to
-            // recalculate. Measured in a Steam session: a client left for good at 05:14:04
-            // holding one pending load, the entry expired ~05:16 with no visible effect, and
-            // the gate only reported OPEN at 05:19:28 when a late ClosedByPeer arrived -
-            // 5m24s of the world held frozen by a player who was already gone.
+            // Dropping entries is not enough - nothing else recomputes the gate on a timer, so
+            // without the refresh below the host sits on the ready screen indefinitely.
             DebugConsole.Log(
                 $"[TransportServer] Expired {_expiredLoadingClients.Count} stale load(s); " +
                 $"pending loads now {PendingLoadingClientCount}");
 
-            // Tell the table why the wait ended. A loader that never came back has failed to
-            // join, and without this the gate simply opens with no explanation of who is
-            // missing.
+            // A loader that never came back has failed to join; without this the gate just
+            // opens with no explanation of who is missing.
             foreach (ulong id in _expiredLoadingClients)
             {
                 string name = MultiplayerSession.KnownPlayerNames.TryGetValue(id, out var known)
@@ -242,18 +198,13 @@ namespace ONI_Together.Networking.Transport
         }
 
         /// <summary>
-        /// HOST ONLY - how many clients are mid "disconnect-to-load-then-reconnect" and have
-        /// therefore dropped off the live roster but are NOT gone. The resume gate and the
-        /// ready screen must keep treating them as unready/expected until they return.
+        /// HOST ONLY - clients mid "disconnect-to-load-then-reconnect": off the live roster but
+        /// NOT gone, so the resume gate and ready screen must keep expecting them.
         ///
-        /// Only off-roster loaders count: a client signals Loading just *before* it
-        /// disconnects, so for a brief window its id is in both _loadingClients and
-        /// ConnectedPlayers - where it is already counted (as Unready). Counting it here too
-        /// would inflate the ready-screen total (e.g. "1/3" for a single loading client).
-        /// This also makes the count naturally zero for a transport that keeps a
-        /// Connection==null placeholder in the roster for the whole load (Steamworks): an
-        /// in-roster loader holds the gate via its Unready state, an off-roster loader holds
-        /// it via this count - no double count, no gap.
+        /// Only off-roster loaders count. Loading is signalled just *before* the disconnect, so
+        /// the id is briefly in ConnectedPlayers too, already counted there as Unready - counting
+        /// it twice inflates the ready-screen total. That also makes this naturally zero on
+        /// Steamworks, which keeps a Connection==null roster placeholder for the whole load.
         /// </summary>
         public int PendingLoadingClientCount
         {

--- a/ONI_Together/Networking/Transport/TransportServer.cs
+++ b/ONI_Together/Networking/Transport/TransportServer.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.OxySync.Components;
 
 namespace ONI_Together.Networking.Transport
 {
@@ -64,6 +66,12 @@ namespace ONI_Together.Networking.Transport
         /// </summary>
         public void MarkClientLoading(ulong clientId)
         {
+            // Logged because this lifecycle decides which chat line a departure gets (failed
+            // join vs left) and whether the gate holds through a load window - and its main
+            // caller, SaveFileRequestPacket, was otherwise silent about it.
+            DebugConsole.Log(
+                $"[TransportServer] {clientId} marked loading " +
+                $"(was {(_loadingClients.ContainsKey(clientId) ? "already marked" : "unmarked")})");
             _loadingClients[clientId] = UnityEngine.Time.unscaledTime;
         }
 
@@ -98,16 +106,27 @@ namespace ONI_Together.Networking.Transport
         /// reports Ready. It needs two clients moving at once to bite, and the alternative -
         /// leaving the entry alone - stalls the gate for the full timeout after every single
         /// load. Restoring a stable client id across a reconnect would remove the choice.
+        ///
+        /// This base implementation is the LAN one. SteamworksServer overrides it to drop the
+        /// fallback, so the guess cannot fire on a transport that does not need it.
         /// </summary>
         public virtual bool ClaimLoadingReconnect(ulong clientId)
         {
-            if (_loadingClients.Remove(clientId))
-            {
-                _reconnectedFromLoad.Add(clientId);
-                return true;
-            }
+            return ClaimExactLoadingReconnect(clientId) || ClaimOldestLoadingReconnect(clientId);
+        }
 
-            return ClaimOldestLoadingReconnect(clientId);
+        /// <summary>
+        /// HOST ONLY - release the pending load recorded under this exact client id. Only
+        /// meaningful on a transport whose client id survives a reconnect.
+        /// </summary>
+        protected bool ClaimExactLoadingReconnect(ulong clientId)
+        {
+            if (!_loadingClients.Remove(clientId))
+                return false;
+
+            DebugConsole.Log($"[TransportServer] {clientId} reconnected; cleared its pending load");
+            _reconnectedFromLoad.Add(clientId);
+            return true;
         }
 
         /// <summary>
@@ -133,6 +152,15 @@ namespace ONI_Together.Networking.Transport
 
             _loadingClients.Remove(oldest);
             _reconnectedFromLoad.Add(clientId);
+
+            // The only branch in this mechanism that guesses. Worth a line in the log: when
+            // the gate misbehaves, this tells you whether an entry was released by an id match
+            // or by assumption, and which entry got consumed.
+            DebugConsole.Log(
+                $"[TransportServer] {clientId} has no pending load of its own; assuming it is " +
+                $"returning loader {oldest} (pending loads left: {_loadingClients.Count}). " +
+                "Wrong if a different client connected while someone else was loading.");
+
             return true;
         }
 
@@ -144,7 +172,8 @@ namespace ONI_Together.Networking.Transport
         /// </summary>
         public void ForgetClientLoading(ulong clientId)
         {
-            _loadingClients.Remove(clientId);
+            if (_loadingClients.Remove(clientId))
+                DebugConsole.Log($"[TransportServer] Dropped pending load for {clientId} (kick/leave)");
             _reconnectedFromLoad.Remove(clientId);
         }
 
@@ -179,8 +208,37 @@ namespace ONI_Together.Networking.Transport
                     _expiredLoadingClients.Add(kvp.Key);
             }
 
+            if (_expiredLoadingClients.Count == 0)
+                return;
+
             foreach (ulong id in _expiredLoadingClients)
                 _loadingClients.Remove(id);
+
+            // Dropping the entry is not enough on its own. Nothing else recomputes the gate on
+            // a timer, so without this refresh the safety net silently frees the count and the
+            // host still sits on the ready screen until some unrelated event happens to
+            // recalculate. Measured in a Steam session: a client left for good at 05:14:04
+            // holding one pending load, the entry expired ~05:16 with no visible effect, and
+            // the gate only reported OPEN at 05:19:28 when a late ClosedByPeer arrived -
+            // 5m24s of the world held frozen by a player who was already gone.
+            DebugConsole.Log(
+                $"[TransportServer] Expired {_expiredLoadingClients.Count} stale load(s); " +
+                $"pending loads now {PendingLoadingClientCount}");
+
+            // Tell the table why the wait ended. A loader that never came back has failed to
+            // join, and without this the gate simply opens with no explanation of who is
+            // missing.
+            foreach (ulong id in _expiredLoadingClients)
+            {
+                string name = MultiplayerSession.KnownPlayerNames.TryGetValue(id, out var known)
+                    ? known
+                    : id.ToString();
+                OxySyncChat.AddSystemMessage(
+                    string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_FAILED, name));
+            }
+
+            ReadyManager.RefreshScreen();
+            ReadyManager.RefreshReadyState();
         }
 
         /// <summary>

--- a/ONI_Together/Networking/Transport/TransportServer.cs
+++ b/ONI_Together/Networking/Transport/TransportServer.cs
@@ -29,5 +29,189 @@ namespace ONI_Together.Networking.Transport
         public virtual float OutgoingBandwidth => 0f;
         public virtual int IncomingPps => 0;
         public virtual int OutgoingPps => 0;
+
+        #region Load-in-flight tracking
+
+        // A client disconnects to load the level and then reconnects. While it is gone the
+        // host must keep treating it as unready, or the resume gate opens and the ready
+        // screen closes mid-load. This bookkeeping lives on the base class rather than in one
+        // transport because the signal that starts it (ClientReadyState.Loading, sent from
+        // GameClient when the save is requested and again from SaveHelper before the
+        // disconnect) is transport-agnostic and every transport needs the same answer.
+        //
+        // clientId -> unscaledTime at which the client reported it started loading.
+        private readonly Dictionary<ulong, float> _loadingClients = new Dictionary<ulong, float>();
+
+        // Clients whose reconnect was matched back to a pending load, so callers can tell a
+        // returning loader apart from a genuinely new join (used to suppress the duplicate
+        // "joined" chat line). Consumed once per entry.
+        private readonly HashSet<ulong> _reconnectedFromLoad = new HashSet<ulong>();
+
+        private readonly List<ulong> _expiredLoadingClients = new List<ulong>();
+
+        // A load entry is only ever dropped by a matching reconnect or by this timeout. It has
+        // to outlast a legitimately slow load, so it cannot reuse Host.TimeoutSeconds: that is
+        // a socket timeout, defaults to 30s and is floored at 30s, while a large-colony
+        // rebuild measured 20-30s on its own. Expiring at the same order as a healthy load
+        // would open the gate on exactly the client this class exists to wait for. This is a
+        // last-resort release for a client that hard crashed and is never coming back, so it
+        // is sized well past any real load rather than tuned.
+        private const float LOAD_RECONNECT_TIMEOUT_SECONDS = 120f;
+
+        /// <summary>
+        /// HOST ONLY - record that a client reported it is loading the level (and is therefore
+        /// about to drop its connection). Repeated calls just refresh the timestamp.
+        /// </summary>
+        public void MarkClientLoading(ulong clientId)
+        {
+            _loadingClients[clientId] = UnityEngine.Time.unscaledTime;
+        }
+
+        /// <summary>
+        /// HOST ONLY - true (once) if this client's connect was matched back to a pending load,
+        /// i.e. it is a returning loader rather than a new join.
+        /// </summary>
+        public bool ConsumeReconnectFromLoad(ulong clientId)
+        {
+            return _reconnectedFromLoad.Remove(clientId);
+        }
+
+        /// <summary>HOST ONLY - true while this exact client id has an in-flight load recorded.</summary>
+        public bool IsClientLoading(ulong clientId)
+        {
+            return _loadingClients.ContainsKey(clientId);
+        }
+
+        /// <summary>
+        /// HOST ONLY - called from a transport's client-connected path to match a fresh
+        /// connection against the pending loads. Returns true if this connect was a returning
+        /// loader.
+        ///
+        /// Matching is by id and nothing else, because guessing is not safe here: consuming
+        /// the entry of a client that is still loading drops PendingLoadingClientCount to zero,
+        /// and the gate then rests solely on the *new* client's Unready flag - so it opens as
+        /// soon as that client reports Ready, with the original loader still mid-load. That is
+        /// precisely the failure this class exists to prevent, so an unmatched connect leaves
+        /// the pending entry alone and the gate stays closed.
+        ///
+        /// LiteNetLib and Steamworks always match: LiteNetLib's OnConnectionRequest echoes back
+        /// the persistent id the client supplied, and Steamworks keys on the SteamID. Riptide
+        /// reassigns its id on reconnect and has nothing to match on - see the override in
+        /// RiptideServer for the trade it is forced into.
+        /// </summary>
+        public virtual bool ClaimLoadingReconnect(ulong clientId)
+        {
+            if (!_loadingClients.Remove(clientId))
+                return false;
+
+            _reconnectedFromLoad.Add(clientId);
+            return true;
+        }
+
+        /// <summary>
+        /// HOST ONLY - release the longest-pending load entry and credit it to
+        /// <paramref name="clientId"/>. Only for transports that cannot identify a returning
+        /// client (Riptide); see the warning on <see cref="ClaimLoadingReconnect"/> for what
+        /// this costs when the guess is wrong.
+        /// </summary>
+        protected void ClaimOldestLoadingReconnect(ulong clientId)
+        {
+            if (_loadingClients.Count == 0)
+                return;
+
+            ulong oldest = 0;
+            float oldestStartedAt = float.MaxValue;
+            foreach (var kvp in _loadingClients)
+            {
+                if (kvp.Value >= oldestStartedAt)
+                    continue;
+
+                oldestStartedAt = kvp.Value;
+                oldest = kvp.Key;
+            }
+
+            _loadingClients.Remove(oldest);
+            _reconnectedFromLoad.Add(clientId);
+        }
+
+        /// <summary>
+        /// HOST ONLY - drop a client's pending load without crediting it as a returning
+        /// loader. For a client that is not coming back: a kicked client would otherwise hold
+        /// the gate until the timeout, and its own disconnect event cannot clear it (the kick
+        /// has already removed the peer mapping that event is keyed on).
+        /// </summary>
+        public void ForgetClientLoading(ulong clientId)
+        {
+            _loadingClients.Remove(clientId);
+            _reconnectedFromLoad.Remove(clientId);
+        }
+
+        /// <summary>
+        /// HOST ONLY - drop all load bookkeeping. Call when the server stops: the transport
+        /// instance outlives a session (NetworkConfig only replaces it when the transport
+        /// itself changes), so without this a client that was mid-load when the host shut
+        /// down still holds the gate closed in the *next* session until it ages out.
+        /// </summary>
+        protected void ClearLoadTracking()
+        {
+            _loadingClients.Clear();
+            _reconnectedFromLoad.Clear();
+        }
+
+        /// <summary>
+        /// HOST ONLY - drop load entries that never came back, so a client that timed out or
+        /// hard crashed mid-load cannot hold the resume gate closed forever. Call from
+        /// Update().
+        /// </summary>
+        protected void ExpireStaleLoadingClients()
+        {
+            if (_loadingClients.Count == 0)
+                return;
+
+            float now = UnityEngine.Time.unscaledTime;
+            _expiredLoadingClients.Clear();
+
+            foreach (var kvp in _loadingClients)
+            {
+                if (now - kvp.Value > LOAD_RECONNECT_TIMEOUT_SECONDS)
+                    _expiredLoadingClients.Add(kvp.Key);
+            }
+
+            foreach (ulong id in _expiredLoadingClients)
+                _loadingClients.Remove(id);
+        }
+
+        /// <summary>
+        /// HOST ONLY - how many clients are mid "disconnect-to-load-then-reconnect" and have
+        /// therefore dropped off the live roster but are NOT gone. The resume gate and the
+        /// ready screen must keep treating them as unready/expected until they return.
+        ///
+        /// Only off-roster loaders count: a client signals Loading just *before* it
+        /// disconnects, so for a brief window its id is in both _loadingClients and
+        /// ConnectedPlayers - where it is already counted (as Unready). Counting it here too
+        /// would inflate the ready-screen total (e.g. "1/3" for a single loading client).
+        /// This also makes the count naturally zero for a transport that keeps a
+        /// Connection==null placeholder in the roster for the whole load (Steamworks): an
+        /// in-roster loader holds the gate via its Unready state, an off-roster loader holds
+        /// it via this count - no double count, no gap.
+        /// </summary>
+        public int PendingLoadingClientCount
+        {
+            get
+            {
+                int count = 0;
+                foreach (ulong id in _loadingClients.Keys)
+                {
+                    if (!MultiplayerSession.ConnectedPlayers.ContainsKey(id))
+                        count++;
+                }
+                return count;
+            }
+        }
+
+        /// <summary>HOST ONLY - true while any client is mid load-reconnect (see <see cref="PendingLoadingClientCount"/>).</summary>
+        public bool HasPendingLoadingClients => PendingLoadingClientCount > 0;
+
+        #endregion
     }
 }

--- a/ONI_Together/Networking/Transport/TransportServer.cs
+++ b/ONI_Together/Networking/Transport/TransportServer.cs
@@ -48,6 +48,8 @@ namespace ONI_Together.Networking.Transport
 
         private readonly List<ulong> _expiredLoadingClients = new List<ulong>();
 
+        private readonly List<ulong> _neverReadyClients = new List<ulong>();
+
         // Entries are dropped by a matching reconnect or by this timeout. It cannot reuse
         // Host.TimeoutSeconds (a socket timeout, defaulted and floored at 30s) because a
         // large-colony load takes 20-30s on its own - expiring there would open the gate on
@@ -63,6 +65,11 @@ namespace ONI_Together.Networking.Transport
                 $"[TransportServer] {clientId} marked loading " +
                 $"(was {(_loadingClients.ContainsKey(clientId) ? "already marked" : "unmarked")})");
             _loadingClients[clientId] = UnityEngine.Time.unscaledTime;
+
+            // Entering the download/load pipeline is progress - give the ready timeout a
+            // fresh window rather than kicking a slow downloader mid-transfer.
+            if (MultiplayerSession.ConnectedPlayers.TryGetValue(clientId, out var player))
+                player.UnreadySince = UnityEngine.Time.unscaledTime;
         }
 
         /// <summary>HOST ONLY - true (once) if this client's connect was matched back to a
@@ -191,6 +198,51 @@ namespace ONI_Together.Networking.Transport
                     : id.ToString();
                 OxySyncChat.AddSystemMessage(
                     string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_FAILED, name));
+            }
+
+            ReadyManager.RefreshScreen();
+            ReadyManager.RefreshReadyState();
+        }
+
+        /// <summary>HOST ONLY - drop a connected client that has sat not-ready past the
+        /// configured timeout. The load window above covers a loader that is GONE; this covers
+        /// one that is still connected but never completes the join - nothing else bounds how
+        /// long a single joiner can hold every other player paused. 0 disables. Call from
+        /// Update().</summary>
+        protected void ExpireNeverReadyClients()
+        {
+            int timeout = Configuration.Instance.Host.Server.ReadyTimeoutSeconds;
+            if (timeout <= 0 || !MultiplayerSession.InActiveSession)
+                return;
+
+            float now = UnityEngine.Time.unscaledTime;
+            _neverReadyClients.Clear();
+
+            foreach (var kvp in MultiplayerSession.ConnectedPlayers)
+            {
+                MultiplayerPlayer player = kvp.Value;
+                if (player.PlayerId == MultiplayerSession.HostUserID)
+                    continue;
+                if (player.readyState == States.ClientReadyState.Ready || player.UnreadySince < 0f)
+                    continue;
+                if (now - player.UnreadySince > timeout)
+                    _neverReadyClients.Add(kvp.Key);
+            }
+
+            if (_neverReadyClients.Count == 0)
+                return;
+
+            foreach (ulong id in _neverReadyClients)
+            {
+                string name = MultiplayerSession.ConnectedPlayers.TryGetValue(id, out var p)
+                    ? p.PlayerName
+                    : id.ToString();
+                DebugConsole.LogWarning(
+                    $"[TransportServer] {id} connected but not ready after {timeout}s - dropping them");
+                OxySyncChat.AddSystemMessage(
+                    string.Format(STRINGS.UI.MP_CHATWINDOW.CHAT_CLIENT_READY_TIMEOUT, name, timeout));
+                ForgetClientLoading(id);
+                KickClient(id);
             }
 
             ReadyManager.RefreshScreen();

--- a/ONI_Together/Networking/Transport/TransportServer.cs
+++ b/ONI_Together/Networking/Transport/TransportServer.cs
@@ -87,37 +87,38 @@ namespace ONI_Together.Networking.Transport
         /// connection against the pending loads. Returns true if this connect was a returning
         /// loader.
         ///
-        /// Matching is by id and nothing else, because guessing is not safe here: consuming
-        /// the entry of a client that is still loading drops PendingLoadingClientCount to zero,
-        /// and the gate then rests solely on the *new* client's Unready flag - so it opens as
-        /// soon as that client reports Ready, with the original loader still mid-load. That is
-        /// precisely the failure this class exists to prevent, so an unmatched connect leaves
-        /// the pending entry alone and the gate stays closed.
+        /// Only Steamworks can match by id: it keys on the SteamID. Neither LAN transport can -
+        /// both derive the client id from the peer handle, and a returning loader is measured
+        /// to come back under a new one (a client that left as id 2 returned as id 3). So the
+        /// LAN case falls back to releasing the longest-pending entry.
         ///
-        /// LiteNetLib and Steamworks always match: LiteNetLib's OnConnectionRequest echoes back
-        /// the persistent id the client supplied, and Steamworks keys on the SteamID. Riptide
-        /// reassigns its id on reconnect and has nothing to match on - see the override in
-        /// RiptideServer for the trade it is forced into.
+        /// That fallback is a guess, and the guess is wrong when a brand-new client connects
+        /// while someone else is loading: it releases the loader's entry, and the gate is then
+        /// held only by the new client's Unready flag, so it opens as soon as that client
+        /// reports Ready. It needs two clients moving at once to bite, and the alternative -
+        /// leaving the entry alone - stalls the gate for the full timeout after every single
+        /// load. Restoring a stable client id across a reconnect would remove the choice.
         /// </summary>
         public virtual bool ClaimLoadingReconnect(ulong clientId)
         {
-            if (!_loadingClients.Remove(clientId))
-                return false;
+            if (_loadingClients.Remove(clientId))
+            {
+                _reconnectedFromLoad.Add(clientId);
+                return true;
+            }
 
-            _reconnectedFromLoad.Add(clientId);
-            return true;
+            return ClaimOldestLoadingReconnect(clientId);
         }
 
         /// <summary>
         /// HOST ONLY - release the longest-pending load entry and credit it to
-        /// <paramref name="clientId"/>. Only for transports that cannot identify a returning
-        /// client (Riptide); see the warning on <see cref="ClaimLoadingReconnect"/> for what
-        /// this costs when the guess is wrong.
+        /// <paramref name="clientId"/>. See the warning on
+        /// <see cref="ClaimLoadingReconnect"/> for what this costs when the guess is wrong.
         /// </summary>
-        protected void ClaimOldestLoadingReconnect(ulong clientId)
+        protected bool ClaimOldestLoadingReconnect(ulong clientId)
         {
             if (_loadingClients.Count == 0)
-                return;
+                return false;
 
             ulong oldest = 0;
             float oldestStartedAt = float.MaxValue;
@@ -132,6 +133,7 @@ namespace ONI_Together.Networking.Transport
 
             _loadingClients.Remove(oldest);
             _reconnectedFromLoad.Add(clientId);
+            return true;
         }
 
         /// <summary>

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -65,10 +65,11 @@ namespace ONI_Together.Patches.GamePatches
         DebugConsole.Log("[GamePatch] World fully loaded, reconnecting to host from cache...");
         GameClient.ReconnectFromCache();
 
-        // Show, not Close. ReconnectFromCache only starts the reconnect, and the host's
-        // gate stays shut for all of it - closing here exposes a live, clickable world
-        // with nothing to raise the screen again. AllClientsReadyPacket, the gate's own
-        // signal, is what closes this screen.
+        // Reset, then Show - never Close. The scene swap destroyed the backing overlay,
+        // so the stale wrapper must be dropped for Show to build a real screen; closing
+        // instead would expose a live, clickable world with nothing to raise the screen
+        // again. AllClientsReadyPacket, the gate's own signal, is what closes it.
+        MultiplayerOverlay.ResetAfterSceneSwap();
         MultiplayerOverlay.Show(STRINGS.UI.MP_OVERLAY.CLIENT.RECONNECTING_AFTER_LOAD);
       }
 

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -65,11 +65,10 @@ namespace ONI_Together.Patches.GamePatches
         DebugConsole.Log("[GamePatch] World fully loaded, reconnecting to host from cache...");
         GameClient.ReconnectFromCache();
 
-        // Show, not Close. ReconnectFromCache only starts the reconnect - measured at 21s
-        // on a Steam join - and the host's gate stays shut for all of it. Closing here left
-        // the client looking at a live, clickable world with no ready screen, and nothing
-        // raises one again until the host's next broadcast. AllClientsReadyPacket, the
-        // gate's own signal, is what should close this screen.
+        // Show, not Close. ReconnectFromCache only starts the reconnect, and the host's
+        // gate stays shut for all of it - closing here exposes a live, clickable world
+        // with nothing to raise the screen again. AllClientsReadyPacket, the gate's own
+        // signal, is what closes this screen.
         MultiplayerOverlay.Show(STRINGS.UI.MP_OVERLAY.CLIENT.RECONNECTING_AFTER_LOAD);
       }
 

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -64,7 +64,13 @@ namespace ONI_Together.Patches.GamePatches
       {
         DebugConsole.Log("[GamePatch] World fully loaded, reconnecting to host from cache...");
         GameClient.ReconnectFromCache();
-        MultiplayerOverlay.Close();
+
+        // Show, not Close. ReconnectFromCache only starts the reconnect - measured at 21s
+        // on a Steam join - and the host's gate stays shut for all of it. Closing here left
+        // the client looking at a live, clickable world with no ready screen, and nothing
+        // raises one again until the host's next broadcast. AllClientsReadyPacket, the
+        // gate's own signal, is what should close this screen.
+        MultiplayerOverlay.Show(STRINGS.UI.MP_OVERLAY.CLIENT.RECONNECTING_AFTER_LOAD);
       }
 
       Game.Instance.gameObject.AddComponent<LogicPortManager>();

--- a/ONI_Together/Patches/PauseScreenPatch.cs
+++ b/ONI_Together/Patches/PauseScreenPatch.cs
@@ -99,14 +99,10 @@ namespace ONI_Together.Patches
 		[HarmonyPatch]
 		public static class ModalPauseScreen_PreventPauses
 		{
-			// Both OnShow overrides that touch the pause stack. KModalButtonMenu (the pause
+			// Both OnShow overrides that touch the pause stack: KModalButtonMenu (the pause
 			// menu's base) does not call KModalScreen.OnShow - it has its own Pause/Unpause
-			// pair - so patching only KModalScreen left the pause menu pausing for real. On the
-			// host that leaked a pause level whenever the menu was closed while the resume gate
-			// was shut: OnShow(false) calls Unpause, the gate prefix blocks it, and the
-			// SpeedControlScreen pauseCount the menu's own Pause had incremented never comes
-			// back down - so when the gate finally opened, ResumeSimAfterReadyScreen's single
-			// unpause left the sim still paused with no indication why.
+			// pair. With only KModalScreen patched, a gate-blocked Unpause plus the menu's
+			// own Pause leaks one SpeedControlScreen pauseCount level per open/close.
 			[UsedImplicitly]
 			static IEnumerable<System.Reflection.MethodBase> TargetMethods()
 			{

--- a/ONI_Together/Patches/PauseScreenPatch.cs
+++ b/ONI_Together/Patches/PauseScreenPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using JetBrains.Annotations;
+using ONI_Together.Menus;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Transport.Steamworks;
 using ONI_Together.UI;
@@ -95,9 +96,26 @@ namespace ONI_Together.Patches
             }
 		}
 
-		[HarmonyPatch(typeof(KModalScreen), nameof(KModalScreen.OnShow), new[] { typeof(bool) })]
+		[HarmonyPatch]
 		public static class ModalPauseScreen_PreventPauses
 		{
+			// Both OnShow overrides that touch the pause stack. KModalButtonMenu (the pause
+			// menu's base) does not call KModalScreen.OnShow - it has its own Pause/Unpause
+			// pair - so patching only KModalScreen left the pause menu pausing for real. On the
+			// host that leaked a pause level whenever the menu was closed while the resume gate
+			// was shut: OnShow(false) calls Unpause, the gate prefix blocks it, and the
+			// SpeedControlScreen pauseCount the menu's own Pause had incremented never comes
+			// back down - so when the gate finally opened, ResumeSimAfterReadyScreen's single
+			// unpause left the sim still paused with no indication why.
+			[UsedImplicitly]
+			static IEnumerable<System.Reflection.MethodBase> TargetMethods()
+			{
+				yield return AccessTools.Method(
+					typeof(KModalScreen), nameof(KModalScreen.OnShow), new[] { typeof(bool) });
+				yield return AccessTools.Method(
+					typeof(KModalButtonMenu), nameof(KModalButtonMenu.OnShow), new[] { typeof(bool) });
+			}
+
             static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> insts)
 			{
 				using var _ = Profiler.Scope();

--- a/ONI_Together/Patches/ReadyScreenInputPatch.cs
+++ b/ONI_Together/Patches/ReadyScreenInputPatch.cs
@@ -6,17 +6,15 @@ namespace ONI_Together.Patches
 {
 	/// <summary>
 	/// Keyboard behaviour of the ready screen: swallow everything. The screen is ONI's
-	/// LoadingOverlay, a KModalScreen, and KModalScreen.OnKeyDown answers Escape by
-	/// Deactivate() - destroying the overlay - so Escape quietly tore the ready screen down
-	/// and exposed a world the gate still held shut, with no way to bring the screen back
-	/// (Show deliberately does not rebuild, see MultiplayerOverlay.Show).
+	/// LoadingOverlay, a KModalScreen, and KModalScreen.OnKeyDown answers Escape with
+	/// Deactivate() - destroying the overlay with no way to bring it back (Show deliberately
+	/// does not rebuild, see MultiplayerOverlay.Show).
 	///
-	/// No key does anything while this screen is up - deliberately. An "Escape opens the
-	/// pause menu over the ready screen" variant was built and field-tested twice: the menu
-	/// ended up active, correctly ordered above the overlay and clickable, yet never visible,
-	/// and blind-clicking it shut a live session down mid-join (see the fix/ready-resume-gate
-	/// notes). The ready screen is a wait-for-players gate; it ends when everyone is ready or
-	/// when the failure protocol (leave-while-loading, 120s load expiry) releases it.
+	/// No key does anything while this screen is up - deliberately. Do not revive the
+	/// "Escape opens the pause menu over the ready screen" variant: field-tested twice, the
+	/// menu ends up active and clickable yet never visible, and blind clicks can end the
+	/// session mid-join. The screen ends when everyone is ready or when the failure protocol
+	/// (leave-while-loading, 120s load expiry) releases it.
 	///
 	/// Patches KModalScreen, not LoadingOverlay: LoadingOverlay does not override OnKeyDown,
 	/// so naming it on the subclass gives Harmony no target and PatchAll throws, taking the

--- a/ONI_Together/Patches/ReadyScreenInputPatch.cs
+++ b/ONI_Together/Patches/ReadyScreenInputPatch.cs
@@ -1,0 +1,48 @@
+using HarmonyLib;
+using JetBrains.Annotations;
+using ONI_Together.Menus;
+
+namespace ONI_Together.Patches
+{
+	/// <summary>
+	/// Keyboard behaviour of the ready screen: swallow everything. The screen is ONI's
+	/// LoadingOverlay, a KModalScreen, and KModalScreen.OnKeyDown answers Escape by
+	/// Deactivate() - destroying the overlay - so Escape quietly tore the ready screen down
+	/// and exposed a world the gate still held shut, with no way to bring the screen back
+	/// (Show deliberately does not rebuild, see MultiplayerOverlay.Show).
+	///
+	/// No key does anything while this screen is up - deliberately. An "Escape opens the
+	/// pause menu over the ready screen" variant was built and field-tested twice: the menu
+	/// ended up active, correctly ordered above the overlay and clickable, yet never visible,
+	/// and blind-clicking it shut a live session down mid-join (see the fix/ready-resume-gate
+	/// notes). The ready screen is a wait-for-players gate; it ends when everyone is ready or
+	/// when the failure protocol (leave-while-loading, 120s load expiry) releases it.
+	///
+	/// Patches KModalScreen, not LoadingOverlay: LoadingOverlay does not override OnKeyDown,
+	/// so naming it on the subclass gives Harmony no target and PatchAll throws, taking the
+	/// whole mod down with it.
+	/// </summary>
+	[HarmonyPatch]
+	public static class ReadyScreenInputPatch
+	{
+		[HarmonyPatch(typeof(KModalScreen), nameof(KModalScreen.OnKeyDown))]
+		[HarmonyPrefix]
+		[UsedImplicitly]
+		public static bool OnKeyDown_Prefix(KModalScreen __instance, KButtonEvent e) => Swallow(__instance, e);
+
+		[HarmonyPatch(typeof(KModalScreen), nameof(KModalScreen.OnKeyUp))]
+		[HarmonyPrefix]
+		[UsedImplicitly]
+		public static bool OnKeyUp_Prefix(KModalScreen __instance, KButtonEvent e) => Swallow(__instance, e);
+
+		/// <summary>Returns false - skip the original - once the key has been eaten.</summary>
+		private static bool Swallow(KModalScreen screen, KButtonEvent e)
+		{
+			if (!(screen is LoadingOverlay) || !MultiplayerOverlay.IsOpen)
+				return true;
+
+			e.Consumed = true;
+			return false;
+		}
+	}
+}

--- a/ONI_Together/Patches/World/Buildings/Operational_Patch.cs
+++ b/ONI_Together/Patches/World/Buildings/Operational_Patch.cs
@@ -82,7 +82,7 @@ namespace ONI_Together.Patches.World.Buildings
                 if (!MultiplayerSession.IsClient)
                     return true;
 
-                if(__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
                 {
                     __result = wrap.IsOperational;
 					return false;
@@ -108,7 +108,7 @@ namespace ONI_Together.Patches.World.Buildings
 				if (!MultiplayerSession.IsClient)
 					return true;
 
-				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
 				{
 					__result = wrap.IsActive;
 					return false;
@@ -132,7 +132,7 @@ namespace ONI_Together.Patches.World.Buildings
 				if (!MultiplayerSession.IsClient)
 					return true;
 
-				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
 				{
 					__result = wrap.IsFunctional;
 					return false;

--- a/ONI_Together/Patches/World/EnergyConsumer_Patches.cs
+++ b/ONI_Together/Patches/World/EnergyConsumer_Patches.cs
@@ -33,7 +33,7 @@ namespace ONI_Together.Patches.World
                 if (!SkipOnClient())
                     return true;
 
-                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
                 {
                     __result = wrap.IsOperational;
                     return false;
@@ -53,7 +53,7 @@ namespace ONI_Together.Patches.World
                 if (flag != EnergyConsumer.PoweredFlag)
                     return true;
 
-                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
                 {
                     __result = wrap.IsOperational;
                     return false;

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -12,6 +12,48 @@ namespace ONI_Together.Patches
 	{
 		public static bool IsSyncing = false;
 
+		// Authority gate: while in a session, the host must not resume/unpause the sim
+		// until every connected player is ready. Pausing is always allowed; only resume
+		// is blocked. IsSyncing lets remote-applied speed changes through.
+		private static bool ResumeBlocked()
+		{
+			if (IsSyncing) return false;
+			if (!MultiplayerSession.IsHost || !MultiplayerSession.InSession) return false;
+			return !ReadyManager.CanHostResume();
+		}
+
+		[HarmonyPatch("SetSpeed")]
+		[HarmonyPrefix]
+		public static bool SetSpeed_Prefix()
+		{
+			using var _ = Profiler.Scope();
+
+			// Setting a speed unpauses the sim — block it while players are not ready.
+			if (ResumeBlocked())
+			{
+				DebugConsole.Log("[SpeedControl] Blocked SetSpeed: not all players are ready");
+				ReadyManager.RefreshScreen();
+				return false;
+			}
+			return true;
+		}
+
+		[HarmonyPatch(nameof(SpeedControlScreen.TogglePause))]
+		[HarmonyPrefix]
+		public static bool TogglePause_Prefix(SpeedControlScreen __instance)
+		{
+			using var _ = Profiler.Scope();
+
+			// TogglePause only resumes when currently paused; pausing stays allowed.
+			if (__instance.IsPaused && ResumeBlocked())
+			{
+				DebugConsole.Log("[SpeedControl] Blocked TogglePause (resume): not all players are ready");
+				ReadyManager.RefreshScreen();
+				return false;
+			}
+			return true;
+		}
+
 		[HarmonyPatch("SetSpeed")]
 		[HarmonyPostfix]
 		public static void SetSpeed_Postfix(int Speed)

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -25,6 +25,14 @@ namespace ONI_Together.Patches
 		// Authority gate: while in a session, the host must not resume/unpause the sim
 		// until every connected player is ready. Pausing is always allowed; only resume
 		// is blocked. IsSyncing lets remote-applied speed changes through.
+		//
+		// Coverage: this gate hooks the user-facing resume entry points — SetSpeed and
+		// TogglePause (the play buttons / spacebar). SpeedControlScreen.Unpause() is NOT
+		// patched. Nothing resumes via Unpause() today (the old auto-resume calls in
+		// AllClientsReadyPacket / HardSyncCompletePacket / SaveLoaderPatch are commented
+		// out), but any future code that resumes programmatically must route through this
+		// gate (check ReadyManager.CanHostResume()) or add an Unpause prefix here —
+		// otherwise it bypasses the safety.
 		private static bool ResumeBlocked()
 		{
 			if (IsSyncing) return false;

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -64,6 +64,11 @@ namespace ONI_Together.Patches
 			{
 				if (IsSyncing) return;
 
+				// Harmony still runs postfixes when a prefix returns false. If the resume
+				// gate blocked this SetSpeed, the local speed never changed — so don't
+				// broadcast it, or clients would resume while the host stays paused.
+				if (ResumeBlocked()) return;
+
 				var packet = new SpeedChangePacket((SpeedChangePacket.SpeedState)Speed);
 
 				PacketSender.SendToAllOtherPeers(packet);

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -17,6 +17,9 @@ namespace ONI_Together.Patches
 		// avoid broadcasting a change that never actually happened locally. (Re-checking
 		// ResumeBlocked() in the postfix would be wrong for TogglePause: pausing while a
 		// client is unready is allowed and must still be broadcast.)
+		// Assumes non-reentrancy: SpeedControlScreen runs on the single game thread, so
+		// prefix→original→postfix completes before another patched call begins. A blocked
+		// call skips the original, so it can't trigger a nested SetSpeed/TogglePause.
 		private static bool _resumeBlockedThisCall = false;
 
 		// Authority gate: while in a session, the host must not resume/unpause the sim

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -12,6 +12,13 @@ namespace ONI_Together.Patches
 	{
 		public static bool IsSyncing = false;
 
+		// Set by the resume-gate prefixes when they block a call. Harmony still runs
+		// postfixes after a prefix returns false, so the matching postfix reads this to
+		// avoid broadcasting a change that never actually happened locally. (Re-checking
+		// ResumeBlocked() in the postfix would be wrong for TogglePause: pausing while a
+		// client is unready is allowed and must still be broadcast.)
+		private static bool _resumeBlockedThisCall = false;
+
 		// Authority gate: while in a session, the host must not resume/unpause the sim
 		// until every connected player is ready. Pausing is always allowed; only resume
 		// is blocked. IsSyncing lets remote-applied speed changes through.
@@ -31,10 +38,12 @@ namespace ONI_Together.Patches
 			// Setting a speed unpauses the sim — block it while players are not ready.
 			if (ResumeBlocked())
 			{
+				_resumeBlockedThisCall = true;
 				DebugConsole.Log("[SpeedControl] Blocked SetSpeed: not all players are ready");
 				ReadyManager.RefreshScreen();
 				return false;
 			}
+			_resumeBlockedThisCall = false;
 			return true;
 		}
 
@@ -47,10 +56,12 @@ namespace ONI_Together.Patches
 			// TogglePause only resumes when currently paused; pausing stays allowed.
 			if (__instance.IsPaused && ResumeBlocked())
 			{
+				_resumeBlockedThisCall = true;
 				DebugConsole.Log("[SpeedControl] Blocked TogglePause (resume): not all players are ready");
 				ReadyManager.RefreshScreen();
 				return false;
 			}
+			_resumeBlockedThisCall = false;
 			return true;
 		}
 
@@ -64,10 +75,9 @@ namespace ONI_Together.Patches
 			{
 				if (IsSyncing) return;
 
-				// Harmony still runs postfixes when a prefix returns false. If the resume
-				// gate blocked this SetSpeed, the local speed never changed — so don't
-				// broadcast it, or clients would resume while the host stays paused.
-				if (ResumeBlocked()) return;
+				// Prefix blocked this call — the local speed never changed, so don't
+				// broadcast it or clients would resume while the host stays paused.
+				if (_resumeBlockedThisCall) { _resumeBlockedThisCall = false; return; }
 
 				var packet = new SpeedChangePacket((SpeedChangePacket.SpeedState)Speed);
 
@@ -89,6 +99,10 @@ namespace ONI_Together.Patches
 			try
 			{
 				if (IsSyncing) return;
+
+				// Prefix blocked this resume — don't broadcast; the local pause state
+				// is unchanged. (Legitimate pauses are not blocked and still broadcast.)
+				if (_resumeBlockedThisCall) { _resumeBlockedThisCall = false; return; }
 
 				var speedState = __instance.IsPaused
 						? SpeedChangePacket.SpeedState.Paused

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -26,13 +26,11 @@ namespace ONI_Together.Patches
 		// until every connected player is ready. Pausing is always allowed; only resume
 		// is blocked. IsSyncing lets remote-applied speed changes through.
 		//
-		// Coverage: this gate hooks the user-facing resume entry points — SetSpeed and
-		// TogglePause (the play buttons / spacebar). SpeedControlScreen.Unpause() is NOT
-		// patched. Nothing resumes via Unpause() today (the old auto-resume calls in
-		// AllClientsReadyPacket / HardSyncCompletePacket / SaveLoaderPatch are commented
-		// out), but any future code that resumes programmatically must route through this
-		// gate (check ReadyManager.CanHostResume()) or add an Unpause prefix here —
-		// otherwise it bypasses the safety.
+		// Coverage: this gate hooks all three local resume entry points — SetSpeed,
+		// TogglePause (play buttons / spacebar) and Unpause (direct/programmatic).
+		// Together with the host-side rejection of remote resume packets (see
+		// SpeedChangePacket.OnDispatched), the host's sim cannot resume while any player
+		// is unready, whoever initiates it.
 		private static bool ResumeBlocked()
 		{
 			if (IsSyncing) return false;
@@ -73,6 +71,24 @@ namespace ONI_Together.Patches
 				return false;
 			}
 			_resumeBlockedThisCall = false;
+			return true;
+		}
+
+		[HarmonyPatch(nameof(SpeedControlScreen.Unpause), new Type[] { typeof(bool) })]
+		[HarmonyPrefix]
+		public static bool Unpause_Prefix()
+		{
+			using var _ = Profiler.Scope();
+
+			// Defensive: keep the gate authoritative for direct/programmatic Unpause()
+			// calls too. No flag bookkeeping needed — Unpause has no broadcasting postfix
+			// here, and a blocked call simply doesn't resume. Legitimate resumes (all
+			// ready, or the IsSyncing mirror path) pass through.
+			if (ResumeBlocked())
+			{
+				DebugConsole.Log("[SpeedControl] Blocked Unpause: not all players are ready");
+				return false;
+			}
 			return true;
 		}
 

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -12,12 +12,92 @@ namespace ONI_Together.Patches
 	{
 		public static bool IsSyncing = false;
 
+		// Set by the resume-gate prefixes when they block a call. Harmony still runs
+		// postfixes after a prefix returns false, so the matching postfix reads this to
+		// avoid broadcasting a change that never actually happened locally. (Re-checking
+		// ResumeBlocked() in the postfix would be wrong for TogglePause: pausing while a
+		// client is unready is allowed and must still be broadcast.)
+		// Assumes non-reentrancy: SpeedControlScreen runs on the single game thread, so
+		// prefix→original→postfix completes before another patched call begins. A blocked
+		// call skips the original, so it can't trigger a nested SetSpeed/TogglePause.
+		private static bool _resumeBlockedThisCall = false;
+
+		// Authority gate: while in a session, the host must not resume/unpause the sim
+		// until every connected player is ready. Pausing is always allowed; only resume
+		// is blocked. IsSyncing lets remote-applied speed changes through.
+		//
+		// Coverage: this gate hooks all three local resume entry points — SetSpeed,
+		// TogglePause (play buttons / spacebar) and Unpause (direct/programmatic).
+		// Together with the host-side rejection of client-originated resume commands (see
+		// GameSpeedSyncer.CmdSetSpeed), the host's sim cannot resume while any player is
+		// unready, whoever initiates it.
+		private static bool ResumeBlocked()
+		{
+			if (IsSyncing) return false;
+			if (!MultiplayerSession.IsHost || !MultiplayerSession.InActiveSession) return false;
+			return !ReadyManager.CanHostResume();
+		}
+
 		[HarmonyPatch("OnPrefabInit")]
 		[HarmonyPostfix]
 		public static void OnPrefabInit_Postfix(SpeedControlScreen __instance)
 		{
 			if (!__instance.TryGetComponent<GameSpeedSyncer>(out _))
 				__instance.gameObject.AddComponent<GameSpeedSyncer>();
+		}
+
+		[HarmonyPatch("SetSpeed")]
+		[HarmonyPrefix]
+		public static bool SetSpeed_Prefix()
+		{
+			using var _ = Profiler.Scope();
+
+			// Setting a speed unpauses the sim — block it while players are not ready.
+			if (ResumeBlocked())
+			{
+				_resumeBlockedThisCall = true;
+				DebugConsole.Log("[SpeedControl] Blocked SetSpeed: not all players are ready");
+				ReadyManager.RefreshScreen();
+				return false;
+			}
+			_resumeBlockedThisCall = false;
+			return true;
+		}
+
+		[HarmonyPatch(nameof(SpeedControlScreen.TogglePause))]
+		[HarmonyPrefix]
+		public static bool TogglePause_Prefix(SpeedControlScreen __instance)
+		{
+			using var _ = Profiler.Scope();
+
+			// TogglePause only resumes when currently paused; pausing stays allowed.
+			if (__instance.IsPaused && ResumeBlocked())
+			{
+				_resumeBlockedThisCall = true;
+				DebugConsole.Log("[SpeedControl] Blocked TogglePause (resume): not all players are ready");
+				ReadyManager.RefreshScreen();
+				return false;
+			}
+			_resumeBlockedThisCall = false;
+			return true;
+		}
+
+		[HarmonyPatch(nameof(SpeedControlScreen.Unpause), new Type[] { typeof(bool) })]
+		[HarmonyPrefix]
+		public static bool Unpause_Prefix()
+		{
+			using var _ = Profiler.Scope();
+
+			// Defensive: keep the gate authoritative for direct/programmatic Unpause()
+			// calls too. No flag bookkeeping needed — Unpause has no broadcasting postfix
+			// here, and a blocked call simply doesn't resume. Legitimate resumes (all
+			// ready, or the IsSyncing mirror path) pass through.
+			if (ResumeBlocked())
+			{
+				DebugConsole.Log("[SpeedControl] Blocked Unpause: not all players are ready");
+				return false;
+			}
+			return true;
 		}
 
 		[HarmonyPatch("SetSpeed")]
@@ -30,6 +110,10 @@ namespace ONI_Together.Patches
 			{
 				if (IsSyncing) return;
 				if (!MultiplayerSession.InActiveSession) return;
+
+				// Prefix blocked this call — the local speed never changed, so don't
+				// request it or clients would resume while the host stays paused.
+				if (_resumeBlockedThisCall) { _resumeBlockedThisCall = false; return; }
 
 				GameSpeedSyncer.Instance?.RequestSetSpeed(Speed);
 			}
@@ -49,6 +133,10 @@ namespace ONI_Together.Patches
 			{
 				if (IsSyncing) return;
 				if (!MultiplayerSession.InActiveSession) return;
+
+				// Prefix blocked this resume — don't request it; the local pause state
+				// is unchanged. (Legitimate pauses are not blocked and still broadcast.)
+				if (_resumeBlockedThisCall) { _resumeBlockedThisCall = false; return; }
 
 				// Original TogglePause has already run. Determine the resulting state.
 				var newState = SpeedControlScreen.Instance.IsPaused

--- a/ONI_Together/Patches/World/SpeedControlPatch.cs
+++ b/ONI_Together/Patches/World/SpeedControlPatch.cs
@@ -12,25 +12,16 @@ namespace ONI_Together.Patches
 	{
 		public static bool IsSyncing = false;
 
-		// Set by the resume-gate prefixes when they block a call. Harmony still runs
-		// postfixes after a prefix returns false, so the matching postfix reads this to
-		// avoid broadcasting a change that never actually happened locally. (Re-checking
-		// ResumeBlocked() in the postfix would be wrong for TogglePause: pausing while a
-		// client is unready is allowed and must still be broadcast.)
-		// Assumes non-reentrancy: SpeedControlScreen runs on the single game thread, so
-		// prefix→original→postfix completes before another patched call begins. A blocked
-		// call skips the original, so it can't trigger a nested SetSpeed/TogglePause.
+		// Set by the resume-gate prefixes when they block a call: Harmony still runs the
+		// postfix after a prefix returns false. The postfix must read this rather than
+		// re-check ResumeBlocked(), which would also suppress a legitimate pause broadcast.
+		// Safe as one field: these calls run on the game thread and cannot nest.
 		private static bool _resumeBlockedThisCall = false;
 
-		// Authority gate: while in a session, the host must not resume/unpause the sim
-		// until every connected player is ready. Pausing is always allowed; only resume
-		// is blocked. IsSyncing lets remote-applied speed changes through.
-		//
-		// Coverage: this gate hooks all three local resume entry points — SetSpeed,
-		// TogglePause (play buttons / spacebar) and Unpause (direct/programmatic).
-		// Together with the host-side rejection of client-originated resume commands (see
-		// GameSpeedSyncer.CmdSetSpeed), the host's sim cannot resume while any player is
-		// unready, whoever initiates it.
+		// HOST ONLY - in a session the sim must not resume until every player is ready;
+		// pausing is always allowed, and IsSyncing lets remote-applied changes through.
+		// All three local resume entry points are hooked (SetSpeed, TogglePause, Unpause);
+		// client-originated resumes are rejected in GameSpeedSyncer.CmdSetSpeed.
 		private static bool ResumeBlocked()
 		{
 			if (IsSyncing) return false;
@@ -88,10 +79,8 @@ namespace ONI_Together.Patches
 		{
 			using var _ = Profiler.Scope();
 
-			// Defensive: keep the gate authoritative for direct/programmatic Unpause()
-			// calls too. No flag bookkeeping needed — Unpause has no broadcasting postfix
-			// here, and a blocked call simply doesn't resume. Legitimate resumes (all
-			// ready, or the IsSyncing mirror path) pass through.
+			// Direct/programmatic Unpause() must obey the gate too. No flag bookkeeping
+			// needed: Unpause has no broadcasting postfix here.
 			if (ResumeBlocked())
 			{
 				DebugConsole.Log("[SpeedControl] Blocked Unpause: not all players are ready");
@@ -111,8 +100,8 @@ namespace ONI_Together.Patches
 				if (IsSyncing) return;
 				if (!MultiplayerSession.InActiveSession) return;
 
-				// Prefix blocked this call — the local speed never changed, so don't
-				// request it or clients would resume while the host stays paused.
+				// Blocked by the prefix: the local speed never changed, so a request here
+				// would resume clients while the host stays paused.
 				if (_resumeBlockedThisCall) { _resumeBlockedThisCall = false; return; }
 
 				GameSpeedSyncer.Instance?.RequestSetSpeed(Speed);
@@ -134,11 +123,10 @@ namespace ONI_Together.Patches
 				if (IsSyncing) return;
 				if (!MultiplayerSession.InActiveSession) return;
 
-				// Prefix blocked this resume — don't request it; the local pause state
-				// is unchanged. (Legitimate pauses are not blocked and still broadcast.)
+				// Blocked by the prefix: pause state unchanged. (Real pauses still broadcast.)
 				if (_resumeBlockedThisCall) { _resumeBlockedThisCall = false; return; }
 
-				// Original TogglePause has already run. Determine the resulting state.
+				// The original already ran, so IsPaused is the post-toggle state.
 				var newState = SpeedControlScreen.Instance.IsPaused
 					? (int)GameSpeedSyncer.SpeedState.Paused
 					: SpeedControlScreen.Instance.GetSpeed();

--- a/ONI_Together/STRINGS.cs
+++ b/ONI_Together/STRINGS.cs
@@ -343,7 +343,6 @@ namespace ONI_Together
 				public class HOST
 				{
 					public static LocString STARTINGHOSTING = "Hosting game...";
-					public static LocString SEND_SAVE_FILE = "Sending save file to a client!\nPlease wait...";
                 }
 
 				public class CLIENT

--- a/ONI_Together/STRINGS.cs
+++ b/ONI_Together/STRINGS.cs
@@ -459,6 +459,7 @@ namespace ONI_Together
 					public static LocString HARDSYNC_INPROGRESS = "Hard sync in progress!";
 					public static LocString FINALIZING_SYNC = "All players are ready!\nPlease wait...";
 					public static LocString WAITING_FOR_PLAYERS_SYNC = "Waiting for players ({0}/{1} ready)...\n";
+					public static LocString INPUT_LOCKED_WHILE_WAITING = "\nTools are disabled until everyone is ready.";
 
 					// New world sync menu
 					public static LocString CLIENT_SYNC_PROGRESS = "Client Sync Progress";

--- a/ONI_Together/STRINGS.cs
+++ b/ONI_Together/STRINGS.cs
@@ -432,6 +432,7 @@ namespace ONI_Together
 					public static LocString MISSING_SAVE_FILE = "Downloaded save file not found.";
 					public static LocString CONNECTING_TO_HOST = "Connecting to {0}!";
 					public static LocString WAITING_FOR_PLAYER = "Waiting for {0}...";
+					public static LocString RECONNECTING_AFTER_LOAD = "World loaded.\nReconnecting to the host...\nTools stay disabled until everyone is ready.";
 
 					public static LocString DOWNLOADING_SAVE_FILE = "Downloading Save File\n\n{0} {1}%\n({2}/{3} chunks)";
 					public static LocString TCP_DOWNLOADING_SAVE_FILE = "Downloading LAN Save File\n\n{0} {1}%\n({2} remaining)";

--- a/ONI_Together/STRINGS.cs
+++ b/ONI_Together/STRINGS.cs
@@ -357,7 +357,6 @@ namespace ONI_Together
 				public class HOST
 				{
 					public static LocString STARTINGHOSTING = "Hosting game...";
-					public static LocString SEND_SAVE_FILE = "Sending save file to a client!\nPlease wait...";
                 }
 
 				public class CLIENT

--- a/ONI_Together/STRINGS.cs
+++ b/ONI_Together/STRINGS.cs
@@ -32,6 +32,7 @@ namespace ONI_Together
 						{
 							public static LocString HARD_SYNC_AT_CYCLE_START = "Hard Sync On Cycle Start";
 							public static LocString TIMEOUT_SECONDS = "Connection Timeout (seconds)";
+							public static LocString READY_TIMEOUT_SECONDS = "Ready Timeout (seconds)";
 							public static LocString PAUSE_SIM_ON_PLAYER_DISCONNECT = "Pause Simulation On Player Disconnect";
 							public static LocString SERVER_TICK_RATE = "Server Tick Rate";
 						}
@@ -81,6 +82,7 @@ namespace ONI_Together
                         {
                             public static LocString HARD_SYNC_AT_CYCLE_START = "Perform a hard sync at the start of every new cycle\n\nDoes not use up your one hard sync per cycle";
                             public static LocString TIMEOUT_SECONDS = "How long the server waits (in seconds) for a response from a connecting or loading client before timing out.\nIncrease this if your friends take a long time to load into the game.\n\nMinimum: 30. (default: 30)";
+                            public static LocString READY_TIMEOUT_SECONDS = "How long a connected player may stay not-ready before the server drops them and lets everyone else resume.\nThe clock restarts when their save transfer begins and when they reconnect after loading.\nIncrease this if your friends download or load very slowly.\n\n0 disables the timeout. Minimum otherwise: 30. (default: 180)";
                             public static LocString PAUSE_SIM_ON_PLAYER_DISCONNECT = "Automatically pauses the simulation when a player disconnects from the server.";
                             public static LocString SERVER_TICK_RATE = "How many times per second the server processes incoming network messages.\nHigher values reduce latency but increase CPU and bandwidth usage.\n\nRange: 20–128 TPS (default: 60)";
                         }
@@ -342,6 +344,7 @@ namespace ONI_Together
 				public static LocString CHAT_CLIENT_JOINED = "<b>{0}</b> joined the game.";
 				public static LocString CHAT_CLIENT_LEFT = "<b>{0}</b> left the game.";
 				public static LocString CHAT_CLIENT_FAILED = "<color=red>{0} failed to connect to the server.</color>";
+				public static LocString CHAT_CLIENT_READY_TIMEOUT = "<color=red>{0} was dropped: not ready after {1}s.</color>";
 
                 public static LocString CHAT_SERVER_STARTED = "Started server over <b>{0}</b>";
 				public static LocString CHAT_SERVER_STOPPED = "Stopped <b>{0}</b> server";

--- a/ONI_Together/Scripts/Buildings/ClientReceiver_Operational.cs
+++ b/ONI_Together/Scripts/Buildings/ClientReceiver_Operational.cs
@@ -26,8 +26,35 @@ namespace ONI_Together.Scripts.Buildings
 
 		public bool IsFunctional { get; set; }
 
-		public bool IsOperational { get; set; } = true;
+		public bool IsOperational { get; set; }
 
 		public bool IsActive { get; set; }
+
+		/// <summary>
+		/// False until the host has actually told us what this building is doing.
+		///
+		/// The getter patches read the fields above. They used to answer from IsOperational
+		/// unconditionally, and it was initialised to true, so a client building reported
+		/// itself as running while its own components were still being initialised. In that
+		/// state Operational.UpdateOperational sees a
+		/// transition into operational during KMonoBehaviour.InitializeComponent and fires
+		/// OnOperationalChanged early - which is fatal for any Klei handler that assumes
+		/// OnSpawn has already run. SweepBotStation.RequestNewSweepBot is one: it throws a
+		/// NullReferenceException, and because the stack contains no mod frames, ONI's crash
+		/// handler simply disables the whole mod.
+		///
+		/// Vanilla does not hit this because an unpowered building is not operational during
+		/// load. Every getter patch is gated on this flag, so until the first packet lands a
+		/// client building answers exactly as vanilla would.
+		/// </summary>
+		public bool HasHostState { get; private set; }
+
+		public void ApplyHostState(bool isOperational, bool isFunctional, bool isActive)
+		{
+			IsOperational = isOperational;
+			IsFunctional = isFunctional;
+			IsActive = isActive;
+			HasHostState = true;
+		}
 	}
 }

--- a/ONI_Together/Scripts/Buildings/ClientReceiver_Operational.cs
+++ b/ONI_Together/Scripts/Buildings/ClientReceiver_Operational.cs
@@ -31,21 +31,15 @@ namespace ONI_Together.Scripts.Buildings
 		public bool IsActive { get; set; }
 
 		/// <summary>
-		/// False until the host has actually told us what this building is doing.
+		/// False until the host has actually told us what this building is doing. Every
+		/// getter patch is gated on this flag, so until the first packet lands a client
+		/// building answers exactly as vanilla would (unpowered = not operational during
+		/// load).
 		///
-		/// The getter patches read the fields above. They used to answer from IsOperational
-		/// unconditionally, and it was initialised to true, so a client building reported
-		/// itself as running while its own components were still being initialised. In that
-		/// state Operational.UpdateOperational sees a
-		/// transition into operational during KMonoBehaviour.InitializeComponent and fires
-		/// OnOperationalChanged early - which is fatal for any Klei handler that assumes
-		/// OnSpawn has already run. SweepBotStation.RequestNewSweepBot is one: it throws a
-		/// NullReferenceException, and because the stack contains no mod frames, ONI's crash
-		/// handler simply disables the whole mod.
-		///
-		/// Vanilla does not hit this because an unpowered building is not operational during
-		/// load. Every getter patch is gated on this flag, so until the first packet lands a
-		/// client building answers exactly as vanilla would.
+		/// Defaulting to "operational" instead makes Operational.UpdateOperational fire
+		/// OnOperationalChanged during KMonoBehaviour.InitializeComponent - fatal for Klei
+		/// handlers that assume OnSpawn has run (SweepBotStation throws, and with no mod
+		/// frames on the stack ONI's crash handler disables the whole mod).
 		/// </summary>
 		public bool HasHostState { get; private set; }
 

--- a/ONI_Together/UI/UnityMultiplayerScreen.cs
+++ b/ONI_Together/UI/UnityMultiplayerScreen.cs
@@ -264,7 +264,15 @@ namespace ONI_Together.UI
 
 			SetJoinVia(JoinMode.Steam);
 			SetHostVia(HostMode.Steam);
-			NetworkConfig.UpdateTransport(NetworkConfig.NetworkTransport.STEAMWORKS); // default to steam
+
+			// UI default only - never a live session's transport. This screen can
+			// initialize lazily mid-join (observed while a downloaded save started
+			// loading), and stomping the transport there rebinds the client to
+			// Steamworks: the Loading notice goes out under a SteamID, the reconnect
+			// targets a Steam host that does not exist, and the client dies to the
+			// menu after its retries.
+			if (!MultiplayerSession.InActiveSession)
+				NetworkConfig.UpdateTransport(NetworkConfig.NetworkTransport.STEAMWORKS); // default to steam
 
 			init = true;
 		}

--- a/ONI_Together/UI/lib/FUI/FDialog.cs
+++ b/ONI_Together/UI/lib/FUI/FDialog.cs
@@ -91,22 +91,41 @@ namespace UI.lib.UIcmp //Source: Aki
 		public override void OnShow(bool show)
 		{
 			base.OnShow(show);
+
+			// In a multiplayer session these dialogs must not touch the pause stack - the same
+			// policy ModalPauseScreen_PreventPauses applies to ONI's own modal screens. It is
+			// not just policy: SpeedControlScreen's pause is a COUNTER, and while the resume
+			// gate is closed the gate prefix blocks the Unpause half of this pair. Every
+			// open/close of a mod dialog during a join then leaked one pause level, and once
+			// the gate opened the host had to hammer the pause button once per leaked level
+			// before the sim would move.
+			//
+			// pausedSim, not a bare session check on both sides: the unpause must mirror what
+			// the open actually did, or a dialog opened outside a session and closed inside
+			// one (or the other way round) leaks a level again.
 			if (pause && SpeedControlScreen.Instance != null)
 			{
 				if (show && !shown)
 				{
-					SpeedControlScreen.Instance.Pause(false);
+					if (!ONI_Together.Networking.MultiplayerSession.InActiveSession)
+					{
+						SpeedControlScreen.Instance.Pause(false);
+						pausedSim = true;
+					}
 				}
-				else
+				else if (!show && shown)
 				{
-					if (!show && shown)
+					if (pausedSim)
 					{
 						SpeedControlScreen.Instance.Unpause(false);
+						pausedSim = false;
 					}
 				}
 				shown = show;
 			}
 		}
+
+		private bool pausedSim = false;
 
 
 		public override void OnKeyUp(KButtonEvent e)

--- a/ONI_Together/UI/lib/FUI/FDialog.cs
+++ b/ONI_Together/UI/lib/FUI/FDialog.cs
@@ -92,17 +92,14 @@ namespace UI.lib.UIcmp //Source: Aki
 		{
 			base.OnShow(show);
 
-			// In a multiplayer session these dialogs must not touch the pause stack - the same
-			// policy ModalPauseScreen_PreventPauses applies to ONI's own modal screens. It is
-			// not just policy: SpeedControlScreen's pause is a COUNTER, and while the resume
-			// gate is closed the gate prefix blocks the Unpause half of this pair. Every
-			// open/close of a mod dialog during a join then leaked one pause level, and once
-			// the gate opened the host had to hammer the pause button once per leaked level
-			// before the sim would move.
+			// In a multiplayer session these dialogs must not touch the pause stack - the
+			// same policy ModalPauseScreen_PreventPauses applies to ONI's own screens.
+			// SpeedControlScreen's pause is a COUNTER and the gate blocks the Unpause half
+			// of this pair, so each open/close during a join leaks one pause level.
 			//
-			// pausedSim, not a bare session check on both sides: the unpause must mirror what
-			// the open actually did, or a dialog opened outside a session and closed inside
-			// one (or the other way round) leaks a level again.
+			// pausedSim, not a bare session check on both sides: the unpause must mirror
+			// what the open actually did, or a dialog opened outside a session and closed
+			// inside one (or the other way round) leaks a level again.
 			if (pause && SpeedControlScreen.Instance != null)
 			{
 				if (show && !shown)

--- a/Shared/Helpers/DialogUtil.cs
+++ b/Shared/Helpers/DialogUtil.cs
@@ -22,6 +22,12 @@ namespace Shared.Helpers
 
 			if (parent == null)
 				parent = frontend && !useScreenSpaceOverlay ? Global.Instance.globalCanvas : GameScreenManager.Instance.GetParent(GameScreenManager.UIRenderTarget.ScreenSpaceOverlay);
+			// One of the two places the mod puts a message in front of a player; the other is
+			// MultiplayerOverlay, which is logged the same way. Between them a report of "it
+			// popped an error" is traceable without asking the player to remember the wording.
+			// Log here rather than at each call site so a dialog added later is covered too.
+			UnityEngine.Debug.Log($"[ONI_Together] [Dialog] {title} :: {(text ?? string.Empty).Replace("\n", " | ")}");
+
 			var dialogue = ((ConfirmDialogScreen)KScreenManager.Instance.StartScreen(ScreenPrefabs.Instance.ConfirmDialogScreen.gameObject, parent));
 
 			if (!frontend)

--- a/Shared/Helpers/DialogUtil.cs
+++ b/Shared/Helpers/DialogUtil.cs
@@ -22,10 +22,8 @@ namespace Shared.Helpers
 
 			if (parent == null)
 				parent = frontend && !useScreenSpaceOverlay ? Global.Instance.globalCanvas : GameScreenManager.Instance.GetParent(GameScreenManager.UIRenderTarget.ScreenSpaceOverlay);
-			// One of the two places the mod puts a message in front of a player; the other is
-			// MultiplayerOverlay, which is logged the same way. Between them a report of "it
-			// popped an error" is traceable without asking the player to remember the wording.
-			// Log here rather than at each call site so a dialog added later is covered too.
+			// Logged here rather than at each call site so every dialog, including
+			// future ones, is traceable from the log.
 			UnityEngine.Debug.Log($"[ONI_Together] [Dialog] {title} :: {(text ?? string.Empty).Replace("\n", " | ")}");
 
 			var dialogue = ((ConfirmDialogScreen)KScreenManager.Instance.StartScreen(ScreenPrefabs.Instance.ConfirmDialogScreen.gameObject, parent));


### PR DESCRIPTION
A loading player read as ready and nothing gated the host's resume, so the ready screen
closed and the sim ran on while a client was still loading the save. This puts every host
resume path behind one all-ready check, holds that check closed for the whole load window
on all three transports, and keeps the ready screen up while it is closed.

## Changes

**The gate**
- Default `readyState` to `Unready`; force a (re)connecting client Unready on connect.
- Add `ReadyManager.CanHostResume()` and gate `SetSpeed`, `TogglePause` and `Unpause` on the
  host. Pausing is always allowed; the `IsSyncing` mirror path is exempt.
- Skip the SetSpeed/TogglePause broadcast when the prefix blocked the call — Harmony runs
  postfixes even after a prefix returns false, so a rejected resume still reached clients.
- Reject client-originated resume in `GameSpeedSyncer.CmdSetSpeed` and re-assert the
  authoritative speed instead of waiting for the 2s force-sync tick.
- Route readiness through one `IsConsideredReady` helper shared by the overlay text, the
  ready count and the gate; count players that are not us, not the raw roster size.

**Load-in-flight tracking**
- Move the bookkeeping onto `TransportServer`. It was wired to a `LiteNetLibServer` cast
  whose methods were empty stubs while Riptide's real implementation had no callers, so
  `PendingLoadingClientCount` was always 0 and no transport had load-window protection.
- Count only loaders that have dropped off the live roster, and add that count to the
  ready-screen total so it reads "2/3" through a load window instead of "2/2".
- Match a returning loader by id where that works, else release the longest-pending entry.
  Neither LAN transport keeps a client id across a reconnect — both derive it from the peer
  handle — so a client that left as id 2 comes back as 3 and the id match never fires there.
  Measured: on LAN the fallback fired three times, each leaving `pending loads: 0`; on Steam
  it fired zero times, so Steamworks matches exactly and overrides to exact-only.
- Mark the client loading host-side in `SendSaveFile` rather than relying on the notice the
  client sends microseconds before closing its socket; on a hard sync that late notice was
  the only signal.
- Clear entries on kick (all three transports — a kick removes the peer mapping the
  disconnect handler keys on), on a Steam lobby leave, and when the server stops.
- Give the expiry its own 120s constant instead of `Host.TimeoutSeconds`, which floors at
  30s — the same order as a large-colony rebuild.

**The ready screen**
- Block raycasts instead of merely covering the world; clicks were reaching a world the host
  had not resumed, and orders placed that way are lost.
- Swallow keys while it is up: `KModalScreen.OnKeyDown` answers Escape with `Deactivate()`,
  so Escape quietly destroyed the screen and exposed the gated world.
- Close a pause menu that was already open rather than stranding it unclosable behind the
  screen, and pair the pause bookkeeping on both sides (`FScreen`, `KModalButtonMenu.OnShow`)
  so a dialog opened during the wait cannot leak a pause level past the gate.
- Keep the screen up through the post-load reconnect. `Game.OnSpawn` closed it as soon as
  the world loaded and then *started* the reconnect, which takes ~21s on a Steam join while
  the gate stays shut — so the client was left on a live, clickable world with no screen
  and nothing raised one until the host's next broadcast. Measured at 23.6s in one join.
- Undo the ready screen's own pause when the gate opens — nothing did, so the host was left
  in front of a frozen world after every join.

**Housekeeping**
- Rebuild `NetworkIdentityRegistry` from the scene when hosting a second session on an
  already-loaded world; teardown clears it and no `OnSpawn` runs again.
- Give a save transfer a registration token so a superseded streaming coroutine stops
  instead of interleaving a second chunk stream under the same TransferId.
- Drop a dig order that arrives before the world exists. Measured: 64 `DigTool.PlaceDig`
  NREs before, 0 after, with the guard itself hit 78 times — the order is lost either way,
  but it no longer costs an exception per packet.
- Log the gate decision (roster, others, pending loads, open/closed). The bare "Refreshing
  ready state..." made a wrongly opened gate indistinguishable from one that held; the gap
  between roster and others is exactly where the Steamworks bug hid.

## Known limits

- The longest-pending fallback is a guess, and is wrong if a different client connects
  during someone else's load. A stable client id across a LAN reconnect would remove it.
- Every transport clears a pending load on a kick, but only Steamworks clears it on a
  voluntary leave. A LAN client that drops mid-load and never returns still holds the gate
  for the full 120s. Not fixed here because it has not been reproduced on LAN — the LAN
  reconnect arrives under a new id and the fallback consumes the entry, which is why the
  window has stayed invisible there.
