### PR TITLE
Chunk oversized LiteNetLib payloads instead of dropping them

### DIFF
--- a/ONI_Together/Networking/Components/ConduitFlowSyncer.cs
+++ b/ONI_Together/Networking/Components/ConduitFlowSyncer.cs
@@ -22,8 +22,9 @@ namespace ONI_Together.Networking.Components
 	//   seconds so dropped unreliable packets self-heal. Mirrors the
 	//   BuildingSyncer "full-state, unreliable, periodic" pattern called out
 	//   in oni-architecture.md.
-	// - Per-packet update cap chosen to keep on-wire size under Steam P2P's
-	//   ~1200 byte MTU for unreliable, so fragmentation does not amplify drops.
+	// - Per-packet update cap sized to the smallest payload budget across the
+	//   transports that enforce one, so fragmentation does not amplify drops.
+	//   See MAX_UPDATES_PER_PACKET.
 	// - Solid rails are out of scope for this iteration: SolidConduitFlow
 	//   contents reference a host-local pickupable handle that does not
 	//   round-trip through serialisation.
@@ -34,9 +35,12 @@ namespace ONI_Together.Networking.Components
 		private const float SYNC_INTERVAL = 1.5f;        // delta cadence — matches WorldStateSyncer.GAS_SYNC_INTERVAL
 		private const float FORCE_REFRESH_INTERVAL = 4.5f; // full re-emit cadence; 3x delta is the smallest spacing that does not duplicate the delta tick
 		private const float INITIAL_DELAY = 5f;
-		// 31 bytes/update including visual flow direction/element/mass. 35 updates
-		// remain below Steam P2P's ~1200 byte unreliable MTU.
-		private const int MAX_UPDATES_PER_PACKET = 35;
+		// 31 bytes/update including visual flow direction/element/mass, plus a 4 byte packet
+		// id and a 4 byte count. 31 updates = 969 bytes, inside the 1000 byte budget the
+		// Riptide and LiteNetLib senders enforce; the old 35 came to 1093 and overran it.
+		// Staying under the budget beats chunking here: these sends are unreliable, so
+		// losing one chunk wastes the whole batch and leaves a partial reassembly pending.
+		private const int MAX_UPDATES_PER_PACKET = 31;
 		private const float MASS_THRESHOLD = 0.01f;      // 10 g
 		private const float TEMP_THRESHOLD = 0.5f;       // 0.5 K
 

--- a/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibPacketSender.cs
+++ b/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibPacketSender.cs
@@ -1,6 +1,7 @@
 using LiteNetLib;
 using ONI_Together.DebugTools;
 using ONI_Together.Networking.Packets.Architecture;
+using ONI_Together.Networking.Packets.Core;
 using Shared.Profiling;
 using System;
 
@@ -8,6 +9,10 @@ namespace ONI_Together.Networking.Transport.Lan
 {
     public class LiteNetLibPacketSender : TransportPacketSender
     {
+        // Same payload budget RiptidePacketSender enforces, kept in step with it so a batch
+        // sized for one LAN transport is not oversized on the other.
+        private const int MAX_PAYLOAD_BYTES = 1000;
+
         public override bool SendPacket(object conn, IPacket packet, PacketSendMode sendType = PacketSendMode.ReliableImmediate)
         {
             using var _ = Profiler.Scope();
@@ -19,6 +24,24 @@ namespace ONI_Together.Networking.Transport.Lan
                 return false;
 
             byte[] bytes = PacketSender.SerializePacketForSending(packet);
+
+            // ConvertSendType only ever yields Unreliable or ReliableOrdered. ReliableOrdered
+            // fragments on its own, but Unreliable is single-datagram: an oversized payload
+            // throws out of peer.Send instead of being split, so the packet is lost and only
+            // SendRaw's catch records it. The batching senders are the ones that hit it, since
+            // aggregating is exactly what pushes a payload past one datagram. Chunk for both
+            // methods the way the Riptide sender does - one path is simpler than two, and the
+            // reliable case is already within the same budget.
+            if (bytes.Length > MAX_PAYLOAD_BYTES && packet is not ChunkedPacket)
+            {
+                return SendChunked(peer, bytes, sendType);
+            }
+
+            return SendRaw(peer, bytes, packet, sendType);
+        }
+
+        private bool SendRaw(NetPeer peer, byte[] bytes, IPacket packet, PacketSendMode sendType)
+        {
             DeliveryMethod deliveryMethod = ConvertSendType(sendType, packet);
 
             try
@@ -35,9 +58,42 @@ namespace ONI_Together.Networking.Transport.Lan
             }
             catch (Exception ex)
             {
-                DebugConsole.LogError("[LiteNetLibPacketSender] Failed to send packet: " + ex.Message);
+                // Name the packet and its size: the previous message carried neither, so the
+                // only way to find out what was being dropped was to read every call site.
+                DebugConsole.LogError(
+                    $"[LiteNetLibPacketSender] Failed to send {packet.GetType().Name} " +
+                    $"({bytes.Length} bytes, {deliveryMethod}): {ex.Message}");
                 return false;
             }
+        }
+
+        private bool SendChunked(NetPeer peer, byte[] fullData, PacketSendMode sendType)
+        {
+            int chunkDataSize = MAX_PAYLOAD_BYTES - 20; // overhead for ChunkedPacket header
+            int totalChunks = (fullData.Length + chunkDataSize - 1) / chunkDataSize;
+            int sequenceId = ChunkedPacket.GetNextSequenceId();
+
+            for (int i = 0; i < totalChunks; i++)
+            {
+                int offset = i * chunkDataSize;
+                int length = Math.Min(chunkDataSize, fullData.Length - offset);
+                byte[] chunkData = new byte[length];
+                Array.Copy(fullData, offset, chunkData, 0, length);
+
+                var chunk = new ChunkedPacket
+                {
+                    SequenceId = sequenceId,
+                    ChunkIndex = i,
+                    TotalChunks = totalChunks,
+                    ChunkData = chunkData
+                };
+
+                byte[] chunkBytes = PacketSender.SerializePacketForSending(chunk);
+                if (!SendRaw(peer, chunkBytes, chunk, sendType))
+                    return false;
+            }
+
+            return true;
         }
 
         private static DeliveryMethod ConvertSendType(PacketSendMode sendType, IPacket packet)


### PR DESCRIPTION
`ConvertSendType` only ever yields `Unreliable` or `ReliableOrdered`. `ReliableOrdered` fragments on its own, but `Unreliable` is single-datagram, so an oversized payload throws out of `peer.Send` and the packet is lost. This chunks oversized payloads the way the Riptide sender does, and sizes the conduit batch to the same budget.

## Changes
- Chunk payloads over 1000 bytes in `LiteNetLibPacketSender` for both delivery methods, using the same budget as `RiptidePacketSender`. The send splits into `SendRaw` and `SendChunked`; already-chunked packets skip the chunking path.
- Name the packet type, byte length and delivery method in the send failure log instead of only the exception message.
- Drop `MAX_UPDATES_PER_PACKET` in `ConduitFlowSyncer` from 35 to 31: 35 updates came to 1093 bytes and crossed the budget, 31 come to 969. The comments now point at that budget rather than Steam P2P's MTU.

## Testing
Only the byte-size arithmetic against the 1000 byte budget (1093 vs 969). No runtime session test is recorded in the commit.