### PR TITLE
Fix fail resolve on entity with multiple networkBehaviour

### DIFF
--- a/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
@@ -3,16 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
-using HarmonyLib;
 using ONI_Together.Misc;
 using ONI_Together.Networking;
-using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.OxySync.Packets;
-using ONI_Together.Networking.Packets.Core;
-using ONI_Together.Networking.Packets.Architecture;
-using ONI_Together.Networking.Components;
 using Shared.OxySync;
-using Shared.OxySync.Attributes;
 using UnityEngine;
 
 namespace ONI_Together.DebugTools.UnitTests
@@ -117,6 +111,7 @@ namespace ONI_Together.DebugTools.UnitTests
             var input = new SyncVarPacket
             {
                 NetId = 12345,
+                BehaviourId = 2,
                 FieldHash = "health".GetHashCode(),
                 Value = (Variant)100f,
                 Timestamp = 987654321098L,
@@ -133,6 +128,8 @@ namespace ONI_Together.DebugTools.UnitTests
 
             if (output.NetId != 12345)
                 return UnitTestResult.Fail($"NetId mismatch: {output.NetId}");
+            if (output.BehaviourId != 2)
+                return UnitTestResult.Fail($"BehaviourId mismatch: {output.BehaviourId}");
             if (output.FieldHash != input.FieldHash)
                 return UnitTestResult.Fail("FieldHash mismatch");
             if (Mathf.Abs(output.Value.Float - 100f) > 0.001f)
@@ -154,7 +151,7 @@ namespace ONI_Together.DebugTools.UnitTests
                 ("count".GetHashCode(), (Variant)42),
             };
 
-            var input = new SyncVarBatchPacket(999, updates)
+            var input = new SyncVarBatchPacket(999, 3, updates)
             {
                 Timestamp = 1234567890123L,
             };
@@ -170,6 +167,8 @@ namespace ONI_Together.DebugTools.UnitTests
 
             if (output.NetId != 999)
                 return UnitTestResult.Fail($"NetId mismatch: {output.NetId}");
+            if (output.BehaviourId != 3)
+                return UnitTestResult.Fail($"BehaviourId mismatch: {output.BehaviourId}");
             if (output.Timestamp != 1234567890123L)
                 return UnitTestResult.Fail($"Timestamp mismatch: {output.Timestamp}");
             if (output.Count != 4)
@@ -192,6 +191,7 @@ namespace ONI_Together.DebugTools.UnitTests
             var input = new CommandPacket
             {
                 NetId = 777,
+                BehaviourId = 1,
                 MethodHash = "TakeDamage".GetHashCode(),
                 Args = new byte[] { 0x01, 0x02, 0x03 },
             };
@@ -207,6 +207,8 @@ namespace ONI_Together.DebugTools.UnitTests
 
             if (output.NetId != 777)
                 return UnitTestResult.Fail($"NetId mismatch: {output.NetId}");
+            if (output.BehaviourId != 1)
+                return UnitTestResult.Fail($"BehaviourId mismatch: {output.BehaviourId}");
             if (output.MethodHash != input.MethodHash)
                 return UnitTestResult.Fail("MethodHash mismatch");
             if (output.Args.Length != 3 || output.Args[0] != 0x01)
@@ -221,6 +223,7 @@ namespace ONI_Together.DebugTools.UnitTests
             var input = new ClientRpcPacket
             {
                 NetId = 555,
+                BehaviourId = 2,
                 MethodHash = "RpcHealed".GetHashCode(),
                 Args = new byte[] { 0x0A },
                 TargetPlayerId = ulong.MaxValue,
@@ -237,6 +240,8 @@ namespace ONI_Together.DebugTools.UnitTests
 
             if (output.NetId != 555)
                 return UnitTestResult.Fail($"NetId mismatch: {output.NetId}");
+            if (output.BehaviourId != 2)
+                return UnitTestResult.Fail($"BehaviourId mismatch: {output.BehaviourId}");
             if (output.MethodHash != input.MethodHash)
                 return UnitTestResult.Fail("MethodHash mismatch");
             if (output.Args.Length != 1 || output.Args[0] != 0x0A)
@@ -253,6 +258,7 @@ namespace ONI_Together.DebugTools.UnitTests
             var input = new ClientRpcPacket
             {
                 NetId = 444,
+                BehaviourId = 3,
                 MethodHash = "RpcPrivateMsg".GetHashCode(),
                 Args = Array.Empty<byte>(),
                 TargetPlayerId = 9001,
@@ -267,6 +273,10 @@ namespace ONI_Together.DebugTools.UnitTests
             using (var r = new BinaryReader(ms, Encoding.UTF8, true))
                 output.Deserialize(r);
 
+            if (output.NetId != 444)
+                return UnitTestResult.Fail($"NetId mismatch: {output.NetId}");
+            if (output.BehaviourId != 3)
+                return UnitTestResult.Fail($"BehaviourId mismatch: {output.BehaviourId}");
             if (output.TargetPlayerId != 9001)
                 return UnitTestResult.Fail($"TargetPlayerId mismatch: {output.TargetPlayerId}");
 

--- a/ONI_Together/Networking/OxySync/Components/OxySyncManager.cs
+++ b/ONI_Together/Networking/OxySync/Components/OxySyncManager.cs
@@ -24,7 +24,8 @@ namespace ONI_Together.Networking.OxySync.Components
         private readonly Dictionary<int, HashSet<NetworkBehaviour>> _behavioursByGroup = new();
 
         // NetworkBehaviour fast lookup Dictionary for quick access by NetId and BehaviourId
-        int behaviorIdCounter = 1;
+        private int behaviorIdCounter = 1;
+        private int MaxRegistrationAttempts = 3;
         private readonly Dictionary<(int, int), NetworkBehaviour> _behaviourLookup = new();
 
         private float _tickAccumulator;
@@ -147,11 +148,10 @@ namespace ONI_Together.Networking.OxySync.Components
 			if (!_behaviours.Contains(behaviour))
 				_behaviours.Add(behaviour);
 
-            bool isKeyExists = _behaviourLookup.ContainsKey((behaviour.NetId, behaviour.BehaviourId));
-            if (behaviour.BehaviourId == -1 || isKeyExists)
-                AssignBehaviourId(behaviour);
-            
-            _behaviourLookup[(behaviour.NetId, behaviour.BehaviourId)] = behaviour;
+            if (AssignBehaviourId(behaviour))
+            {
+                _behaviourLookup[(behaviour.NetId, behaviour.BehaviourId)] = behaviour;
+            }
 
 			if (behaviour.GetType().GetCustomAttribute<FixedInterestGroupAttribute>() != null)
 				_explicitGroupTypes.Add(behaviour.GetType());
@@ -432,9 +432,32 @@ namespace ONI_Together.Networking.OxySync.Components
             }
         }
 
-        private void AssignBehaviourId(NetworkBehaviour behaviour)
+        private bool AssignBehaviourId(NetworkBehaviour behaviour)
         {
-            behaviour.BehaviourId = behaviorIdCounter++;
+            int behaviorId = behaviour.BehaviourId;
+            for (int attempts = 0; attempts < MaxRegistrationAttempts; attempts++)
+            {
+                bool isUnassigned = behaviorId == -1;
+                bool isDuplicate = _behaviourLookup.ContainsKey((behaviour.NetId, behaviorId));
+                if (!isUnassigned && !isDuplicate)
+                {
+                    behaviour.BehaviourId = behaviorId;
+                    return true;
+                }
+
+                behaviorId = behaviorIdCounter++;
+            }
+
+            if (!_behaviourLookup.ContainsKey((behaviour.NetId, behaviorId)))
+            {
+                behaviour.BehaviourId = behaviorId;
+                return true;
+            }
+
+            DebugConsole.LogWarning(
+                $"[OxySyncManager] Failed to assign BehaviourId for {behaviour.GetType().Name}" +
+                $" on {behaviour.gameObject.name} after {MaxRegistrationAttempts} attempts.");
+            return false;
         }
     }
 }

--- a/ONI_Together/Networking/OxySync/Components/OxySyncManager.cs
+++ b/ONI_Together/Networking/OxySync/Components/OxySyncManager.cs
@@ -23,12 +23,27 @@ namespace ONI_Together.Networking.OxySync.Components
         private readonly HashSet<Type> _explicitGroupTypes = new();
         private readonly Dictionary<int, HashSet<NetworkBehaviour>> _behavioursByGroup = new();
 
+        // NetworkBehaviour fast lookup Dictionary for quick access by NetId and BehaviourId
+        int behaviorIdCounter = 1;
+        private readonly Dictionary<(int, int), NetworkBehaviour> _behaviourLookup = new();
+
         private float _tickAccumulator;
 
         public int RegisteredCount => _behaviours.Count;
         public IReadOnlyList<NetworkBehaviour> AllBehaviours => _behaviours;
         public static int GetBehaviourCountInGroup(int groupId) =>
             Instance != null && Instance._behavioursByGroup.TryGetValue(groupId, out var set) ? set.Count : 0;
+
+        public static bool TryGet(int NetId, int BehaviourId, out NetworkBehaviour behaviour)
+        {
+            if (Instance == null)
+            {
+                behaviour = null;
+                return false;
+            }
+
+            return Instance._behaviourLookup.TryGetValue((NetId, BehaviourId), out behaviour);
+        }
 
         private void Awake()
         {
@@ -64,22 +79,24 @@ namespace ONI_Together.Networking.OxySync.Components
             NetworkBehaviour.IsClientQuery = () => MultiplayerSession.IsClient;
             NetworkBehaviour.InSessionQuery = () => MultiplayerSession.InActiveSession;
 
-            NetworkBehaviour.SendCommandToHost = (netId, methodHash, args, sendType) =>
+            NetworkBehaviour.SendCommandToHost = (netId, behaviourId, methodHash, args, sendType) =>
             {
                 PacketSender.SendToHost(new CommandPacket
                 {
                     NetId = netId,
+                    BehaviourId = behaviourId,
                     MethodHash = methodHash,
                     Args = args,
                 }, (PacketSendMode)sendType);
                 return true;
             };
 
-            NetworkBehaviour.SendClientRpcToAll = (netId, methodHash, args, sendType) =>
+            NetworkBehaviour.SendClientRpcToAll = (netId, behaviourId, methodHash, args, sendType) =>
             {
                 PacketSender.SendToAllClients(new ClientRpcPacket
                 {
                     NetId = netId,
+                    BehaviourId = behaviourId,
                     MethodHash = methodHash,
                     Args = args,
                     TargetPlayerId = ulong.MaxValue,
@@ -87,11 +104,12 @@ namespace ONI_Together.Networking.OxySync.Components
                 return true;
             };
 
-            NetworkBehaviour.SendClientRpcToGroup = (group, netId, methodHash, args, sendType) =>
+            NetworkBehaviour.SendClientRpcToGroup = (group, netId, behaviourId, methodHash, args, sendType) =>
             {
                 PacketSender.SendToGroup(group, new ClientRpcPacket
                 {
                     NetId = netId,
+                    BehaviourId = behaviourId,
                     MethodHash = methodHash,
                     Args = args,
                     TargetPlayerId = ulong.MaxValue,
@@ -101,11 +119,12 @@ namespace ONI_Together.Networking.OxySync.Components
 
             NetworkBehaviour.LocalUserIdQuery = () => MultiplayerSession.LocalUserID;
 
-            NetworkBehaviour.SendTargetRpcToPlayer = (targetPlayer, netId, methodHash, args, sendType) =>
+            NetworkBehaviour.SendTargetRpcToPlayer = (targetPlayer, netId, behaviourId, methodHash, args, sendType) =>
             {
                 PacketSender.SendToPlayer(targetPlayer, new ClientRpcPacket
                 {
                     NetId = netId,
+                    BehaviourId = behaviourId,
                     MethodHash = methodHash,
                     Args = args,
                     TargetPlayerId = targetPlayer,
@@ -128,6 +147,12 @@ namespace ONI_Together.Networking.OxySync.Components
 			if (!_behaviours.Contains(behaviour))
 				_behaviours.Add(behaviour);
 
+            bool isKeyExists = _behaviourLookup.ContainsKey((behaviour.NetId, behaviour.BehaviourId));
+            if (behaviour.BehaviourId == -1 || isKeyExists)
+                AssignBehaviourId(behaviour);
+            
+            _behaviourLookup[(behaviour.NetId, behaviour.BehaviourId)] = behaviour;
+
 			if (behaviour.GetType().GetCustomAttribute<FixedInterestGroupAttribute>() != null)
 				_explicitGroupTypes.Add(behaviour.GetType());
 
@@ -145,6 +170,8 @@ namespace ONI_Together.Networking.OxySync.Components
         private void Unregister(NetworkBehaviour behaviour)
         {
             _behaviours.Remove(behaviour);
+
+            _behaviourLookup.Remove((behaviour.NetId, behaviour.BehaviourId));
 
             RemoveBehaviourFromGroupIndex(behaviour, behaviour.InterestGroup);
             var fields = behaviour.SyncVarFields;
@@ -196,6 +223,7 @@ namespace ONI_Together.Networking.OxySync.Components
                     continue;
 
                 int netId = identity.NetId;
+                int behaviourId = behaviour.BehaviourId;
                 long timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
                 foreach (var kvp in _changedByGroup)
@@ -211,6 +239,7 @@ namespace ONI_Together.Networking.OxySync.Components
                         PacketSender.SendToGroup(groupId, new SyncVarPacket
                         {
                             NetId = netId,
+                            BehaviourId = behaviourId,
                             FieldHash = update.Hash,
                             Value = update.Value,
                             Timestamp = timestamp,
@@ -218,7 +247,7 @@ namespace ONI_Together.Networking.OxySync.Components
                     }
                     else
                     {
-                        var batch = new SyncVarBatchPacket(netId, updates)
+						var batch = new SyncVarBatchPacket(netId, behaviourId, updates)
                         {
                             Timestamp = timestamp,
                         };
@@ -361,6 +390,7 @@ namespace ONI_Together.Networking.OxySync.Components
 
                 int netId = behaviour.NetId;
                 if (netId == 0) continue;
+                int behaviourId = behaviour.BehaviourId;
 
                 var fields = behaviour.SyncVarFields;
                 if (fields.Count == 0) continue;
@@ -386,6 +416,7 @@ namespace ONI_Together.Networking.OxySync.Components
                     PacketSender.SendToPlayer(playerId, new SyncVarPacket
                     {
                         NetId = netId,
+                        BehaviourId = behaviourId,
                         FieldHash = update.Hash,
                         Value = update.Value,
                         Timestamp = timestamp,
@@ -393,12 +424,17 @@ namespace ONI_Together.Networking.OxySync.Components
                 }
                 else
                 {
-                    PacketSender.SendToPlayer(playerId, new SyncVarBatchPacket(netId, updates)
+					PacketSender.SendToPlayer(playerId, new SyncVarBatchPacket(netId, behaviourId, updates)
                     {
                         Timestamp = timestamp,
                     }, PacketSendMode.ReliableImmediate);
                 }
             }
+        }
+
+        private void AssignBehaviourId(NetworkBehaviour behaviour)
+        {
+            behaviour.BehaviourId = behaviorIdCounter++;
         }
     }
 }

--- a/ONI_Together/Networking/OxySync/Packets/ClientRpcPacket.cs
+++ b/ONI_Together/Networking/OxySync/Packets/ClientRpcPacket.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.Packets.Architecture;
 using Shared.OxySync;
 using Shared.Profiling;
@@ -10,6 +11,7 @@ namespace ONI_Together.Networking.OxySync.Packets
     public class ClientRpcPacket : IPacket
     {
         public int NetId;
+        public int BehaviourId;
         public int MethodHash;
         public byte[] Args;
         public ulong TargetPlayerId;
@@ -23,6 +25,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(NetId);
+            writer.Write(BehaviourId);
             writer.Write(MethodHash);
             writer.Write(Args.Length);
             writer.Write(Args);
@@ -32,6 +35,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Deserialize(BinaryReader reader)
         {
             NetId = reader.ReadInt32();
+            BehaviourId = reader.ReadInt32();
             MethodHash = reader.ReadInt32();
             int len = reader.ReadInt32();
             Args = reader.ReadBytes(len);
@@ -47,7 +51,9 @@ namespace ONI_Together.Networking.OxySync.Packets
             if (TargetPlayerId != ulong.MaxValue && TargetPlayerId != MultiplayerSession.LocalUserID)
                 return;
 
-            if (!NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out var behaviour))
+            OxySyncManager.TryGet(NetId, BehaviourId, out NetworkBehaviour behaviour);
+            
+            if (behaviour == null &&  !NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out behaviour))
                 return;
 
             behaviour.InvokeClientRpc(MethodHash, Args);

--- a/ONI_Together/Networking/OxySync/Packets/CommandPacket.cs
+++ b/ONI_Together/Networking/OxySync/Packets/CommandPacket.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.Packets.Architecture;
 using Shared.OxySync;
 using Shared.Profiling;
@@ -10,6 +11,7 @@ namespace ONI_Together.Networking.OxySync.Packets
     public class CommandPacket : IPacket
     {
         public int NetId;
+        public int BehaviourId;
         public int MethodHash;
         public byte[] Args;
 
@@ -21,6 +23,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(NetId);
+            writer.Write(BehaviourId);
             writer.Write(MethodHash);
             writer.Write(Args.Length);
             writer.Write(Args);
@@ -29,6 +32,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Deserialize(BinaryReader reader)
         {
             NetId = reader.ReadInt32();
+            BehaviourId = reader.ReadInt32();
             MethodHash = reader.ReadInt32();
             int len = reader.ReadInt32();
             Args = reader.ReadBytes(len);
@@ -40,7 +44,9 @@ namespace ONI_Together.Networking.OxySync.Packets
 
             if (!MultiplayerSession.IsHost) return;
 
-            if (!NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out var behaviour))
+            OxySyncManager.TryGet(NetId, BehaviourId, out NetworkBehaviour behaviour);
+
+            if (behaviour == null && !NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out behaviour))
                 return;
 
             behaviour.InvokeCommand(MethodHash, Args);

--- a/ONI_Together/Networking/OxySync/Packets/SyncVarBatchPacket.cs
+++ b/ONI_Together/Networking/OxySync/Packets/SyncVarBatchPacket.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using ONI_Together.Misc;
-using ONI_Together.Networking;
-using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.Packets.Architecture;
 using Shared.OxySync;
 using Shared.Profiling;
@@ -12,6 +11,7 @@ namespace ONI_Together.Networking.OxySync.Packets
     public class SyncVarBatchPacket : IPacket
     {
         public int NetId;
+        public int BehaviourId;
         public int Count;
         public int[] FieldHashes;
         public Variant[] Values;
@@ -23,9 +23,10 @@ namespace ONI_Together.Networking.OxySync.Packets
             Values = System.Array.Empty<Variant>();
         }
 
-        public SyncVarBatchPacket(int netId, List<(int Hash, Variant Value)> updates)
+        public SyncVarBatchPacket(int netId, int behaviourId, List<(int Hash, Variant Value)> updates)
         {
             NetId = netId;
+            BehaviourId = behaviourId;
             Count = updates.Count;
             FieldHashes = new int[updates.Count];
             Values = new Variant[updates.Count];
@@ -39,6 +40,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(NetId);
+            writer.Write(BehaviourId);
             writer.Write(Timestamp);
             writer.Write(Count);
             for (int i = 0; i < Count; i++)
@@ -51,6 +53,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Deserialize(BinaryReader reader)
         {
             NetId = reader.ReadInt32();
+            BehaviourId = reader.ReadInt32();
             Timestamp = reader.ReadInt64();
             Count = reader.ReadInt32();
             FieldHashes = new int[Count];
@@ -68,7 +71,9 @@ namespace ONI_Together.Networking.OxySync.Packets
 
             if (MultiplayerSession.IsHost) return;
 
-            if (!NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out var behaviour))
+            OxySyncManager.TryGet(NetId, BehaviourId, out NetworkBehaviour behaviour);
+
+            if (behaviour == null && !NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out behaviour))
                 return;
 
             var fields = behaviour.SyncVarFields;

--- a/ONI_Together/Networking/OxySync/Packets/SyncVarPacket.cs
+++ b/ONI_Together/Networking/OxySync/Packets/SyncVarPacket.cs
@@ -2,6 +2,7 @@ using System.IO;
 using ONI_Together.Misc;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.Packets.Architecture;
 using Shared.OxySync;
 using Shared.Profiling;
@@ -12,6 +13,7 @@ namespace ONI_Together.Networking.OxySync.Packets
     public class SyncVarPacket : IPacket
     {
         public int NetId;
+        public int BehaviourId;
         public int FieldHash;
         public Variant Value;
         public long Timestamp;
@@ -19,6 +21,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(NetId);
+            writer.Write(BehaviourId);
             writer.Write(FieldHash);
             Value.Write(writer);
             writer.Write(Timestamp);
@@ -27,6 +30,7 @@ namespace ONI_Together.Networking.OxySync.Packets
         public void Deserialize(BinaryReader reader)
         {
             NetId = reader.ReadInt32();
+            BehaviourId = reader.ReadInt32();
             FieldHash = reader.ReadInt32();
             Value = Variant.Read(reader);
             Timestamp = reader.ReadInt64();
@@ -38,7 +42,9 @@ namespace ONI_Together.Networking.OxySync.Packets
 
             if (MultiplayerSession.IsHost) return;
 
-            if (!NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out var behaviour))
+            OxySyncManager.TryGet(NetId, BehaviourId, out NetworkBehaviour behaviour);
+
+            if (behaviour == null && !NetworkIdentityRegistry.TryGetComponent<NetworkBehaviour>(NetId, out behaviour))
                 return;
 
             var fields = behaviour.SyncVarFields;

--- a/Shared/OxySync/NetworkBehaviour.cs
+++ b/Shared/OxySync/NetworkBehaviour.cs
@@ -17,10 +17,10 @@ namespace Shared.OxySync
         public static Func<bool>? IsClientQuery;
         public static Func<bool>? InSessionQuery;
 
-        public static Func<int, int, byte[], int, bool>? SendCommandToHost;
-        public static Func<int, int, byte[], int, bool>? SendClientRpcToAll;
-        public static Func<int, int, int, byte[], int, bool>? SendClientRpcToGroup;
-        public static Func<ulong, int, int, byte[], int, bool>? SendTargetRpcToPlayer;
+        public static Func<int, int, int, byte[], int, bool>? SendCommandToHost;
+        public static Func<int, int, int, byte[], int, bool>? SendClientRpcToAll;
+        public static Func<int, int, int, int, byte[], int, bool>? SendClientRpcToGroup;
+        public static Func<ulong, int, int, int, byte[], int, bool>? SendTargetRpcToPlayer;
 
         public static Func<NetworkBehaviour, int>? NetIdQuery;
         public static Action<NetworkBehaviour, int>? NetIdSetter;
@@ -48,6 +48,7 @@ namespace Shared.OxySync
         public float _lastSyncTime;
         public float _lastActiveSyncTime;
         public int InterestGroup { get; set; } = -1;
+        public int BehaviourId { get; set; } = -1;
 
         public IReadOnlyList<SyncVarField> SyncVarFields =>
             _syncVarFields ?? (IReadOnlyList<SyncVarField>)Array.Empty<SyncVarField>();
@@ -262,7 +263,7 @@ namespace Shared.OxySync
             }
 
             var sendMode = GetCommandSendMode(hash);
-            SendCommandToHost?.Invoke(NetId, hash, serialized, sendMode);
+            SendCommandToHost?.Invoke(NetId, BehaviourId, hash, serialized, sendMode);
         }
 
         protected void CallCommand(Expression<Action> expr)
@@ -311,9 +312,9 @@ namespace Shared.OxySync
             if (group == -1) group = InterestGroup;
             var sendMode = GetClientRpcSendMode(hash);
             if (group == -1)
-                SendClientRpcToAll?.Invoke(NetId, hash, serialized, sendMode);
+                SendClientRpcToAll?.Invoke(NetId, BehaviourId, hash, serialized, sendMode);
             else
-                SendClientRpcToGroup?.Invoke(group, NetId, hash, serialized, sendMode);
+                SendClientRpcToGroup?.Invoke(group, NetId, BehaviourId, hash, serialized, sendMode);
 
             if (GetClientRpcIncludeHost(hash))
                 InvokeClientRpc(hash, serialized);
@@ -347,9 +348,9 @@ namespace Shared.OxySync
 
             var sendMode = GetClientRpcSendMode(hash);
             if (interestGroup == -1)
-                SendClientRpcToAll?.Invoke(NetId, hash, serialized, sendMode);
+                SendClientRpcToAll?.Invoke(NetId, BehaviourId, hash, serialized, sendMode);
             else
-                SendClientRpcToGroup?.Invoke(interestGroup, NetId, hash, serialized, sendMode);
+                SendClientRpcToGroup?.Invoke(interestGroup, NetId, BehaviourId, hash, serialized, sendMode);
 
             if (GetClientRpcIncludeHost(hash))
                 InvokeClientRpc(hash, serialized);
@@ -382,7 +383,7 @@ namespace Shared.OxySync
             var serialized = RpcSerializer.Serialize(args, argTypes);
 
             var sendMode = GetTargetRpcSendMode(hash);
-            SendTargetRpcToPlayer?.Invoke(targetPlayer, NetId, hash, serialized, sendMode);
+            SendTargetRpcToPlayer?.Invoke(targetPlayer, NetId, BehaviourId, hash, serialized, sendMode);
         }
 
         protected void CallTargetRpc(ulong targetPlayer, Expression<Action> expr)


### PR DESCRIPTION
# Problem
When Multiple `NetworkBehaviour` attached to a `GameObject`, all will resolve incorrectly except the first one.

# Cause
`OnDispetch` function use `NetworkIdentityRegistry.TryGetComponent` to get the behaviour. However, it will return the first hit.
For example, Both `OxyEntityPosition` and `VitalStatus` are added to a base minion, when Vital Status send an RPC, `OnDispetch`  would get the OxyEntityPosition component by using the NetId, and so fail to resolve the method by using the method hash.

# Solution
Add a `BehaviourID` into the `NetworkBehaviour`. Since this alpha design allow any class to modify without guard, I use it with the `netId` together as the unique key, and made a dictionary for the fast lookup.
Existing method, using `NetId` alone, still there as a fallback, In case of the `NetId`  overriding. In this case, we can try our luck to get the right `NetworkBehaviour` on resolving step.