### PR TITLE
Keep a failed startup trace write from aborting mod initialisation

### DIFF
--- a/ONI_Together/Menus/MultiplayerOverlay.cs
+++ b/ONI_Together/Menus/MultiplayerOverlay.cs
@@ -118,6 +118,14 @@ namespace ONI_Together.Menus
 		{
 			using var _ = Profiler.Scope();
 
+			// This overlay is the only trace several user-facing failures leave behind:
+			// the paths that show a message and send the player back to the menu draw UI
+			// and log nothing, so a report of "it kicked me out" arrives with no way to
+			// tell which check rejected it. Log the transition rather than every call -
+			// the ready screen re-shows the same text constantly.
+			if (text != Text)
+				DebugConsole.Log($"[MultiplayerOverlay] {(text ?? string.Empty).Replace("\n", " | ")}");
+
 			if (overlay == null)
 			{
 				overlay = new MultiplayerOverlay();
@@ -128,6 +136,9 @@ namespace ONI_Together.Menus
 		public static void Close()
 		{
 			using var _ = Profiler.Scope();
+
+			if (overlay != null)
+				DebugConsole.Log("[MultiplayerOverlay] closed");
 
 			overlay?.Dispose();
 			overlay = null;

--- a/ONI_Together/MultiplayerMod.cs
+++ b/ONI_Together/MultiplayerMod.cs
@@ -41,6 +41,28 @@ namespace ONI_Together
         public static int MainThreadId { get; private set; }
         public static SynchronizationContext MainThread { get; private set; }
 
+        /// <summary>
+        /// Best-effort checkpoint trace. The file sits in the game install directory and is
+        /// opened, appended to and closed once per checkpoint, seven times in quick
+        /// succession - which loses races with on-access virus scanners often enough to
+        /// matter. Those writes used to run bare inside OnLoad's try, so a single
+        /// IOException on the trace file aborted the rest of initialisation: the
+        /// Multiplayer_Modules object and every component below it were never created, the
+        /// mod came up dead, and the log blamed whatever the aborted thread happened to be
+        /// parsing at the time. A diagnostic must never be able to do that.
+        /// </summary>
+        private static void TraceCheckpoint(string logPath, string message)
+        {
+            try
+            {
+                System.IO.File.AppendAllText(logPath, message);
+            }
+            catch (Exception ex)
+            {
+                DebugConsole.LogWarning($"[ONI_Together] Could not write startup trace: {ex.Message}");
+            }
+        }
+
         public override void OnLoad(Harmony harmony)
 		{
 			using var _ = Profiler.Scope();
@@ -61,20 +83,20 @@ namespace ONI_Together
 				DebugConsole.Log("[ONI_Together] Loaded Oxygen Not Included Together Multiplayer Mod.");
 
                 // CHECKPOINT 1
-                System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 1: Pre-DebugMenu\n");
+                TraceCheckpoint(logPath, "[Trace] Checkpoint 1: Pre-DebugMenu\n");
 				DebugMenu.Init();
 
                 // CHECKPOINT 2
-                System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 2: Pre-SteamLobby\n");
+                TraceCheckpoint(logPath, "[Trace] Checkpoint 2: Pre-SteamLobby\n");
 				SteamLobby.Initialize();
 
 				// CHECKPOINT 3
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 3: Pre-GameObjects\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 3: Pre-GameObjects\n");
 				var go = new GameObject("Multiplayer_Modules");
 				UnityEngine.Object.DontDestroyOnLoad(go);
 
 				// CHECKPOINT 4
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 4: Pre-Components\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 4: Pre-Components\n");
 				go.AddComponent<NetworkingComponent>();
 				go.AddComponent<UIVisibilityController>();
 				go.AddComponent<MainThreadExecutor>();
@@ -93,11 +115,11 @@ namespace ONI_Together
 				go.AddComponent<DiscordRichPresence>();
 
 				// CHECKPOINT 5
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 5: Pre-Listeners\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 5: Pre-Listeners\n");
 				SetupListeners();
 
 				// CHECKPOINT 6
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 6: Pre-ResLoad\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 6: Pre-ResLoad\n");
 				LoadAssetBundles();
 
 				foreach (var res in Assembly.GetExecutingAssembly().GetManifestResourceNames())
@@ -105,7 +127,7 @@ namespace ONI_Together
 					DebugConsole.Log("Embedded Resource: " + res);
 				}
 
-				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 7: Success\n");
+				TraceCheckpoint(logPath, "[Trace] Checkpoint 7: Success\n");
 			}
 			catch (Exception ex)
 			{

--- a/Shared/Helpers/DialogUtil.cs
+++ b/Shared/Helpers/DialogUtil.cs
@@ -22,6 +22,12 @@ namespace Shared.Helpers
 
 			if (parent == null)
 				parent = frontend && !useScreenSpaceOverlay ? Global.Instance.globalCanvas : GameScreenManager.Instance.GetParent(GameScreenManager.UIRenderTarget.ScreenSpaceOverlay);
+			// One of the two places the mod puts a message in front of a player; the other is
+			// MultiplayerOverlay, which is logged the same way. Between them a report of "it
+			// popped an error" is traceable without asking the player to remember the wording.
+			// Log here rather than at each call site so a dialog added later is covered too.
+			UnityEngine.Debug.Log($"[ONI_Together] [Dialog] {title} :: {(text ?? string.Empty).Replace("\n", " | ")}");
+
 			var dialogue = ((ConfirmDialogScreen)KScreenManager.Instance.StartScreen(ScreenPrefabs.Instance.ConfirmDialogScreen.gameObject, parent));
 
 			if (!frontend)


### PR DESCRIPTION
The seven startup checkpoints wrote to `ONI_Together_Log.txt` with no error handling. An `IOException` on that file does not escape `OnLoad` — `OnLoad`'s own `catch` swallows it and logs `CRITICAL ERROR IN ONLOAD` — but it abandons the rest of the `try`, so `LoadAssetBundles()` and everything after the failing checkpoint never run. `Multiplayer_Modules` and every component below it are never created, the mod comes up dead, and the log blames whatever the aborted thread happened to be parsing at the time. The writes now go through a helper that reports the failure and carries on. Also logs the two places the mod puts a message in front of a player, which recorded nothing before.

## Changes
- Added `MultiplayerMod.TraceCheckpoint`, which catches a failed trace write, reports it through `DebugConsole.LogWarning` and continues, and routed all seven `OnLoad` checkpoint writes through it.
- `MultiplayerOverlay.Show` logs the overlay text, only when it changes - the ready screen re-shows the same text constantly - and `Close` logs the dismissal.
- `DialogUtil` logs the title and text of every confirm dialog from the helper rather than each call site, so dialogs added later are covered.

## Testing

Hit in the wild while trying to run extra game instances for a multiplayer test. Three parallel install copies would not start at all: each reached `-- MAIN MENU --` and then quit cleanly about 0.4s later, with no error beyond `CRITICAL ERROR IN ONLOAD: System.IO.IOException: Sharing violation on path ...\ONI_Together_Log.txt`.

- **5 consecutive launch failures** across three separate install directories, each with exactly one `CRITICAL ERROR IN ONLOAD`.
- Instances that started successfully in the same window had **0** of that error. 100% correlation between the error and the death.
- The checkpoint file stopped at a **different** checkpoint each run — once after 5, once after 2. A deterministic bug fails in the same place every time; a varying failure point is an external process winning a race for the file, which is what an on-access virus scanner does to a file opened, appended to and closed seven times in about a second.
- Deleting the trace file first did not help, so it is not a stale lock.
- Launching a single instance with nothing else running failed the same way, so it is not contention between game instances.

With this patch, on the same install directories: **2/2 launched**, and the trace ran to `Checkpoint 7: Success`.
