### PR TITLE
Harden chunked packet reassembly and cover it with tests

### DIFF
--- a/ONI_Together/DebugTools/UnitTests/ChunkedPacketTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/ChunkedPacketTests.cs
@@ -1,0 +1,176 @@
+using System;
+using ONI_Together.Networking;
+using ONI_Together.Networking.Packets.Architecture;
+using ONI_Together.Networking.Packets.Core;
+
+namespace ONI_Together.DebugTools.UnitTests
+{
+	/// <summary>
+	/// The chunking path is the one piece of the LiteNetLib payload-budget work that has never
+	/// executed: the conduit batch was trimmed to fit inside the budget, so nothing has yet
+	/// crossed it in a live session, and SendChunked logs nothing - "no chunk lines in the log"
+	/// is equally consistent with "never ran" and "ran every tick".
+	///
+	/// These drive the real reassembly (ChunkedPacket.TryReassemble, the same call OnDispatched
+	/// makes) rather than a copy of the join loop, so they cover the split arithmetic, the
+	/// per-chunk serialisation and the pending-set bookkeeping without needing a socket.
+	/// </summary>
+	public static class ChunkedPacketTests
+	{
+		// Mirrors LiteNetLibPacketSender/RiptidePacketSender: MAX_PAYLOAD_BYTES - header room.
+		private const int CHUNK_DATA_SIZE = 1000 - 20;
+
+		private static byte[] MakePayload(int length)
+		{
+			var data = new byte[length];
+			for (int i = 0; i < length; i++)
+				data[i] = (byte)(i * 31 + (i >> 8));
+
+			return data;
+		}
+
+		/// <summary>
+		/// Split exactly the way SendChunked does, then push every piece through a
+		/// serialise/deserialise round trip so the wire format is exercised too.
+		/// </summary>
+		private static ChunkedPacket[] SplitAndRoundTrip(byte[] payload, int sequenceId)
+		{
+			int totalChunks = (payload.Length + CHUNK_DATA_SIZE - 1) / CHUNK_DATA_SIZE;
+			var packets = new ChunkedPacket[totalChunks];
+
+			for (int i = 0; i < totalChunks; i++)
+			{
+				int offset = i * CHUNK_DATA_SIZE;
+				int length = Math.Min(CHUNK_DATA_SIZE, payload.Length - offset);
+				var chunkData = new byte[length];
+				Array.Copy(payload, offset, chunkData, 0, length);
+
+				var sent = new ChunkedPacket
+				{
+					SequenceId = sequenceId,
+					ChunkIndex = i,
+					TotalChunks = totalChunks,
+					ChunkData = chunkData
+				};
+
+				byte[] wire = PacketSender.SerializePacketForSending(sent);
+
+				// Skip the 4 byte packet id the sender prepends; Deserialize starts after it.
+				using var stream = new System.IO.MemoryStream(wire, 4, wire.Length - 4);
+				using var reader = new System.IO.BinaryReader(stream);
+
+				var received = new ChunkedPacket();
+				received.Deserialize(reader);
+				packets[i] = received;
+			}
+
+			return packets;
+		}
+
+		[UnitTest(name: "Chunking: an oversized payload survives split and reassembly", category: "Transport")]
+		public static UnitTestResult OversizedPayloadRoundTrips()
+		{
+			ChunkedPacket.ResetPending();
+
+			// 2600 bytes over a 980 byte chunk = 3 pieces with a deliberately short last one,
+			// which is where an off-by-one in the split would show up.
+			byte[] payload = MakePayload(2600);
+			var chunks = SplitAndRoundTrip(payload, 9001);
+
+			if (chunks.Length != 3)
+				return UnitTestResult.Fail($"Expected 3 chunks for 2600 bytes, got {chunks.Length}");
+
+			byte[] reassembled = null;
+			for (int i = 0; i < chunks.Length; i++)
+			{
+				bool complete = ChunkedPacket.TryReassemble(
+					chunks[i].SequenceId, chunks[i].ChunkIndex, chunks[i].TotalChunks, chunks[i].ChunkData,
+					out var result);
+
+				if (complete && i != chunks.Length - 1)
+					return UnitTestResult.Fail($"Reassembly reported complete at chunk {i} of {chunks.Length}");
+
+				if (complete)
+					reassembled = result;
+			}
+
+			if (reassembled == null)
+				return UnitTestResult.Fail("Reassembly never completed");
+
+			if (reassembled.Length != payload.Length)
+				return UnitTestResult.Fail($"Reassembled {reassembled.Length} bytes, expected {payload.Length}");
+
+			for (int i = 0; i < payload.Length; i++)
+			{
+				if (reassembled[i] != payload[i])
+					return UnitTestResult.Fail($"Payload differs at byte {i}: {reassembled[i]} != {payload[i]}");
+			}
+
+			return UnitTestResult.Pass($"{payload.Length} bytes survived {chunks.Length} chunks byte for byte");
+		}
+
+		[UnitTest(name: "Chunking: chunks arriving out of order still reassemble", category: "Transport")]
+		public static UnitTestResult OutOfOrderChunksReassemble()
+		{
+			ChunkedPacket.ResetPending();
+
+			// Both LAN senders can emit chunks unreliably, so arrival order is not guaranteed.
+			byte[] payload = MakePayload(3500);
+			var chunks = SplitAndRoundTrip(payload, 9002);
+
+			byte[] reassembled = null;
+			for (int i = chunks.Length - 1; i >= 0; i--)
+			{
+				if (ChunkedPacket.TryReassemble(
+					chunks[i].SequenceId, chunks[i].ChunkIndex, chunks[i].TotalChunks, chunks[i].ChunkData,
+					out var result))
+				{
+					reassembled = result;
+				}
+			}
+
+			if (reassembled == null)
+				return UnitTestResult.Fail("Reverse-order delivery never completed");
+
+			if (reassembled.Length != payload.Length)
+				return UnitTestResult.Fail($"Reassembled {reassembled.Length} bytes, expected {payload.Length}");
+
+			for (int i = 0; i < payload.Length; i++)
+			{
+				if (reassembled[i] != payload[i])
+					return UnitTestResult.Fail($"Payload differs at byte {i} after reverse-order delivery");
+			}
+
+			return UnitTestResult.Pass("Reverse-order chunks reassemble in the original order");
+		}
+
+		[UnitTest(name: "Chunking: a corrupt header is rejected, not thrown on", category: "Transport")]
+		public static UnitTestResult CorruptHeaderIsRejected()
+		{
+			ChunkedPacket.ResetPending();
+
+			var data = new byte[16];
+
+			if (ChunkedPacket.TryReassemble(9100, 0, 0, data, out _))
+				return UnitTestResult.Fail("TotalChunks = 0 was accepted");
+
+			if (ChunkedPacket.TryReassemble(9101, 0, -5, data, out _))
+				return UnitTestResult.Fail("A negative TotalChunks was accepted");
+
+			if (ChunkedPacket.TryReassemble(9102, 0, int.MaxValue, data, out _))
+				return UnitTestResult.Fail("An absurd TotalChunks was accepted - that sizes an allocation");
+
+			// The one that used to throw IndexOutOfRangeException straight out of the handler.
+			if (ChunkedPacket.TryReassemble(9103, 7, 3, data, out _))
+				return UnitTestResult.Fail("A ChunkIndex past TotalChunks was accepted");
+
+			if (ChunkedPacket.TryReassemble(9104, -1, 3, data, out _))
+				return UnitTestResult.Fail("A negative ChunkIndex was accepted");
+
+			if (ChunkedPacket.TryReassemble(9105, 0, 2, null, out _))
+				return UnitTestResult.Fail("A null chunk body was accepted");
+
+			return UnitTestResult.Pass("Corrupt chunk headers are rejected without throwing");
+		}
+	}
+}

--- a/ONI_Together/Networking/Packets/Core/ChunkedPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ChunkedPacket.cs
@@ -11,7 +11,21 @@ namespace ONI_Together.Networking.Packets.Core
 		public int TotalChunks;
 		public byte[] ChunkData;
 
+		// A 1000 byte budget over a 512 KB save chunk is ~530 pieces; anything past this is a
+		// corrupt header rather than a real message.
+		private const int MAX_CHUNKS_PER_MESSAGE = 4096;
+
+		private const float PENDING_CHUNK_TIMEOUT_SECONDS = 30f;
+
 		private static Dictionary<int, byte[][]> _pendingChunks = new Dictionary<int, byte[][]>();
+		private static Dictionary<int, float> _pendingStartedAt = new Dictionary<int, float>();
+		private static List<int> _stalePending = new List<int>();
+
+		// NOTE: the pending map is keyed on SequenceId alone, and every peer runs its own
+		// counter from 0 - so on a host receiving chunked messages from two clients at once,
+		// their sequence ids collide and the two payloads corrupt each other. Fixing it needs
+		// a sender id on the wire (PacketHandler.HandleIncoming takes only bytes and has no
+		// notion of who sent them), which is a protocol change and out of scope here.
 		private static int _nextSequenceId = 0;
 
 		public ChunkedPacket() { }
@@ -36,29 +50,53 @@ namespace ONI_Together.Networking.Packets.Core
 
 		public void OnDispatched()
 		{
-			if (!_pendingChunks.TryGetValue(SequenceId, out var chunks))
+			if (TryReassemble(SequenceId, ChunkIndex, TotalChunks, ChunkData, out byte[] fullData))
+				PacketHandler.HandleIncoming(fullData);
+		}
+
+		/// <summary>
+		/// Accumulate one chunk and hand back the original payload once the set is complete.
+		/// Separated from <see cref="OnDispatched"/> so the reassembly can be exercised without
+		/// dispatching a packet - a test that reimplements the join would only be testing its
+		/// own copy of it.
+		/// </summary>
+		internal static bool TryReassemble(int sequenceId, int chunkIndex, int totalChunks, byte[] chunkData, out byte[] fullData)
+		{
+			fullData = null;
+
+			// The header arrives off the wire, so treat it as hostile: a corrupt or malicious
+			// TotalChunks would otherwise size an allocation, and a ChunkIndex outside it would
+			// throw out of a packet handler.
+			if (totalChunks <= 0 || totalChunks > MAX_CHUNKS_PER_MESSAGE)
+				return false;
+
+			if (chunkIndex < 0 || chunkIndex >= totalChunks || chunkData == null)
+				return false;
+
+			DropStalePending();
+
+			if (!_pendingChunks.TryGetValue(sequenceId, out var chunks) || chunks.Length != totalChunks)
 			{
-				chunks = new byte[TotalChunks][];
-				_pendingChunks[SequenceId] = chunks;
+				chunks = new byte[totalChunks][];
+				_pendingChunks[sequenceId] = chunks;
 			}
 
-			chunks[ChunkIndex] = ChunkData;
-
-			for (int i = 0; i < TotalChunks; i++)
-			{
-				if (chunks[i] == null)
-					return;
-			}
-
-			_pendingChunks.Remove(SequenceId);
+			chunks[chunkIndex] = chunkData;
+			_pendingStartedAt[sequenceId] = UnityEngine.Time.unscaledTime;
 
 			int totalSize = 0;
-			foreach (var chunk in chunks)
+			for (int i = 0; i < totalChunks; i++)
 			{
-				totalSize += chunk.Length;
+				if (chunks[i] == null)
+					return false;
+
+				totalSize += chunks[i].Length;
 			}
 
-			byte[] fullData = new byte[totalSize];
+			_pendingChunks.Remove(sequenceId);
+			_pendingStartedAt.Remove(sequenceId);
+
+			fullData = new byte[totalSize];
 			int offset = 0;
 			foreach (var chunk in chunks)
 			{
@@ -66,7 +104,40 @@ namespace ONI_Together.Networking.Packets.Core
 				offset += chunk.Length;
 			}
 
-			PacketHandler.HandleIncoming(fullData);
+			return true;
+		}
+
+		/// <summary>
+		/// Chunked sends inherit the delivery method of the message they carry, so an
+		/// unreliable batch that loses one chunk never completes. Without this the partial
+		/// set stays in the map for the rest of the session.
+		/// </summary>
+		private static void DropStalePending()
+		{
+			if (_pendingStartedAt.Count == 0)
+				return;
+
+			float now = UnityEngine.Time.unscaledTime;
+			_stalePending.Clear();
+
+			foreach (var kvp in _pendingStartedAt)
+			{
+				if (now - kvp.Value > PENDING_CHUNK_TIMEOUT_SECONDS)
+					_stalePending.Add(kvp.Key);
+			}
+
+			foreach (int sequenceId in _stalePending)
+			{
+				_pendingChunks.Remove(sequenceId);
+				_pendingStartedAt.Remove(sequenceId);
+			}
+		}
+
+		/// <summary>Drop all partial reassemblies. For tests and for session teardown.</summary>
+		internal static void ResetPending()
+		{
+			_pendingChunks.Clear();
+			_pendingStartedAt.Clear();
 		}
 
 		public static int GetNextSequenceId()


### PR DESCRIPTION
The chunking path had never executed: the conduit batch is trimmed to fit inside the payload budget, so nothing crossed it in a live session. Pulling the join out of `OnDispatched` into `ChunkedPacket.TryReassemble` makes it testable, and the tests turned up two defects.

## Changes
- Split reassembly out of `OnDispatched` into `ChunkedPacket.TryReassemble`, so the join can be driven without dispatching a packet.
- Reject corrupt headers: `TotalChunks` outside 1..4096 sized an allocation, and a `ChunkIndex` outside it threw IndexOutOfRangeException out of the packet handler.
- Drop partial sets after 30 seconds; previously a set was removed only on completion, so an unreliable batch that lost a chunk stayed in the map for the rest of the session.
- Rebuild the pending set when an arriving chunk disagrees with the stored `TotalChunks`, and add `ResetPending` for tests.
- Add `ChunkedPacketTests` under DebugTools/UnitTests.
- Document the known limitation: the pending map is keyed on `SequenceId` alone while every peer counts from 0, so two peers sending chunked messages to one receiver would collide. Closing it needs a sender id on the wire, which is a protocol change and out of scope.

## Testing
Three unit tests, no socket needed: a 2600 byte payload through split, per-chunk serialise/deserialise and reassembly compared byte for byte; the same in reverse arrival order; and corrupt headers. The sequence id collision was measured over a four client session and does not arise there - chunked sends only go host to client.