### PR TITLE
protocol: check the mod version at the handshake

### DIFF
--- a/ONI_Together/Networking/GameClient.cs
+++ b/ONI_Together/Networking/GameClient.cs
@@ -1,4 +1,4 @@
-using ONI_Together.DebugTools;
+﻿using ONI_Together.DebugTools;
 using ONI_Together.Menus;
 using ONI_Together.Misc;
 using ONI_Together.Networking.Components;
@@ -264,6 +264,17 @@ namespace ONI_Together.Networking
 			if (packet.PacketRegistryFingerprint != ProtocolCompatibility.PacketFingerprint)
 			{
 				message = string.Format(STRINGS.UI.PROTOCOL.VALIDATION.FINGERPRINT_MISMATCH, packet.PacketRegistryFingerprint, ProtocolCompatibility.PacketFingerprint);
+				return false;
+			}
+
+			// The host's mod version, which this side did not check either. Without it a
+			// client still joins a host it cannot agree with, even though the host now
+			// refuses the reverse.
+			if (!string.IsNullOrEmpty(packet.ModVersion)
+				&& packet.ModVersion != ProtocolCompatibility.ModVersion)
+			{
+				message = string.Format(STRINGS.UI.PROTOCOL.MOD_VERSION_MISMATCH,
+					ProtocolCompatibility.ModVersion, packet.ModVersion);
 				return false;
 			}
 

--- a/ONI_Together/Networking/Packets/Handshake/GameStateRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/Handshake/GameStateRequestPacket.cs
@@ -195,7 +195,7 @@ namespace ONI_Together.Networking.Packets.Handshake
 				return false;
 			}
 
-			if (!ProtocolCompatibility.Matches(ProtocolVersion, PacketRegistryFingerprint))
+			if (!ProtocolCompatibility.Matches(ProtocolVersion, PacketRegistryFingerprint, ModVersion))
 			{
 				reason = ProtocolCompatibility.BuildMismatchReason(ProtocolVersion, PacketRegistryFingerprint, ModVersion, true);
 				return false;

--- a/ONI_Together/Networking/ProtocolCompatibility.cs
+++ b/ONI_Together/Networking/ProtocolCompatibility.cs
@@ -1,4 +1,4 @@
-using ONI_Together.Networking.Packets.Architecture;
+﻿using ONI_Together.Networking.Packets.Architecture;
 using Shared.Profiling;
 
 namespace ONI_Together.Networking
@@ -30,9 +30,28 @@ namespace ONI_Together.Networking
 			}
 		}
 
-		public static bool Matches(int protocolVersion, int packetFingerprint)
+		public static bool Matches(int protocolVersion, int packetFingerprint, string modVersion)
 		{
 			using var _ = Profiler.Scope();
+
+			// The mod version is part of the decision, not just the explanation.
+			//
+			// BuildMismatchReason below already compares mod versions, but it is only
+			// called to explain a rejection this method has made - and this method looked
+			// at the protocol version and the packet fingerprint alone. Two peers on
+			// different mod versions with the same packet registry were accepted, so
+			// MOD_VERSION_MISMATCH was unreachable and the "Bypass Protocol Checks"
+			// tooltip, which promises mod version mismatches are checked, was not
+			// accurate.
+			//
+			// Such a pair connects and then disagrees about the world in ways that look
+			// exactly like a sync bug, which makes it expensive to diagnose.
+			//
+			// An empty version means a peer too old to send one; those already fail the
+			// metadata check, so treating a blank as a mismatch would only change which
+			// message they get.
+			if (!string.IsNullOrEmpty(modVersion) && modVersion != ModVersion)
+				return false;
 
 			return protocolVersion == CurrentProtocolVersion
 				&& packetFingerprint == PacketFingerprint;


### PR DESCRIPTION
Two peers on different mod versions with the same packet registry are accepted
today, connect, and then disagree about the world in ways indistinguishable from
a sync bug.

ProtocolCompatibility.Matches decides compatibility from the protocol version and
the packet fingerprint. BuildMismatchReason, immediately below it, already
compares mod versions - but it is only called to explain a rejection Matches has
already made, so for a mod-version-only difference it is never reached. That
makes STRINGS.UI.PROTOCOL.MOD_VERSION_MISMATCH unreachable, and the "Bypass
Protocol Checks" tooltip - "Ignores protocol version, packet registry
fingerprint, and mod version mismatches" - describes a check that does not
happen.

GameClient.TryValidateHostProtocol had the same gap in the other direction, so
even with the host refusing, a client would still join a host it cannot agree
with.

Both sides compare it now. No wire format change: ModVersion is already carried
on GameStateRequestPacket and already populated by PopulateProtocolMetadata, so
older peers are unaffected beyond being rejected with a clearer reason. An empty
version is treated as "not sent" rather than as a mismatch, since those peers
already fail the metadata check.

Verified on two machines, three cases:

  different mod versions   host:   "Rejecting client 2: Mod version mismatch.
                                    Host=0.7.4, Peer=0.7.3."
                           client: "Host protocol validation failed: Mod version
                                    mismatch. Host=0.7.4, Peer=0.7.3."
  same version             session establishes as before, no new messages
  bypass enabled           unchanged
