### PR TITLE
assignment: do not rename a building the cell fallback merely found

### DIFF
--- a/ONI_Together/Networking/Packets/World/AssignmentPacket.cs
+++ b/ONI_Together/Networking/Packets/World/AssignmentPacket.cs
@@ -1,4 +1,4 @@
-using ONI_Together.DebugTools;
+﻿using ONI_Together.DebugTools;
 using ONI_Together.Networking.Components;
 using ONI_Together.Networking.Packets.Architecture;
 using System.IO;
@@ -57,10 +57,38 @@ namespace ONI_Together.Networking.Packets.World
 					GameObject buildingGO = Grid.Objects[Cell, (int)ObjectLayer.Building];
 					if (buildingGO != null)
 					{
-						buildingIdentity = buildingGO.AddOrGet<NetworkIdentity>();
-						buildingIdentity.NetId = BuildingNetId;
-						buildingIdentity.RegisterIdentity();
-						DebugConsole.Log($"[AssignmentPacket] Resolved building by cell {Cell}, assigned NetId {BuildingNetId}");
+						// Position finds a candidate; it does not license renaming it.
+						//
+						// An assignable is not always a building - a duplicant is assigned
+						// to an atmo suit, and that suit sits inside a locker at the same
+						// cell. When the id cannot be resolved, this took whatever building
+						// occupied the cell and gave it the packet's id, so one number
+						// meant a suit on one peer and a locker on the other.
+						//
+						// A building that already carries a different id is something else,
+						// and this packet is not about it.
+						var existing = buildingGO.GetComponent<NetworkIdentity>();
+						if (existing != null && existing.NetId != 0 && existing.NetId != BuildingNetId)
+						{
+							DebugConsole.LogWarning(
+								$"[AssignmentPacket] not renaming '{buildingGO.PrefabID()}' at cell {Cell} " +
+								$"from NetId {existing.NetId} to {BuildingNetId} - it is already " +
+								"addressed as something else, so this packet is about a different object.");
+						}
+						else
+						{
+							// OverrideNetId, not a field write.
+							//
+							// Assigning NetId directly moved the field without moving the
+							// registry entry, and RegisterIdentity begins with
+							// "if (IsRegistered) return" - so for a building that was already
+							// registered the new id was never filed at all, leaving the object
+							// unreachable at the old id and the new one alike. OverrideNetId
+							// unregisters, reassigns and re-registers together.
+							buildingIdentity = buildingGO.AddOrGet<NetworkIdentity>();
+							buildingIdentity.OverrideNetId(BuildingNetId);
+							DebugConsole.Log($"[AssignmentPacket] Resolved building by cell {Cell}, assigned NetId {BuildingNetId}");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
When BuildingNetId cannot be resolved, the fallback takes whatever building
occupies the cell and gives it that id. Two things go wrong with that.

An assignable is not always a building. A duplicant is assigned to an atmo suit,
and the suit sits inside a locker at the same cell - so the packet's id, which
belongs to the suit, lands on the locker and one number then means a suit on one
peer and a locker on the other. Every packet addressed to either is applied to
the wrong object from that point on.

And the id is written straight onto the field:

    buildingIdentity.NetId = BuildingNetId;
    buildingIdentity.RegisterIdentity();

RegisterIdentity begins with "if (IsRegistered) return", so for a building that
was already registered - which is the normal case for anything the fallback
finds - the new id is never filed. The registry still maps the old id to this
object while the field claims the new one, and the object is reachable at
neither.

So a building that already carries a different id is left alone and the refusal
is logged, and when the id is taken it goes through OverrideNetId, which
unregisters, reassigns and re-registers together.

No wire format change. Position stays a way to find a candidate; it is no longer
a licence to rename it.
