### PR TITLE
census: notice at runtime what the client is missing

### DIFF
--- a/ONI_Together/MultiplayerMod.cs
+++ b/ONI_Together/MultiplayerMod.cs
@@ -91,6 +91,7 @@ namespace ONI_Together
 				go.AddComponent<LogicStateSyncer>();
 				go.AddComponent<OxySyncManager>();
 				go.AddComponent<NetIdActivityTracker>();
+				go.AddComponent<IdCensus>();
 				go.AddComponent<DiscordRichPresence>();
 
 				// CHECKPOINT 5

--- a/ONI_Together/Networking/Components/IdCensus.cs
+++ b/ONI_Together/Networking/Components/IdCensus.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.Packets.Core;
+using UnityEngine;
+
+namespace ONI_Together.Networking.Components
+{
+    /// <summary>
+    /// Ask continuously, and for every kind of object at once, whether the client has what
+    /// the host has. See IdCensusPacket for why this is worth a packet.
+    ///
+    /// The host walks its own NetworkIdentity objects in batches and the client looks each
+    /// id up. An id missing on one pass is probably in flight; an id missing on two
+    /// consecutive passes is gone, and only the second is reported.
+    ///
+    /// What it cannot see, stated so a zero is not read as good news:
+    /// - objects the host never gave an id. Nothing without an id can appear in a census
+    ///   of ids.
+    /// - objects the client has and the host does not. The traffic goes one way.
+    /// - an object the client holds under a DIFFERENT id. This walks ids, so "present
+    ///   under another number" and "absent" look the same from here. Telling those apart
+    ///   needs cell and prefab on the wire, which costs several times the bandwidth; worth
+    ///   doing only if the count below ever justifies it.
+    /// - anything while the client is disconnected, which is when a reconnect is most
+    ///   likely to have emptied the registry.
+    /// </summary>
+    public class IdCensus : MonoBehaviour
+    {
+        /// <summary>
+        /// Four batches a second, forty ids each.
+        ///
+        /// Sized so the interesting counter can actually fire. At one batch a second a pass
+        /// over ten thousand objects takes four minutes and the two-pass count needs eight,
+        /// which is longer than many sessions spend settled - the counter would read zero
+        /// and could not read anything else. At four a second a pass is about a minute.
+        ///
+        /// Forty per packet keeps the payload near 160 bytes, well inside the 1000-byte
+        /// limit, so this never reaches the chunking path.
+        /// </summary>
+        private const float SendInterval = 0.25f;
+        private const int BatchSize = 40;
+
+        /// <summary>
+        /// Nothing for the first half minute of a session. A join spawns everything at once
+        /// and the two peers are legitimately out of step while that lands.
+        /// </summary>
+        private const float StartDelay = 30f;
+
+        private float _next;
+        private float _startedAt;
+        private bool _started;
+
+        /// <summary>
+        /// The ids to walk, snapshotted per pass rather than re-read per batch: the world
+        /// changes while the walk is in progress, and a moving list would silently skip
+        /// entries - the one failure an instrument built to find missing things cannot have.
+        /// </summary>
+        private List<int> _snapshot;
+        private int _position;
+        private int _cycle;
+
+        // --- client side ---
+
+        private static readonly HashSet<int> _missingThisCycle = new HashSet<int>();
+        private static readonly HashSet<int> _missingLastCycle = new HashSet<int>();
+        private static int _cycleSeen = -1;
+
+        /// <summary>Ids the host offered and this peer looked up.</summary>
+        public static int Checked { get; private set; }
+
+        /// <summary>Ids missing at the moment they were offered. Includes things in flight.</summary>
+        public static int MissingNow { get; private set; }
+
+        /// <summary>
+        /// Ids missing on two consecutive passes. This is the number that means something -
+        /// a pass is about a minute, and nothing legitimately in flight survives that long.
+        /// </summary>
+        public static int MissingPersistent { get; private set; }
+
+        /// <summary>
+        /// Passes completed, so a zero above can be told from "it never ran". Read these
+        /// two together; a zero with no completed passes says nothing at all.
+        /// </summary>
+        public static int CyclesCompleted { get; private set; }
+
+        public static void Reset()
+        {
+            _missingThisCycle.Clear();
+            _missingLastCycle.Clear();
+            _cycleSeen = -1;
+            Checked = 0;
+            MissingNow = 0;
+            MissingPersistent = 0;
+            CyclesCompleted = 0;
+        }
+
+        private void Update()
+        {
+            if (!MultiplayerSession.SessionHasPlayers || !MultiplayerSession.IsHost) return;
+            if (Game.Instance == null) return;
+
+            if (!_started)
+            {
+                _started = true;
+                _startedAt = Time.unscaledTime;
+                return;
+            }
+            if (Time.unscaledTime - _startedAt < StartDelay) return;
+            if (Time.unscaledTime < _next) return;
+            _next = Time.unscaledTime + SendInterval;
+
+            if (_snapshot == null || _position >= _snapshot.Count)
+            {
+                // The world rather than the registry: this asks what the host actually
+                // holds, and a registry that has quietly lost an entry is one of the things
+                // worth catching rather than trusting.
+                _snapshot = new List<int>();
+                foreach (var identity in Object.FindObjectsByType<NetworkIdentity>(
+                             FindObjectsInactive.Exclude, FindObjectsSortMode.None))
+                {
+                    if (identity.IsNullOrDestroyed() || identity.NetId == 0) continue;
+                    _snapshot.Add(identity.NetId);
+                }
+                _position = 0;
+                _cycle++;
+            }
+
+            int take = Mathf.Min(BatchSize, _snapshot.Count - _position);
+            if (take <= 0) return;
+
+            var batch = new int[take];
+            _snapshot.CopyTo(_position, batch, 0, take);
+            _position += take;
+
+            PacketSender.SendToAllClients(
+                new IdCensusPacket { Cycle = _cycle, NetIds = batch },
+                PacketSendMode.Reliable);
+        }
+
+        /// <summary>Client side: look each id up, and remember what was not there.</summary>
+        internal static void Receive(int cycle, int[] netIds)
+        {
+            if (netIds == null) return;
+
+            if (cycle != _cycleSeen)
+            {
+                if (_cycleSeen >= 0)
+                {
+                    CyclesCompleted++;
+                    _missingLastCycle.Clear();
+                    foreach (int id in _missingThisCycle) _missingLastCycle.Add(id);
+                }
+                _missingThisCycle.Clear();
+                _cycleSeen = cycle;
+            }
+
+            foreach (int id in netIds)
+            {
+                if (id == 0) continue;
+                Checked++;
+
+                if (NetworkIdentityRegistry.TryGet(id, out var identity) && !identity.IsNullOrDestroyed())
+                    continue;
+
+                _missingThisCycle.Add(id);
+                MissingNow++;
+
+                if (!_missingLastCycle.Contains(id)) continue;
+
+                MissingPersistent++;
+
+                // Only the first few, and only for absences that have survived a pass.
+                // A per-id line for everything would be the whole log; the counter is the
+                // measurement and these are for finding out what one of them was.
+                if (MissingPersistent <= 10)
+                {
+                    DebugConsole.LogWarning(
+                        $"[Census] the host holds NetId {id} and this peer does not, on two " +
+                        $"consecutive passes - grep the host log for that id to see what it is " +
+                        $"({MissingPersistent} so far, {Checked} checked)");
+                }
+            }
+        }
+    }
+}

--- a/ONI_Together/Networking/Packets/Core/IdCensusPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/IdCensusPacket.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.Components;
+using ONI_Together.Networking.Packets.Architecture;
+
+namespace ONI_Together.Networking.Packets.Core
+{
+    /// <summary>
+    /// A slice of what the host holds, so a client can notice what it is missing without
+    /// anyone having to know in advance what kind of object went astray.
+    ///
+    /// The mod has good instruments for one peer at a time - the network overlay, the
+    /// packet tracker, the sync stats, the per-NetId activity tracker. None of them
+    /// compares the two peers, so "the client does not have that object" is only ever
+    /// found by a player noticing something missing and somebody then reading two logs
+    /// side by side. Every defect of that shape I have chased was found that way, one
+    /// object type at a time.
+    ///
+    /// This asks the general question continuously and cheaply. The host walks its own
+    /// NetworkIdentity objects, forty ids at a time, four times a second, and the client
+    /// looks each one up. That is 640 bytes a second of payload, and a ten thousand object
+    /// colony is covered end to end in about a minute.
+    ///
+    /// Ids only. Prefab names would make the report readable on the spot and would also
+    /// push the packet past the 1000-byte payload limit into the chunking path. The client
+    /// cannot name an object it does not have, but the host's log can - grep the id.
+    ///
+    /// It reports and does not repair. Creating a missing object from an announcement is a
+    /// separate question with its own failure modes; the point here is that the absence
+    /// stops being invisible.
+    /// </summary>
+    public class IdCensusPacket : IPacket
+    {
+        /// <summary>
+        /// Which pass over the host's objects this batch belongs to.
+        ///
+        /// The client needs pass boundaries to tell a real absence from an object still in
+        /// flight. Something announced a moment ago is legitimately missing right now and
+        /// will be there next pass; something missing on two consecutive passes is not in
+        /// flight, it is gone. Without this the report is mostly noise, and noise in a
+        /// warning is how a real signal gets ignored.
+        /// </summary>
+        public int Cycle;
+
+        public int[] NetIds;
+
+        public void Serialize(BinaryWriter writer)
+        {
+            writer.Write(Cycle);
+            writer.Write(NetIds?.Length ?? 0);
+            if (NetIds != null)
+                foreach (int id in NetIds)
+                    writer.Write(id);
+        }
+
+        public void Deserialize(BinaryReader reader)
+        {
+            Cycle = reader.ReadInt32();
+            int count = reader.ReadInt32();
+
+            // A length read off the wire is a length somebody else chose.
+            if (count < 0 || count > 4096) { NetIds = new int[0]; return; }
+
+            NetIds = new int[count];
+            for (int i = 0; i < count; i++)
+                NetIds[i] = reader.ReadInt32();
+        }
+
+        public void OnDispatched()
+        {
+            if (MultiplayerSession.IsHost) return;
+            IdCensus.Receive(Cycle, NetIds);
+        }
+    }
+}


### PR DESCRIPTION
﻿The mod measures one peer well - the network overlay, PacketTracker, SyncStats,
NetIdActivityTracker all describe what this machine is doing. Nothing compares the
two peers, so "the client does not have that object" is only ever found by a player
noticing something absent and somebody then reading two logs side by side. Every
defect of that shape I have chased was found that way, one object type at a time,
after the fact.

This asks the general question while the game is running. The host walks its own
NetworkIdentity objects, forty ids at a time, four times a second; the client looks
each one up. 640 bytes a second of payload, and a ten thousand object colony is
covered end to end in about a minute.

An id missing on one pass is probably in flight. An id missing on two consecutive
passes is gone, and only that is reported - a warning that is mostly noise is how a
real signal gets ignored.

Sizing is deliberate. At one batch a second a pass over ten thousand objects takes
four minutes and the two-pass count needs eight, which is longer than many sessions
spend settled: the counter would read zero and could not read anything else. Forty
ids per packet keeps the payload near 160 bytes, well inside the 1000-byte limit,
so this never reaches the chunking path.

It walks the world rather than the registry, on purpose. A registry that has quietly
lost entries is one of the things worth catching rather than trusting.

What it cannot see is written on the class, so a zero is not read as good news:
objects the host never named, objects the client has and the host does not, and -
the important one - an object the client holds under a DIFFERENT id, which from an
id census is indistinguishable from an absent one. Separating those needs cell and
prefab on the wire at several times the bandwidth, and is worth doing only if the
count justifies it.

Reports and does not repair. Building a missing object from an announcement is a
separate question with its own failure modes; the point here is that the absence
stops being invisible.

In my fork this found 44-50 persistent absences a run within minutes of being
switched on, and splitting them by whether the client had ever held the id turned
"announcements are being lost" - which is what I had reported - into "the two
simulations merge loose matter differently", which is a different problem with a
different fix. That correction is the argument for it.

Builds clean against this branch - the only error is the pre-existing
UnityChatBoxUI.cs:55.

