### PR TITLE
Don't report a client building as running before the host has said so

### DIFF
--- a/ONI_Together/DebugTools/UnitTests/OperationalStateCoverageTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OperationalStateCoverageTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Text;
+using ONI_Together.Networking;
+using ONI_Together.Scripts.Buildings;
+using UnityEngine;
+
+namespace ONI_Together.DebugTools.UnitTests
+{
+	/// <summary>
+	/// The HasHostState gate stopped a client building reporting itself as running before the
+	/// host had said anything, which is what was crashing SweepBotStation. That the crash went
+	/// away was verified; that operational status still *displays* correctly afterwards was
+	/// not, and it is the likeliest place for that change to have introduced a regression.
+	///
+	/// What this branch owns is the gate: without host state a building must not report itself
+	/// as running. Whether that state reaches every building belongs to the delivery layer, so
+	/// the coverage number is reported rather than asserted.
+	///
+	/// CLIENT ONLY, read-only, and worth running a few seconds after the world has settled -
+	/// immediately after a join every building is legitimately still waiting.
+	/// </summary>
+	public static class OperationalStateCoverageTests
+	{
+		[UnitTest(name: "Operational: no client building claims unsent host state", category: "Sync")]
+		public static UnitTestResult NoBuildingClaimsUnsentState()
+		{
+			// Not applicable is not a failure.
+			if (!MultiplayerSession.InActiveSession)
+				return UnitTestResult.Pass("skipped: not in a session");
+
+			if (!MultiplayerSession.IsClient)
+				return UnitTestResult.Pass("skipped: client only");
+
+			var receivers = Object.FindObjectsByType<ClientReceiver_Operational>(FindObjectsSortMode.None);
+			if (receivers == null || receivers.Length == 0)
+				return UnitTestResult.Pass("skipped: no gated buildings in the scene yet");
+
+			int withState = 0;
+			int claimingWithoutState = 0;
+			int operational = 0, functional = 0, active = 0;
+
+			foreach (var wrap in receivers)
+			{
+				if (!wrap.HasHostState)
+				{
+					// The point of the gate: with no host state the wrapper must not be able to
+					// report a building as running.
+					if (wrap.IsOperational || wrap.IsFunctional || wrap.IsActive)
+						claimingWithoutState++;
+
+					continue;
+				}
+
+				withState++;
+				if (wrap.IsOperational) operational++;
+				if (wrap.IsFunctional) functional++;
+				if (wrap.IsActive) active++;
+			}
+
+			if (claimingWithoutState > 0)
+				return UnitTestResult.Fail(
+					$"{claimingWithoutState} of {receivers.Length} buildings claim a state the host never sent");
+
+			// Coverage is reported, not asserted. Whether host state reaches every building is
+			// the delivery layer's business, and it was already unreliable before this gate -
+			// the old default of true simply hid it.
+			return UnitTestResult.Pass(
+				$"no building claims unsent state; {withState}/{receivers.Length} have it "
+				+ $"(operational {operational}, functional {functional}, active {active})");
+		}
+	}
+}

--- a/ONI_Together/Networking/Packets/World/Buildings/OperationalStatePacket.cs
+++ b/ONI_Together/Networking/Packets/World/Buildings/OperationalStatePacket.cs
@@ -60,9 +60,7 @@ namespace ONI_Together.Networking.Packets.World.Buildings
 			if (!entity.TryGetComponent<ClientReceiver_Operational>(out var client))
 				return;
 
-			client.IsFunctional = IsFunctional;
-			client.IsOperational = IsOperational;
-			client.IsActive = IsActive;
+			client.ApplyHostState(IsOperational, IsFunctional, IsActive);
 		}
 	}
 }

--- a/ONI_Together/Patches/World/Buildings/Operational_Patch.cs
+++ b/ONI_Together/Patches/World/Buildings/Operational_Patch.cs
@@ -82,7 +82,7 @@ namespace ONI_Together.Patches.World.Buildings
                 if (!MultiplayerSession.IsClient)
                     return true;
 
-                if(__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
                 {
                     __result = wrap.IsOperational;
 					return false;
@@ -108,7 +108,7 @@ namespace ONI_Together.Patches.World.Buildings
 				if (!MultiplayerSession.IsClient)
 					return true;
 
-				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
 				{
 					__result = wrap.IsActive;
 					return false;
@@ -132,7 +132,7 @@ namespace ONI_Together.Patches.World.Buildings
 				if (!MultiplayerSession.IsClient)
 					return true;
 
-				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+				if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
 				{
 					__result = wrap.IsFunctional;
 					return false;

--- a/ONI_Together/Patches/World/EnergyConsumer_Patches.cs
+++ b/ONI_Together/Patches/World/EnergyConsumer_Patches.cs
@@ -33,7 +33,7 @@ namespace ONI_Together.Patches.World
                 if (!SkipOnClient())
                     return true;
 
-                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
                 {
                     __result = wrap.IsOperational;
                     return false;
@@ -53,7 +53,7 @@ namespace ONI_Together.Patches.World
                 if (flag != EnergyConsumer.PoweredFlag)
                     return true;
 
-                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap))
+                if (__instance.TryGetComponent<ClientReceiver_Operational>(out var wrap) && wrap.HasHostState)
                 {
                     __result = wrap.IsOperational;
                     return false;

--- a/ONI_Together/Scripts/Buildings/ClientReceiver_Operational.cs
+++ b/ONI_Together/Scripts/Buildings/ClientReceiver_Operational.cs
@@ -26,8 +26,35 @@ namespace ONI_Together.Scripts.Buildings
 
 		public bool IsFunctional { get; set; }
 
-		public bool IsOperational { get; set; } = true;
+		public bool IsOperational { get; set; }
 
 		public bool IsActive { get; set; }
+
+		/// <summary>
+		/// False until the host has actually told us what this building is doing.
+		///
+		/// The getter patches read the fields above. They used to answer from IsOperational
+		/// unconditionally, and it was initialised to true, so a client building reported
+		/// itself as running while its own components were still being initialised. In that
+		/// state Operational.UpdateOperational sees a
+		/// transition into operational during KMonoBehaviour.InitializeComponent and fires
+		/// OnOperationalChanged early - which is fatal for any Klei handler that assumes
+		/// OnSpawn has already run. SweepBotStation.RequestNewSweepBot is one: it throws a
+		/// NullReferenceException, and because the stack contains no mod frames, ONI's crash
+		/// handler simply disables the whole mod.
+		///
+		/// Vanilla does not hit this because an unpowered building is not operational during
+		/// load. Every getter patch is gated on this flag, so until the first packet lands a
+		/// client building answers exactly as vanilla would.
+		/// </summary>
+		public bool HasHostState { get; private set; }
+
+		public void ApplyHostState(bool isOperational, bool isFunctional, bool isActive)
+		{
+			IsOperational = isOperational;
+			IsFunctional = isFunctional;
+			IsActive = isActive;
+			HasHostState = true;
+		}
 	}
 }


### PR DESCRIPTION
`ClientReceiver_Operational.IsOperational` defaulted to true and the getter patches answered from it unconditionally, so during `KMonoBehaviour` initialisation a client building reported itself as running before any host state arrived. `Operational.UpdateOperational` then saw a transition into operational and fired `OnOperationalChanged` before `OnSpawn` had run: `SweepBotStation.RequestNewSweepBot` threw a `NullReferenceException`, and since the stack carries no mod frames ONI disabled the whole mod.

## Changes
- Add `HasHostState` to `ClientReceiver_Operational`, set only when host state is applied, and drop the `IsOperational = true` default.
- Gate the five getter patches (`Operational` operational/active/functional, `EnergyConsumer` operational and powered-flag) on `HasHostState`, so a client building answers as vanilla would until the first packet lands.
- Replace the three field assignments in `OperationalStatePacket` with `ApplyHostState`, which sets the three values and the flag together.
- Add a client-only unit test asserting no building reports a state the host never sent. It reports how many buildings have host state but does not assert on it — delivery is a separate concern.


## Reproduction

Same two-instance LAN session, once on upstream and once with this branch. Upstream, on the client:

```
[ERROR] SweepBotStationComplete ~~~!System.NullReferenceException
  at SweepBotStation.RequestNewSweepBot (System.Object data)
  at SweepBotStation.OnOperationalChanged (System.Object _)
  at KMonoBehaviour.InitializeComponent ()
!~~~Error in SweepBotStationComplete.EnergyConsumer.OnPrefabInit
```

13 of them in one join. The stack carries no mod frames, so ONI attributes the crash to the base game and disables every mod.

With this branch: 0, across both clients of that run and across four clients of a five-instance run.

## Testing
Ran in-session: 13 of these `NullReferenceException`s before, 0 after. The test was run on a client after the world had settled; a four client session shows host state does not always reach every building, which the old default of true hid.

Corroborated on Steamworks in a later session, on a different save containing a sweep bot station: 2 before, 0 after. ONI also stopped raising the "a mod caused an error and has been unchecked" dialog, which had been disabling the whole mod on every client load of that colony.