### PR TITLE
conduit: replicate off-screen pipes on the refresh tick

### DIFF
--- a/ONI_Together/Networking/Components/ConduitFlowSyncer.cs
+++ b/ONI_Together/Networking/Components/ConduitFlowSyncer.cs
@@ -1,4 +1,4 @@
-using ONI_Together.DebugTools;
+﻿using ONI_Together.DebugTools;
 using ONI_Together.Networking.Packets.World;
 using ONI_Together.Networking.Transport.Steamworks;
 using Shared.Profiling;
@@ -173,8 +173,25 @@ namespace ONI_Together.Networking.Components
 
 				// Visibility gate (invariant #1) — only allocate scratch use
 				// once per pipe cell, after the Grid.Objects rejection.
-				ws.GetClientsViewingCell(cell, _recipientScratch);
-				if (_recipientScratch.Count == 0) continue;
+				//
+				// Lifted on the force-refresh tick, and only there. The gate is right for
+				// deltas: a pipe changing off-screen is not worth a packet every 200ms.
+				// As the only path it meant an off-screen pipe was never replicated at
+				// all — the client kept whatever its own simulation produced and nothing
+				// corrected it, because the delta and the refresh both skipped it.
+				//
+				// That is not only cosmetic. A client's buildings draw from those pipes
+				// whether or not anybody is looking, so an aquatuner can be fed on one
+				// peer and dry on the other with nothing on screen to explain it.
+				//
+				// Cost is bounded by construction: one full sweep every
+				// FORCE_REFRESH_INTERVAL rather than every tick, and MaybeQueueCell still
+				// skips cells with no contents, so an empty pipe network costs nothing.
+				if (!forceRefresh)
+				{
+					ws.GetClientsViewingCell(cell, _recipientScratch);
+					if (_recipientScratch.Count == 0) continue;
+				}
 				pipeCellsVisible++;
 
 				if (hasGas)


### PR DESCRIPTION
Pipe contents are sent only for cells a client is currently looking at, so an
off-screen pipe is never replicated at all: the client keeps whatever its own
simulation produced, and nothing corrects it. The delta pass and the periodic
force refresh both skip it, so there is no path that ever catches up.

Measured by recording, per cell, whether contents had actually been sent, and
comparing the two peers' pipes cell by cell. Of 1,306 pipe cells, the 950 that
had been sent agreed exactly, and every disagreement was among the 356 that had
not. The syncer was not failing - it was not being asked.

Not only cosmetic either: a client's buildings draw from those pipes whether or
not anybody is looking at them, so an aquatuner can be fed on one peer and dry on
the other with nothing on screen to explain it.

The gate stays for deltas, where it is right - a pipe changing off-screen is not
worth a packet every 200ms - and is lifted only on the force-refresh tick. Cost
is bounded by construction: one full sweep every FORCE_REFRESH_INTERVAL instead
of every tick, and MaybeQueueCell still skips cells with no contents, so an empty
pipe network costs nothing.

After the change, conduit contents compare 1,544 cells shared, 0 differing, 0
one-sided. Host frame time was unchanged at 17.8ms, with the syncer at 103ms
across 3,333 frames (0.03ms/frame).
