### PR TITLE
logic: resend automation state on a timer, not only when it changes

### DIFF
--- a/ONI_Together/Networking/Components/LogicStateSyncer.cs
+++ b/ONI_Together/Networking/Components/LogicStateSyncer.cs
@@ -30,12 +30,30 @@ namespace ONI_Together.Networking.Components
         // Viewport scratch buffer
         private readonly HashSet<ulong> _viewportScratch = new();
 
+        /// <summary>
+        /// How often a logic building states itself even though nothing changed.
+        ///
+        /// A signal is one bit that sits unchanged for hours, so "nothing changed" is the
+        /// normal state of a working circuit. Delta-only means two peers that disagree once
+        /// stay that way: the host's value never changes again, so it never speaks again,
+        /// and the client keeps the opposite bit for the rest of the session - doors that
+        /// will not open and pumps that will not run, with nothing on screen to say why.
+        ///
+        /// Fifteen seconds, phase-spread per entry. One small packet per building per
+        /// fifteen seconds, and it is the only thing that can close a divergence nobody is
+        /// touching.
+        /// </summary>
+        private const float RESYNC_INTERVAL = 15f;
+
         private class BuildingEntry
         {
             public GameObject go;
             public Variant lastValue;
             public bool lastActive;
             public Dictionary<string, Variant> lastOptional;
+
+            /// <summary>When this building next owes a keyframe whatever it thinks changed.</summary>
+            public float nextResync;
         }
 
         public override void OnSpawn()
@@ -94,16 +112,15 @@ namespace ONI_Together.Networking.Components
                 if (!SampleBuilding(entry.go, out var value, out var active, out var optional))
                     continue;
 
+                bool dueForResync = Time.unscaledTime >= entry.nextResync;
+
                 bool changed = LogicStatePacket.VariantValueChanged(value, entry.lastValue)
                     || active != entry.lastActive
-                    || LogicStatePacket.OptionalValuesChanged(optional, entry.lastOptional);
+                    || LogicStatePacket.OptionalValuesChanged(optional, entry.lastOptional)
+                    || dueForResync;
 
                 if (!changed)
                     continue;
-
-                entry.lastValue = value;
-                entry.lastActive = active;
-                entry.lastOptional = optional;
 
                 int cell = Grid.PosToCell(entry.go);
 
@@ -116,7 +133,19 @@ namespace ONI_Together.Networking.Components
                     OptionalValues = optional,
                 };
 
-                if (WorldStateSyncer.Instance != null)
+                entry.lastValue = value;
+                entry.lastActive = active;
+                entry.lastOptional = optional;
+                if (dueForResync)
+                    entry.nextResync = Time.unscaledTime + RESYNC_INTERVAL;
+
+                // A keyframe ignores the viewport, which is the whole point of it.
+                //
+                // Culling deltas is right - nobody needs a signal change for a circuit they
+                // cannot see - but sending the repair only to watchers would make it wait on
+                // the same condition that caused the damage. A circuit nobody is looking at
+                // is exactly the one that has drifted.
+                if (!dueForResync && WorldStateSyncer.Instance != null)
                 {
                     WorldStateSyncer.Instance.GetClientsViewingCell(cell, _viewportScratch, 2);
                     foreach (var playerId in _viewportScratch)
@@ -221,6 +250,10 @@ namespace ONI_Together.Networking.Components
                 lastValue = default,
                 lastActive = false,
                 lastOptional = null,
+
+                // Spread by id so a colony's automation does not all come due on one frame.
+                nextResync = Time.unscaledTime + INIT_DELAY
+                             + ((System.Math.Abs(netId) % 1024) / 1024f) * RESYNC_INTERVAL,
             };
         }
 


### PR DESCRIPTION
﻿LogicStateSyncer sends a building's logic state when it differs from the last one
sent, and never otherwise. That cannot repair a peer that is already wrong.

A logic signal is one bit that sits unchanged for hours, so "nothing changed" is
the normal state of a working circuit. Once the two peers disagree about one, the
host's value never changes again, so it never speaks again, and the client keeps
the opposite bit for the rest of the session. What the player sees is a door that
will not open or a pump that will not run, with nothing on screen to say why.

StructureStateSyncers already solved this shape for buildings - the same delta-only
sync there left containers hundreds of kilograms apart and the fifteen-second
keyframe closed it. This is the same fix for automation:

- RESYNC_INTERVAL 15s, per tracked building
- phase-spread by NetId, so a colony's automation does not all come due on one frame
- the keyframe ignores the viewport. Culling deltas is right, but sending the repair
  only to watchers would make it wait on the same condition that caused the damage -
  a circuit nobody is looking at is exactly the one that has drifted.

Measured in my fork, which carries this change: logicResyncs 323 and 399 on the
host across separate runs and 0 on the client, which is the shape it should have -
only the host sends them. No change to client errors, netid agreement or the
conduit/circuit comparisons in those runs.

Scoped deliberately to the keyframe. This file also records lastValue BEFORE the
send, so a change that went to nobody is marked delivered - the same fault the
structure syncer fixed by recording only on delivery. Fixing that here needs
PacketSender.SendToAllClients / SendToPlayer to report whether anything was sent,
which is a wider change than this PR should carry, and the keyframe covers most of
its cost anyway by re-sending within fifteen seconds. Happy to do it as a follow-up
if you want the counts.

Builds clean against this branch - the only error is the pre-existing
UnityChatBoxUI.cs:55.

