### PR TITLE
Log unit test results and add a skipped state

### DIFF
--- a/ONI_Together/DebugTools/DevToolMultiplayer.cs
+++ b/ONI_Together/DebugTools/DevToolMultiplayer.cs
@@ -441,6 +441,13 @@ namespace ONI_Together.DebugTools
 
             ImGui.SameLine();
 
+            // The category picker below only filters the table; without this the only way to
+            // exercise the session-dependent categories was to run every test in the assembly.
+            if (ImGui.Button("Run Category") && unitTestSelectedCategory != "All")
+                UnitTestRegistry.RunCategory(unitTestSelectedCategory);
+
+            ImGui.SameLine();
+
             ImGui.Checkbox("Auto Run", ref unitTestAutoRun);
             ImGui.SameLine();
             ImGui.SetNextItemWidth(100);
@@ -464,11 +471,14 @@ namespace ONI_Together.DebugTools
             var tests = UnitTestRegistry.Tests;
             int passed = tests.Count(t => t.IsPassed);
             int failed = tests.Count(t => t.IsFailed);
+            int skipped = tests.Count(t => t.IsSkipped);
             int notRun = tests.Count(t => !t.HasRun);
             double totalTime = tests.Where(t => t.HasRun).Sum(t => t.DurationMs);
             ImGui.TextColored(new Vector4(0f, 1f, 0f, 1f), $"{passed} passed");
             ImGui.SameLine();
             ImGui.TextColored(new Vector4(1f, 0f, 0f, 1f), $"{failed} failed");
+            ImGui.SameLine();
+            ImGui.TextColored(new Vector4(0.6f, 0.6f, 0.6f, 1f), $"{skipped} skipped");
             ImGui.SameLine();
             ImGui.TextColored(new Vector4(1f, 1f, 0f, 1f), $"{notRun} not run");
             ImGui.SameLine();
@@ -541,6 +551,10 @@ namespace ONI_Together.DebugTools
                             case TestState.Failed:
                                 color = new Vector4(1f, 0f, 0f, 1f);
                                 label = $"FAIL ({test.DurationMs:F2} ms)";
+                                break;
+                            case TestState.Skipped:
+                                color = new Vector4(0.6f, 0.6f, 0.6f, 1f);
+                                label = "SKIPPED";
                                 break;
                             case TestState.InProgress:
                                 color = new Vector4(0f, 1f, 1f, 1f);

--- a/ONI_Together/DebugTools/UnitTest.cs
+++ b/ONI_Together/DebugTools/UnitTest.cs
@@ -19,6 +19,7 @@ namespace ONI_Together.DebugTools
 
         public bool IsPassed => State == TestState.Passed;
         public bool IsFailed => State == TestState.Failed;
+        public bool IsSkipped => State == TestState.Skipped;
         public bool IsInProgress => State == TestState.InProgress;
 
         public UnitTest(string name, string category, MethodInfo method)
@@ -65,6 +66,23 @@ namespace ONI_Together.DebugTools
 
             sw.Stop();
             DurationMs = sw.Elapsed.TotalMilliseconds;
+
+            // Results only ever existed in the ImGui table, so a test run left nothing behind
+            // and had to be reported by screenshot. Several of these tests exist specifically
+            // to cover behaviour that cannot be triggered by hand (a load window lasts
+            // seconds), which is exactly the case where a durable, greppable record matters.
+            string verdict = State == TestState.Passed ? "PASS"
+                : State == TestState.Failed ? "FAIL"
+                : State == TestState.Skipped ? "SKIP"
+                : State.ToString().ToUpperInvariant();
+            string line = $"[UnitTest] {verdict} [{Category}] {Name} ({DurationMs:F1} ms)";
+            if (!string.IsNullOrEmpty(Message))
+                line += $" - {Message.Replace("\n", " | ")}";
+
+            if (State == TestState.Failed)
+                DebugConsole.LogWarning(line);
+            else
+                DebugConsole.Log(line);
         }
     }
 }

--- a/ONI_Together/DebugTools/UnitTestRegistry.cs
+++ b/ONI_Together/DebugTools/UnitTestRegistry.cs
@@ -47,6 +47,44 @@ namespace ONI_Together.DebugTools
         {
             foreach (var test in _tests)
                 test.Run();
+
+            LogSummary("all");
+        }
+
+        /// <summary>
+        /// Run one category. The UI's category picker only filtered the table - "Run All" always
+        /// ran everything - so there was no way to exercise just the handful of tests that need
+        /// a live hosted session without also running the other fifty.
+        /// </summary>
+        public static void RunCategory(string category)
+        {
+            foreach (var test in _tests)
+            {
+                if (test.Category == category)
+                    test.Run();
+            }
+
+            LogSummary(category);
+        }
+
+        private static void LogSummary(string scope)
+        {
+            int passed = 0, failed = 0, skipped = 0, other = 0;
+
+            foreach (var test in _tests)
+            {
+                if (!test.HasRun)
+                    continue;
+                if (scope != "all" && test.Category != scope)
+                    continue;
+
+                if (test.IsPassed) passed++;
+                else if (test.IsFailed) failed++;
+                else if (test.IsSkipped) skipped++;
+                else other++;
+            }
+
+            DebugConsole.Log($"[UnitTest] === {scope}: {passed} passed, {failed} failed, {skipped} skipped ===");
         }
 
         public static void RunFailed()

--- a/ONI_Together/DebugTools/UnitTestResult.cs
+++ b/ONI_Together/DebugTools/UnitTestResult.cs
@@ -9,7 +9,8 @@ namespace ONI_Together.DebugTools
         NotRun,
         InProgress,
         Passed,
-        Failed
+        Failed,
+        Skipped
     }
 
     public class UnitTestResult
@@ -22,6 +23,10 @@ namespace ONI_Together.DebugTools
 
         public static UnitTestResult Fail(string message)
             => new UnitTestResult { State = TestState.Failed, Message = message };
+
+        /// <summary>Could not run here - wrong role, no session, world not loaded.</summary>
+        public static UnitTestResult Skip(string reason)
+            => new UnitTestResult { State = TestState.Skipped, Message = reason };
 
         public static UnitTestResult InProgress(string message = null)
             => new UnitTestResult { State = TestState.InProgress, Message = message };

--- a/ONI_Together/DebugTools/UnitTests/TransportTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/TransportTests.cs
@@ -44,10 +44,10 @@ namespace ONI_Together.DebugTools.UnitTests
 		public static UnitTestResult ConnectionStable()
 		{
 			if (!MultiplayerSession.InActiveSession)
-				return UnitTestResult.Fail("Not in a multiplayer session");
+				return UnitTestResult.Skip("Not in a multiplayer session");
 
 			if (!NetworkConfig.IsLanConfig())
-				return UnitTestResult.Fail("Stability check only implemented for LAN/LiteNetLib transport");
+				return UnitTestResult.Skip("Only implemented for the LAN transport");
 
 			if (MultiplayerSession.IsHost)
 			{


### PR DESCRIPTION
Test results only existed in the ImGui table, so a run left nothing in the log and had to be reported by screenshot. Tests that could not run where they were invoked reported Fail, which is indistinguishable from a real defect.

## Changes
- Log each result as `[UnitTest] PASS/FAIL/SKIP [Category] Name (duration) - message`, failures through `LogWarning` and the rest through `Log`; newlines in the message become ` | `.
- Log a tally after a run: `[UnitTest] === <scope>: N passed, N failed, N skipped ===`.
- Add `TestState.Skipped`, `UnitTestResult.Skip(reason)` and `UnitTest.IsSkipped`.
- `ConnectionStable` skips rather than fails when there is no active session or the transport is not LAN.
- Add a "Run Category" button and `UnitTestRegistry.RunCategory`; the category picker only filtered the table while "Run All" ran the whole assembly, so the categories needing a live hosted session could not be run on their own.

## Testing
No test run recorded.