### PR TITLE
Fix the work syncing issues on objects between the client and the host

### DIFF
--- a/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
@@ -5,8 +5,10 @@ using System.Reflection;
 using System.Text;
 using ONI_Together.Misc;
 using ONI_Together.Networking;
+using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.OxySync.Packets;
 using Shared.OxySync;
+using Shared.OxySync.Attributes;
 using UnityEngine;
 
 namespace ONI_Together.DebugTools.UnitTests

--- a/ONI_Together/MultiplayerMod.cs
+++ b/ONI_Together/MultiplayerMod.cs
@@ -91,7 +91,6 @@ namespace ONI_Together
 				go.AddComponent<OxySyncManager>();
 				go.AddComponent<NetIdActivityTracker>();
 				go.AddComponent<DiscordRichPresence>();
-				go.AddComponent<WorkableSyncer>();
 
 				// CHECKPOINT 5
 				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 5: Pre-Listeners\n");

--- a/ONI_Together/MultiplayerMod.cs
+++ b/ONI_Together/MultiplayerMod.cs
@@ -91,6 +91,7 @@ namespace ONI_Together
 				go.AddComponent<OxySyncManager>();
 				go.AddComponent<NetIdActivityTracker>();
 				go.AddComponent<DiscordRichPresence>();
+				go.AddComponent<WorkableSyncer>();
 
 				// CHECKPOINT 5
 				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 5: Pre-Listeners\n");

--- a/ONI_Together/Networking/Components/NetworkIdentity.cs
+++ b/ONI_Together/Networking/Components/NetworkIdentity.cs
@@ -12,7 +12,7 @@ namespace ONI_Together.Networking.Components
 		public int NetId = 0;
 
 		[SkipSaveFileSerialization]
-		private bool IsRegistered = false;
+		public bool IsRegistered { get; private set; } = false;
 
 		public override void OnSpawn()
 		{

--- a/ONI_Together/Networking/OxySync/Components/WorkableSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/WorkableSyncer.cs
@@ -13,17 +13,17 @@ namespace ONI_Together.Networking.OxySync.Components
     public class WorkableSyncer : NetworkBehaviour
     {
 
-        private static string GetWorkableTypeId(Workable workable)
+        private string GetWorkableTypeId(Workable workable)
         {
             return workable?.GetType().AssemblyQualifiedName ?? string.Empty;
         }
 
-        private static string GetWorkableTypeId(string workableTypeId)
+        private string GetWorkableTypeId(string workableTypeId)
         {
             return workableTypeId ?? string.Empty;
         }
 
-        private static Type ResolveWorkableType(string workableTypeId)
+        private Type ResolveWorkableType(string workableTypeId)
         {
             string normalizedTypeId = GetWorkableTypeId(workableTypeId);
             if (string.IsNullOrEmpty(normalizedTypeId))
@@ -49,12 +49,12 @@ namespace ONI_Together.Networking.OxySync.Components
                 .FirstOrDefault(t => t != null);
         }
 
-        private static (int WorkableNetId, string WorkableTypeId, MethodType Method) BuildAuthKey(int workableNetId, string workableTypeId, MethodType method)
+        private (int WorkableNetId, string WorkableTypeId, MethodType Method) BuildAuthKey(int workableNetId, string workableTypeId, MethodType method)
         {
             return (workableNetId, GetWorkableTypeId(workableTypeId), method);
         }
 
-        private static (int WorkableNetId, string WorkableTypeId, MethodType Method) BuildAuthKey(Workable workable, MethodType method)
+        private (int WorkableNetId, string WorkableTypeId, MethodType Method) BuildAuthKey(Workable workable, MethodType method)
         {
             return (workable.GetNetId(), GetWorkableTypeId(workable), method);
         }
@@ -100,19 +100,18 @@ namespace ONI_Together.Networking.OxySync.Components
 
         public static bool IsAuthorized(int workableNetId, string workableTypeId, MethodType method)
         {
-            var syncer = Instance;
-            if (syncer == null)
+            if (Instance == null)
             {
                 return false;
             }
 
-            return syncer.workableAuthorization.ContainsKey(BuildAuthKey(workableNetId, workableTypeId, method));
+            return Instance.workableAuthorization.ContainsKey(Instance.BuildAuthKey(workableNetId, workableTypeId, method));
         }
 
         public static bool IsAuthorized(int workableNetId, string workableTypeId, MethodType method, out int workerNetId)
         {
             var syncer = Instance;
-            if (syncer != null && syncer.workableAuthorization.TryGetValue(BuildAuthKey(workableNetId, workableTypeId, method), out var workerId))
+            if (syncer != null && syncer.workableAuthorization.TryGetValue(syncer.BuildAuthKey(workableNetId, workableTypeId, method), out var workerId))
             {
                 workerNetId = workerId;
                 return true;
@@ -130,14 +129,14 @@ namespace ONI_Together.Networking.OxySync.Components
                 return false;
             }
 
-            return syncer.workableAuthorization.ContainsKey(BuildAuthKey(workable, method));
+            return syncer.workableAuthorization.ContainsKey(syncer.BuildAuthKey(workable, method));
         }
 
         public static bool IsAuthorized(Workable workable, MethodType method, out int workerNetId)
         {
             var syncer = Instance;
             if (syncer != null && workable != null && !workable.IsNullOrDestroyed() &&
-                syncer.workableAuthorization.TryGetValue(BuildAuthKey(workable, method), out var workerId))
+                syncer.workableAuthorization.TryGetValue(syncer.BuildAuthKey(workable, method), out var workerId))
             {
                 workerNetId = workerId;
                 return true;
@@ -149,7 +148,7 @@ namespace ONI_Together.Networking.OxySync.Components
 
         public static void UnAuthorize(int workableNetId, string workableTypeId, MethodType method)
         {
-            Instance?.workableAuthorization.Remove(BuildAuthKey(workableNetId, workableTypeId, method));
+            Instance?.workableAuthorization.Remove(Instance.BuildAuthKey(workableNetId, workableTypeId, method));
         }
 
         public static void UnAuthorize(Workable workable, MethodType method)
@@ -159,21 +158,19 @@ namespace ONI_Together.Networking.OxySync.Components
                 return;
             }
 
-            Instance?.workableAuthorization.Remove(BuildAuthKey(workable, method));
+            Instance?.workableAuthorization.Remove(Instance.BuildAuthKey(workable, method));
         }
 
-        public static void RequestUpdateWorkable(MethodType method, Workable workable, WorkerBase worker)
+        public void RequestUpdateWorkable(MethodType method, Workable workable, WorkerBase worker)
         {
-            var syncer = Instance;
-            if (!MultiplayerSession.IsHostInSession || syncer == null)
+            if (!MultiplayerSession.IsHostInSession || !MultiplayerSession.SessionHasPlayers)
             {
-                DebugConsole.LogWarning($"[WorkableSyncer] Skip sync for method {method}: host/session not ready or syncer missing. IsHostInSession={MultiplayerSession.IsHostInSession}, SyncerNull={syncer == null}");
                 return;
             }
 
             if (workable.IsNullOrDestroyed() || worker.IsNullOrDestroyed())
             {
-                DebugConsole.LogWarning($"[WorkableSyncer] Skip sync for method {method}: workable/worker missing. WorkableNullOrDestroyed={workable.IsNullOrDestroyed()}, WorkerNullOrDestroyed={worker.IsNullOrDestroyed()}");
+                DebugConsole.LogWarning($"[WorkableSyncer] Skip sync for method {method}: WorkableNullOrDestroyed={workable.IsNullOrDestroyed()}, WorkerNullOrDestroyed={worker.IsNullOrDestroyed()}");
                 return;
             }
 
@@ -181,15 +178,19 @@ namespace ONI_Together.Networking.OxySync.Components
             int workerNetId = worker.GetNetId();
             if (workableNetId == 0 || workerNetId == 0)
             {
-                DebugConsole.LogWarning($"[WorkableSyncer] Skip sync for method {method}: invalid NetId(s). WorkableNetId={workableNetId}, WorkerNetId={workerNetId}, Workable={workable.GetProperName()}, Worker={worker.GetProperName()}");
+                DebugConsole.LogWarning(
+                    $"[WorkableSyncer] Skip sync for method {method}: invalid NetId(s). " +
+                    $"Workable '{workable.GetProperName()}' has NetId '{workableNetId}', " +
+                    $"Worker '{worker.GetProperName()}' has NetId '{workerNetId}'");
+
                 return;
             }
 
             try
             {
                 string workableTypeId = GetWorkableTypeId(workable);
-                DebugConsole.Log($"[WorkableSyncer] Sync workable {workableNetId} ({workableTypeId}) with Worker {workerNetId} to {method.ToString()}");
-                syncer.CallCommand(nameof(CmdUpdateWorkable), (byte)method, workableNetId, workableTypeId, workerNetId);
+                DebugConsole.Log($"[WorkableSyncer] Worker has NetId {workerNetId} '{method}' on workable {workableNetId} : {workableTypeId}");
+                CallClientRpc(nameof(RpcUpdateWorkable), method, workableNetId, workableTypeId, workerNetId);
             }
             catch (System.Exception ex)
             {
@@ -197,20 +198,9 @@ namespace ONI_Together.Networking.OxySync.Components
             }
         }
 
-        [Command]
-        private void CmdUpdateWorkable(byte method, int workableNetId, string workableTypeId, int workerNetId)
-        {
-            CallClientRpc(nameof(RpcUpdateWorkable), (MethodType)method, workableNetId, workableTypeId, workerNetId);
-        }
-
         [ClientRpc]
         private void RpcUpdateWorkable(MethodType method, int workableNetId, string workableTypeId, int workerNetId)
         {
-            if (!isClient || !MultiplayerSession.IsClient)
-            {
-                return;
-            }
-
             if (workableNetId == 0 || !NetworkIdentityRegistry.TryGet(workableNetId, out var identity) || identity == null || identity.gameObject.IsNullOrDestroyed())
             {
                 return;
@@ -248,7 +238,7 @@ namespace ONI_Together.Networking.OxySync.Components
 
             workableAuthorization[BuildAuthKey(workableNetId, workableTypeId, method)] = workerNetId;
 
-            DebugConsole.Log($"[WorkableSyncer] Sync workable {workableNetId} ({GetWorkableTypeId(workable)}) with Worker {workerNetId} to {method.ToString()}");
+            DebugConsole.Log($"[WorkableSyncer] [Client] Worker has NetId {workerNetId} '{method}' on workable {workableNetId} : {workableTypeId}");
 
             switch (method)
             {
@@ -268,11 +258,6 @@ namespace ONI_Together.Networking.OxySync.Components
                     DebugConsole.LogWarning($"[WorkableSyncer] Unknown method name: {method}");
                     break;
             }
-        }
-
-        private void Update()
-        {
-            if (!isServer) return;
         }
     }
 }

--- a/ONI_Together/Networking/OxySync/Components/WorkableSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/WorkableSyncer.cs
@@ -1,0 +1,277 @@
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using KSerialization;
+using ONI_Together.DebugTools;
+using ONI_Together.Patches;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class WorkableSyncer : NetworkBehaviour
+    {
+
+        private static string GetWorkableTypeId(Workable workable)
+        {
+            return workable?.GetType().AssemblyQualifiedName ?? string.Empty;
+        }
+
+        private static string GetWorkableTypeId(string workableTypeId)
+        {
+            return workableTypeId ?? string.Empty;
+        }
+
+        private static Type ResolveWorkableType(string workableTypeId)
+        {
+            string normalizedTypeId = GetWorkableTypeId(workableTypeId);
+            if (string.IsNullOrEmpty(normalizedTypeId))
+            {
+                return null;
+            }
+
+            var type = Type.GetType(normalizedTypeId);
+            if (type != null)
+            {
+                return type;
+            }
+
+            string fullName = normalizedTypeId.Split(',')[0].Trim();
+            if (string.IsNullOrEmpty(fullName))
+            {
+                return null;
+            }
+
+            return AppDomain.CurrentDomain
+                .GetAssemblies()
+                .Select(asm => asm.GetType(fullName, throwOnError: false, ignoreCase: false))
+                .FirstOrDefault(t => t != null);
+        }
+
+        private static (int WorkableNetId, string WorkableTypeId, MethodType Method) BuildAuthKey(int workableNetId, string workableTypeId, MethodType method)
+        {
+            return (workableNetId, GetWorkableTypeId(workableTypeId), method);
+        }
+
+        private static (int WorkableNetId, string WorkableTypeId, MethodType Method) BuildAuthKey(Workable workable, MethodType method)
+        {
+            return (workable.GetNetId(), GetWorkableTypeId(workable), method);
+        }
+
+        public static WorkableSyncer Instance { get; private set; }
+        public enum MethodType: byte
+        {
+            StartWork,
+            StopWork,
+            CompleteWork,
+            AbortWork
+        }
+
+        private Dictionary<(int WorkableNetId, string WorkableTypeId, MethodType Method), int> workableAuthorization = [];
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId() {
+            if (Instance == null)
+            {
+                DebugConsole.LogWarning("[WorkableSyncer] Initializing WorkableSyncer instance.");
+                Instance = Game.Instance.gameObject.AddComponent<WorkableSyncer>();
+            }
+
+            Instance.workableAuthorization.Clear();
+            Instance.NetId = nameof(WorkableSyncer).GetHashCode();
+        }
+
+        public static bool IsAuthorized(int workableNetId, string workableTypeId, MethodType method)
+        {
+            var syncer = Instance;
+            if (syncer == null)
+            {
+                return false;
+            }
+
+            return syncer.workableAuthorization.ContainsKey(BuildAuthKey(workableNetId, workableTypeId, method));
+        }
+
+        public static bool IsAuthorized(int workableNetId, string workableTypeId, MethodType method, out int workerNetId)
+        {
+            var syncer = Instance;
+            if (syncer != null && syncer.workableAuthorization.TryGetValue(BuildAuthKey(workableNetId, workableTypeId, method), out var workerId))
+            {
+                workerNetId = workerId;
+                return true;
+            }
+
+            workerNetId = 0;
+            return false;
+        }
+
+        public static bool IsAuthorized(Workable workable, MethodType method)
+        {
+            var syncer = Instance;
+            if (syncer == null || workable == null || workable.IsNullOrDestroyed())
+            {
+                return false;
+            }
+
+            return syncer.workableAuthorization.ContainsKey(BuildAuthKey(workable, method));
+        }
+
+        public static bool IsAuthorized(Workable workable, MethodType method, out int workerNetId)
+        {
+            var syncer = Instance;
+            if (syncer != null && workable != null && !workable.IsNullOrDestroyed() &&
+                syncer.workableAuthorization.TryGetValue(BuildAuthKey(workable, method), out var workerId))
+            {
+                workerNetId = workerId;
+                return true;
+            }
+
+            workerNetId = 0;
+            return false;
+        }
+
+        public static void UnAuthorize(int workableNetId, string workableTypeId, MethodType method)
+        {
+            Instance?.workableAuthorization.Remove(BuildAuthKey(workableNetId, workableTypeId, method));
+        }
+
+        public static void UnAuthorize(Workable workable, MethodType method)
+        {
+            if (workable == null || workable.IsNullOrDestroyed())
+            {
+                return;
+            }
+
+            Instance?.workableAuthorization.Remove(BuildAuthKey(workable, method));
+        }
+
+        public static void RequestUpdateWorkable(MethodType method, Workable workable, WorkerBase worker)
+        {
+            var syncer = Instance;
+            if (!MultiplayerSession.IsHostInSession || syncer == null)
+            {
+                DebugConsole.LogWarning($"[WorkableSyncer] Skip sync for method {method}: host/session not ready or syncer missing. IsHostInSession={MultiplayerSession.IsHostInSession}, SyncerNull={syncer == null}");
+                return;
+            }
+
+            if (workable.IsNullOrDestroyed() || worker.IsNullOrDestroyed())
+            {
+                DebugConsole.LogWarning($"[WorkableSyncer] Skip sync for method {method}: workable/worker missing. WorkableNullOrDestroyed={workable.IsNullOrDestroyed()}, WorkerNullOrDestroyed={worker.IsNullOrDestroyed()}");
+                return;
+            }
+
+            int workableNetId = workable.GetNetId();
+            int workerNetId = worker.GetNetId();
+            if (workableNetId == 0 || workerNetId == 0)
+            {
+                DebugConsole.LogWarning($"[WorkableSyncer] Skip sync for method {method}: invalid NetId(s). WorkableNetId={workableNetId}, WorkerNetId={workerNetId}, Workable={workable.GetProperName()}, Worker={worker.GetProperName()}");
+                return;
+            }
+
+            try
+            {
+                string workableTypeId = GetWorkableTypeId(workable);
+                DebugConsole.Log($"[WorkableSyncer] Sync workable {workableNetId} ({workableTypeId}) with Worker {workerNetId} to {method.ToString()}");
+                syncer.CallCommand(nameof(CmdUpdateWorkable), (byte)method, workableNetId, workableTypeId, workerNetId);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[WorkableSyncer] Failed to request update for method {method}. WorkableNetId={workableNetId}, WorkerNetId={workerNetId}. Error: {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdUpdateWorkable(byte method, int workableNetId, string workableTypeId, int workerNetId)
+        {
+            CallClientRpc(nameof(RpcUpdateWorkable), (MethodType)method, workableNetId, workableTypeId, workerNetId);
+        }
+
+        [ClientRpc]
+        private void RpcUpdateWorkable(MethodType method, int workableNetId, string workableTypeId, int workerNetId)
+        {
+            if (!isClient || !MultiplayerSession.IsClient)
+            {
+                return;
+            }
+
+            if (workableNetId == 0 || !NetworkIdentityRegistry.TryGet(workableNetId, out var identity) || identity == null || identity.gameObject.IsNullOrDestroyed())
+            {
+                return;
+            }
+
+            Workable workable = null;
+            string normalizedTypeId = GetWorkableTypeId(workableTypeId);
+            if (!string.IsNullOrEmpty(normalizedTypeId))
+            {
+                var workableType = ResolveWorkableType(normalizedTypeId);
+                if (workableType == null)
+                {
+                    DebugConsole.LogWarning($"[WorkableSyncer] Could not resolve workable type '{normalizedTypeId}' for netId {workableNetId}");
+                    return;
+                }
+
+                workable = identity.gameObject.GetComponent(workableType) as Workable;
+                if (workable == null)
+                {
+                    DebugConsole.LogWarning($"[WorkableSyncer] GameObject for netId {workableNetId} does not have workable type '{normalizedTypeId}'");
+                    return;
+                }
+            }
+
+            workable ??= identity.gameObject.GetComponent<Workable>();
+            if (workable == null)
+            {
+                return;
+            }
+
+            if (workerNetId == 0 || !NetworkIdentityRegistry.TryGetComponent<WorkerBase>(workerNetId, out var worker) || worker == null || worker.gameObject.IsNullOrDestroyed())
+            {
+                return;
+            }
+
+            workableAuthorization[BuildAuthKey(workableNetId, workableTypeId, method)] = workerNetId;
+
+            DebugConsole.Log($"[WorkableSyncer] Sync workable {workableNetId} ({GetWorkableTypeId(workable)}) with Worker {workerNetId} to {method.ToString()}");
+
+            switch (method)
+            {
+                case MethodType.StartWork:
+                    workable.StartWork(worker);
+                    break;
+                case MethodType.StopWork:
+                    workable.StopWork(worker, false);
+                    break;
+                case MethodType.CompleteWork:
+                    workable.CompleteWork(worker);
+                    break;
+                case MethodType.AbortWork:
+                    workable.StopWork(worker, true);
+                    break;
+                default:
+                    DebugConsole.LogWarning($"[WorkableSyncer] Unknown method name: {method}");
+                    break;
+            }
+        }
+
+        private void Update()
+        {
+            if (!isServer) return;
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/WorkableSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/WorkableSyncer.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
 using System;
 using System.Linq;
-using KSerialization;
 using ONI_Together.DebugTools;
-using ONI_Together.Patches;
 using Shared.OxySync;
 using Shared.OxySync.Attributes;
 using UnityEngine;
@@ -86,11 +84,14 @@ namespace ONI_Together.Networking.OxySync.Components
             base.OnCleanUp();
         }
 
-        public static void RegisterNetId() {
+        public static void RegisterNetId(GameObject parent = null) {
+            var root = parent == null ? Game.Instance.gameObject : parent;
             if (Instance == null)
             {
                 DebugConsole.LogWarning("[WorkableSyncer] Initializing WorkableSyncer instance.");
-                Instance = Game.Instance.gameObject.AddComponent<WorkableSyncer>();
+                var syncerRoot = new GameObject("WorkableSyncer");
+                syncerRoot.transform.SetParent(root.transform);
+                Instance = syncerRoot.AddComponent<WorkableSyncer>();
             }
 
             Instance.workableAuthorization.Clear();

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -4,7 +4,9 @@ using ONI_Together.Menus;
 using ONI_Together.Misc.World;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.OxySync.Components.Tools;
+using ONI_Together.Networking.States;
 using ONI_Together.UI;
 using Shared.Profiling;
 
@@ -70,6 +72,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      WorkableSyncer.RegisterNetId();
     }
   }
 }

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -72,7 +72,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
-      WorkableSyncer.RegisterNetId();
+      WorkableSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/World/WorkablePatch.cs
+++ b/ONI_Together/Patches/World/WorkablePatch.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components;
 using Shared.Profiling;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,6 +11,29 @@ namespace ONI_Together.Patches.World
 {
 	internal class WorkablePatch
 	{
+		private static bool IsAuthorizedForWorker(Workable workable, WorkableSyncer.MethodType method, WorkerBase worker)
+		{
+			using var _ = Profiler.Scope();
+
+			if (!MultiplayerSession.IsClient)
+			{
+				return true;
+			}
+
+			if (!WorkableSyncer.IsAuthorized(workable, method, out int authorizedWorkerNetId))
+			{
+				return false;
+			}
+
+			if (worker == null || worker.IsNullOrDestroyed())
+			{
+				return authorizedWorkerNetId == 0;
+			}
+
+			int incomingWorkerNetId = worker.GetNetId();
+			return authorizedWorkerNetId == incomingWorkerNetId;
+		}
+
 		private static bool TryGetRemotePercent(Component target, RemoteProgressKind progressKind, out float percentComplete)
 		{
 			using var _ = Profiler.Scope();
@@ -53,6 +77,136 @@ namespace ONI_Together.Patches.World
 
 				__result = percentComplete;
 				return false;
+			}
+		}
+
+		[HarmonyPatch(typeof(Workable), nameof(Workable.StartWork))]
+		public class Workable_StartWork_Patch
+		{
+			public static bool Prefix(Workable __instance, out bool __state, ref WorkerBase worker_to_start)
+			{
+				using var _ = Profiler.Scope();
+				__state = true;
+
+				if (__instance.IsNullOrDestroyed())
+				{
+					return true;
+				}
+				
+				// Let the host decide if the work should start when we're a client
+				if (MultiplayerSession.IsClient && !IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.StartWork, worker_to_start))
+				{
+					__state = false;
+					return false;
+				}
+
+				if (MultiplayerSession.IsHostInSession)
+				{
+					WorkableSyncer.RequestUpdateWorkable(WorkableSyncer.MethodType.StartWork, __instance, worker_to_start);
+				}
+
+				return true;
+			}
+			public static void Postfix(Workable __instance, bool __state, ref WorkerBase worker_to_start)
+			{
+				using var _ = Profiler.Scope();
+
+				if (__instance.IsNullOrDestroyed() || !__state)
+					return;
+				
+				if (MultiplayerSession.IsClient && IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.StartWork, worker_to_start))
+				{
+					WorkableSyncer.UnAuthorize(__instance, WorkableSyncer.MethodType.StartWork);
+				}
+			}
+		}
+
+		[HarmonyPatch(typeof(Workable), nameof(Workable.StopWork))]
+		public class Workable_StopWork_Patch
+		{
+			public static bool Prefix(Workable __instance, out bool __state, ref WorkerBase workerToStop, bool aborted)
+			{
+				using var _ = Profiler.Scope();
+				__state = true;
+
+				if (__instance.IsNullOrDestroyed())
+				{
+					return true;
+				}
+
+				// Let the host decide if the work should start when we're a client
+				WorkableSyncer.MethodType method = aborted ? WorkableSyncer.MethodType.AbortWork : WorkableSyncer.MethodType.StopWork;
+				if (MultiplayerSession.IsClient && !IsAuthorizedForWorker(__instance, method, workerToStop))
+				{
+					__state = false;
+					return false;
+				}
+
+				if (MultiplayerSession.IsHostInSession)
+				{
+					WorkableSyncer.RequestUpdateWorkable(method, __instance, workerToStop);
+				}
+
+				return true;
+			}
+
+			public static void Postfix(Workable __instance, bool __state, ref WorkerBase workerToStop, bool aborted)
+			{
+				using var _ = Profiler.Scope();
+
+				if (__instance.IsNullOrDestroyed() || !__state)
+				{
+					return;
+				}
+
+				WorkableSyncer.MethodType method = aborted ? WorkableSyncer.MethodType.AbortWork : WorkableSyncer.MethodType.StopWork;
+				if (MultiplayerSession.IsClient && IsAuthorizedForWorker(__instance, method, workerToStop))
+				{
+					WorkableSyncer.UnAuthorize(__instance, method);
+				}
+			}
+		}
+
+		[HarmonyPatch(typeof(Workable), nameof(Workable.CompleteWork))]
+		public class Workable_CompleteWork_Patch
+		{
+			public static bool Prefix(Workable __instance, out bool __state, ref WorkerBase worker)
+			{
+				using var _ = Profiler.Scope();
+				__state = true;
+
+				if (__instance.IsNullOrDestroyed())
+				{
+					return true;
+				}
+				
+				// Let the host decide if the work should complete when we're a client
+				if (MultiplayerSession.IsClient && !IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.CompleteWork, worker))
+				{
+					__state = false;
+					return false;
+				}
+
+				if (MultiplayerSession.IsHostInSession)
+				{
+					WorkableSyncer.RequestUpdateWorkable(WorkableSyncer.MethodType.CompleteWork, __instance, worker);
+				}
+
+				return true;
+			}
+			public static void Postfix(Workable __instance, bool __state, ref WorkerBase worker)
+			{
+				using var _ = Profiler.Scope();
+
+				if (__instance.IsNullOrDestroyed() || !__state)
+				{
+					return;
+				}
+
+				if (MultiplayerSession.IsClient && IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.CompleteWork, worker))
+				{
+					WorkableSyncer.UnAuthorize(__instance, WorkableSyncer.MethodType.CompleteWork);
+				}
 			}
 		}
 

--- a/ONI_Together/Patches/World/WorkablePatch.cs
+++ b/ONI_Together/Patches/World/WorkablePatch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
 using ONI_Together.Networking.OxySync.Components;
@@ -11,27 +12,50 @@ namespace ONI_Together.Patches.World
 {
 	internal class WorkablePatch
 	{
-		private static bool IsAuthorizedForWorker(Workable workable, WorkableSyncer.MethodType method, WorkerBase worker)
+		private static bool IsAuthorizedToWork(Workable workable, WorkableSyncer.MethodType method, WorkerBase worker, out WorkableSyncer syncer)
 		{
 			using var _ = Profiler.Scope();
 
-			if (!MultiplayerSession.IsClient)
+			syncer = null;
+
+			if (workable == null || workable.IsNullOrDestroyed())
 			{
 				return true;
 			}
 
-			if (!WorkableSyncer.IsAuthorized(workable, method, out int authorizedWorkerNetId))
+			if (worker == null || worker.IsNullOrDestroyed())
 			{
+				return true;
+			}
+
+			if (MultiplayerSession.IsClient)
+			{
+				if (WorkableSyncer.IsAuthorized(workable, method, out var authorizedWokerNetId))
+				{
+					if (worker.GetNetId() == authorizedWokerNetId)
+					{
+						DebugConsole.Log($"[WorkablePatch] Client worker {worker.GetProperName()} is authorized to '{method}' on {workable.GetProperName()}");
+						return true;
+					}
+				}
+
+				// If we're a client and not authorized to work, we should skip the work
 				return false;
 			}
 
-			if (worker == null || worker.IsNullOrDestroyed())
+			if (MultiplayerSession.IsHostInSession && MultiplayerSession.SessionHasPlayers)
 			{
-				return authorizedWorkerNetId == 0;
+				syncer = WorkableSyncer.Instance;
+
+				if (syncer == null)
+				{
+					WorkableSyncer.RegisterNetId();
+					syncer = WorkableSyncer.Instance;
+				}
+
 			}
 
-			int incomingWorkerNetId = worker.GetNetId();
-			return authorizedWorkerNetId == incomingWorkerNetId;
+			return true;
 		}
 
 		private static bool TryGetRemotePercent(Component target, RemoteProgressKind progressKind, out float percentComplete)
@@ -88,22 +112,15 @@ namespace ONI_Together.Patches.World
 				using var _ = Profiler.Scope();
 				__state = true;
 
-				if (__instance.IsNullOrDestroyed())
-				{
-					return true;
-				}
-				
-				// Let the host decide if the work should start when we're a client
-				if (MultiplayerSession.IsClient && !IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.StartWork, worker_to_start))
+				if (!IsAuthorizedToWork(__instance, WorkableSyncer.MethodType.StartWork, worker_to_start, out var syncer))
 				{
 					__state = false;
 					return false;
 				}
 
-				if (MultiplayerSession.IsHostInSession)
-				{
-					WorkableSyncer.RequestUpdateWorkable(WorkableSyncer.MethodType.StartWork, __instance, worker_to_start);
-				}
+				
+				syncer?.RequestUpdateWorkable(WorkableSyncer.MethodType.StartWork, __instance, worker_to_start);
+				
 
 				return true;
 			}
@@ -114,7 +131,7 @@ namespace ONI_Together.Patches.World
 				if (__instance.IsNullOrDestroyed() || !__state)
 					return;
 				
-				if (MultiplayerSession.IsClient && IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.StartWork, worker_to_start))
+				if (MultiplayerSession.IsClient && IsAuthorizedToWork(__instance, WorkableSyncer.MethodType.StartWork, worker_to_start, out var _ignoredWorkerNetId))
 				{
 					WorkableSyncer.UnAuthorize(__instance, WorkableSyncer.MethodType.StartWork);
 				}
@@ -136,16 +153,14 @@ namespace ONI_Together.Patches.World
 
 				// Let the host decide if the work should start when we're a client
 				WorkableSyncer.MethodType method = aborted ? WorkableSyncer.MethodType.AbortWork : WorkableSyncer.MethodType.StopWork;
-				if (MultiplayerSession.IsClient && !IsAuthorizedForWorker(__instance, method, workerToStop))
+				if (!IsAuthorizedToWork(__instance, method, workerToStop, out var syncer))
 				{
 					__state = false;
 					return false;
 				}
 
-				if (MultiplayerSession.IsHostInSession)
-				{
-					WorkableSyncer.RequestUpdateWorkable(method, __instance, workerToStop);
-				}
+				syncer?.RequestUpdateWorkable(method, __instance, workerToStop);
+
 
 				return true;
 			}
@@ -153,14 +168,11 @@ namespace ONI_Together.Patches.World
 			public static void Postfix(Workable __instance, bool __state, ref WorkerBase workerToStop, bool aborted)
 			{
 				using var _ = Profiler.Scope();
-
 				if (__instance.IsNullOrDestroyed() || !__state)
-				{
 					return;
-				}
 
 				WorkableSyncer.MethodType method = aborted ? WorkableSyncer.MethodType.AbortWork : WorkableSyncer.MethodType.StopWork;
-				if (MultiplayerSession.IsClient && IsAuthorizedForWorker(__instance, method, workerToStop))
+				if (MultiplayerSession.IsClient && IsAuthorizedToWork(__instance, method, workerToStop, out var _ignoredWorkerNetId))
 				{
 					WorkableSyncer.UnAuthorize(__instance, method);
 				}
@@ -181,16 +193,13 @@ namespace ONI_Together.Patches.World
 				}
 				
 				// Let the host decide if the work should complete when we're a client
-				if (MultiplayerSession.IsClient && !IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.CompleteWork, worker))
+				if (!IsAuthorizedToWork(__instance, WorkableSyncer.MethodType.CompleteWork, worker, out var syncer))
 				{
 					__state = false;
 					return false;
 				}
 
-				if (MultiplayerSession.IsHostInSession)
-				{
-					WorkableSyncer.RequestUpdateWorkable(WorkableSyncer.MethodType.CompleteWork, __instance, worker);
-				}
+				syncer?.RequestUpdateWorkable(WorkableSyncer.MethodType.CompleteWork, __instance, worker);
 
 				return true;
 			}
@@ -203,7 +212,7 @@ namespace ONI_Together.Patches.World
 					return;
 				}
 
-				if (MultiplayerSession.IsClient && IsAuthorizedForWorker(__instance, WorkableSyncer.MethodType.CompleteWork, worker))
+				if (MultiplayerSession.IsClient && IsAuthorizedToWork(__instance, WorkableSyncer.MethodType.CompleteWork, worker, out var _ignoredWorkerNetId))
 				{
 					WorkableSyncer.UnAuthorize(__instance, WorkableSyncer.MethodType.CompleteWork);
 				}


### PR DESCRIPTION
Origin: Currently, the client has its own schedule to do different work, so the misalignment between the host and the client are growing as time moving.
Edit: Currently, due to the game time mismatch, instructing the duplicants to work in the client would cause the indication on workable mismatch.

This patch skip the clients own work command. Instead, the host will send the work commands to the clients to work.

This fix the issue that the clients always indicting a work not done on some objects, such as the Door (Issue #184).

## Before Fix

https://github.com/user-attachments/assets/4bea3075-cded-4e97-81bb-5f3119078e19


## Result


https://github.com/user-attachments/assets/40123eb1-0915-45bc-b418-de6d528d907e


