### PR TITLE
extensions: add a NetworkIdentity lookup that does not attach one

### DIFF
--- a/ONI_Together/Networking/Extensions.cs
+++ b/ONI_Together/Networking/Extensions.cs
@@ -45,6 +45,48 @@ namespace ONI_Together.Networking
 			return identity != null;
 		}
 
+		/// <summary>
+		/// The identity this object already has, or null. Never attaches one.
+		///
+		/// GetNetIdentity above ends in AddComponent, which is right when the caller is
+		/// about to address the object and wrong when it is only asking. Five places in
+		/// the mod already need the asking version and spell it out by hand as
+		/// GetComponent&lt;NetworkIdentity&gt;() - both overlay draw paths, both overlay
+		/// hover paths, and the cell fallback in BuildingConfigPacket - so they lose the
+		/// null check and the profiler scope the helpers have.
+		///
+		/// The overlay is the clearest case: drawing a network overlay should not attach
+		/// a NetworkIdentity to whatever the cursor passes over.
+		/// </summary>
+		public static NetworkIdentity GetExistingNetIdentity(this GameObject go)
+		{
+			using var _ = Profiler.Scope();
+
+			if (go.IsNullOrDestroyed())
+				return null;
+
+			return go.TryGetComponent<NetworkIdentity>(out var identity) ? identity : null;
+		}
+
+		/// <summary>Same, from a component - the overload GetNetIdentity already has.</summary>
+		public static NetworkIdentity GetExistingNetIdentity(this MonoBehaviour behaviour)
+		{
+			using var _ = Profiler.Scope();
+
+			if (behaviour.IsNullOrDestroyed())
+				return null;
+
+			return behaviour.gameObject.GetExistingNetIdentity();
+		}
+
+		/// <summary>The asking form of TryGetNetIdentity: reports what is there, adds nothing.</summary>
+		public static bool TryGetExistingNetIdentity(this GameObject go, out NetworkIdentity identity)
+		{
+			using var _ = Profiler.Scope();
+			identity = GetExistingNetIdentity(go);
+			return identity != null;
+		}
+
 		public static int GetNetId(this MonoBehaviour behaviour)
 		{
 			using var _ = Profiler.Scope();

--- a/ONI_Together/Networking/Overlay/NetworkingOverlayMode.cs
+++ b/ONI_Together/Networking/Overlay/NetworkingOverlayMode.cs
@@ -393,7 +393,7 @@ namespace ONI_Together.Networking.Overlay
 		{
 			if (root != null)
 			{
-				var identity = root.GetComponent<NetworkIdentity>();
+				var identity = root.GetExistingNetIdentity();
 				if (identity != null)
 					partition?.Add(identity);
 			}
@@ -403,7 +403,7 @@ namespace ONI_Together.Networking.Overlay
 		{
 			if (root != null && root.gameObject != null)
 			{
-				var identity = root.GetComponent<NetworkIdentity>();
+				var identity = root.GetExistingNetIdentity();
 				if (identity != null)
 				{
 					layerTargets.Remove(identity);

--- a/ONI_Together/Networking/Overlay/NetworkingOverlayPatches.cs
+++ b/ONI_Together/Networking/Overlay/NetworkingOverlayPatches.cs
@@ -275,7 +275,7 @@ namespace ONI_Together.Networking.Overlay
 			internal static void Postfix(SelectToolHoverTextCard __instance)
 			{
 				__instance.modeFilters[NetworkingOverlayMode.ID] =
-					(KSelectable sel) => sel.GetComponent<NetworkIdentity>() != null;
+					(KSelectable sel) => sel.GetExistingNetIdentity() != null;
 				__instance.overlayFilterMap[NetworkingOverlayMode.ID] = () => false;
 			}
 		}
@@ -290,7 +290,7 @@ namespace ONI_Together.Networking.Overlay
 
 				var hover = SelectTool.Instance?.hover;
 				if (hover == null) return;
-				var identity = hover.GetComponent<NetworkIdentity>();
+				var identity = hover.GetExistingNetIdentity();
 				if (identity == null || identity.NetId == 0) return;
 
 				var tracker = NetIdActivityTracker.Instance;


### PR DESCRIPTION
﻿GetNetIdentity ends in AddComponent, which is right when the caller is about to
address the object and wrong when it is only asking. Five places already need the
asking form and spell it out by hand as GetComponent<NetworkIdentity>(), losing the
null check and the profiler scope the helpers carry:

  Overlay/NetworkingOverlayMode.cs      two draw paths
  Overlay/NetworkingOverlayPatches.cs   the hover filter and the hover read
  Packets/World/BuildingConfigPacket.cs the cell fallback

The overlay is the clearest of them. Drawing a network overlay should not attach a
NetworkIdentity to whatever the cursor passes over, and a hover filter that asks
"does this have an identity" would make the answer true by asking.

So GetExistingNetIdentity() and TryGetExistingNetIdentity() sit beside the existing
pair with the same shape - a GameObject overload and a MonoBehaviour one - and the
four overlay sites use them. BuildingConfigPacket is left alone here; it is the
subject of #174 and changing it in two places at once would make that review harder
to read.

There is a second use for it beyond tidiness, which is why I wrote it in the first
place: anything winding an object DOWN wants this form. Calling the attaching
version from a cleanup path attaches an identity to a dying object and then throws
when it tries to register it, and an unregister that creates the thing it is
unregistering was never going to be right.

Builds clean against this branch - the only error is the pre-existing
UnityChatBoxUI.cs:55, `ChatToggle?.onClick = ...`, which C# rejects because you
cannot assign through `?.`. It is there before this change and unaffected by it.

