### PR TITLE
battery_tracker: do not run against a world that is still loading

### DIFF
--- a/ONI_Together/Patches/World/BatteryTrackerPatch.cs
+++ b/ONI_Together/Patches/World/BatteryTrackerPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
+using ONI_Together.Networking.States;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.World
@@ -32,6 +33,42 @@ namespace ONI_Together.Patches.World
 			// otherwise — blocking it leaves batteries unregistered in the local CircuitManager,
 			// making every powered building render as "no power" until the next joules delta.
 			if (GameClient.IsHardSyncInProgress)
+				return false;
+
+			// A world that is still being built.
+			//
+			// Measured on a client three milliseconds after "Loaded <save>": a
+			// NullReferenceException inside UpdateData, from TrackerTool.Update. The
+			// tracker runs while the world is half built and reads something that is not
+			// there yet.
+			//
+			// It matters for the same reason the hard-sync block above does. An exception
+			// out of UpdateData leaves batteries unregistered in the local CircuitManager,
+			// which is the "every powered building shows no power" state this patch exists
+			// to avoid - so throwing here costs what blocking here used to.
+			//
+			// Skipped rather than caught: one missed tracker update is invisible, and the
+			// next one runs a fraction of a second later against a finished world.
+			if (Game.Instance == null || Grid.WidthInCells == 0)
+				return false;
+
+			// A client that is not playing yet, including the gap in the middle of a
+			// reconnect.
+			//
+			// Testing GameClient.State alone against LoadingWorld was not enough, and the
+			// log says why in three consecutive lines in the same millisecond: "State
+			// changed to: LoadingWorld", "Disconnected from server", "State changed to:
+			// Disconnected". The save transfer finishes and the transport drops while the
+			// world loads, so by the time the tracker ran the state being watched for had
+			// already been replaced.
+			//
+			// MultiplayerSession.IsClient is false during that gap too, which is why the
+			// cached connection is consulted - it is what the reconnect path itself uses
+			// to decide whether to rejoin once the world has loaded. A host is neither,
+			// so its behaviour is unchanged.
+			bool clientOrReconnecting = MultiplayerSession.IsClient
+				|| (!MultiplayerSession.IsHost && GameClient.HasCachedConnection());
+			if (clientOrReconnecting && GameClient.State != ClientState.InGame)
 				return false;
 
 			return true;


### PR DESCRIPTION
BatteryTracker.UpdateData throws a NullReferenceException on a client three
milliseconds after "Loaded <save>" - from TrackerTool.Update, with the tracker
reading something the half-built world does not have yet.

It matters for the same reason the hard-sync block already here does: an
exception out of UpdateData leaves batteries unregistered in the local
CircuitManager, which is the "every powered building shows no power" state this
patch exists to prevent. Throwing here costs what blocking here used to.

Two conditions, because one was not enough.

The first is that the world exists at all. The second is that this peer is
actually playing - and testing GameClient.State against LoadingWorld alone did
not work. The log explains it in three consecutive lines in the same
millisecond: "State changed to: LoadingWorld", "Disconnected from server",
"State changed to: Disconnected". The save transfer finishes and the transport
drops while the world loads, so by the time the tracker ran, the state being
watched for had already been replaced by another one.

MultiplayerSession.IsClient is false during that gap too, which is why the
cached connection is consulted - it is what the reconnect path itself uses to
decide whether to rejoin after the world finishes loading. A host is neither a
client nor reconnecting, so its behaviour is unchanged.

Skipped rather than caught: one missed tracker update is invisible, and the next
one runs a fraction of a second later against a finished world.

Evidence: the exception was observed on a client in a reconnect run, and did not
appear in any of four reconnect runs after the change. It is intermittent - it
needs the tracker to tick inside the window between the world loading and the
session being re-established - so four clean runs are not proof, only the
strongest evidence available without forcing that window open.
