### PR TITLE
Set Riptide TimeoutTime after Connect, not before

### DIFF
--- a/ONI_Together/Networking/Transport/Riptide/RiptideClient.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideClient.cs
@@ -69,7 +69,6 @@ namespace ONI_Together.Networking.Transport.Lan
             MultiplayerSession.ServerIp = ip;
             MultiplayerSession.ServerPort = port;
             _client = new Client("RiptideClient");
-            _client.TimeoutTime = Configuration.Instance.Client.TimeoutSeconds * 1000;
 
             int timeout = Configuration.Instance.Client.TimeoutSeconds;
             _client.Connected += OnConnectedToServer;
@@ -80,6 +79,11 @@ namespace ONI_Together.Networking.Transport.Lan
             DebugConsole.Log($"Connecting to {ip}:{port}");
             CoroutineRunner.RunOne(WaitForConnectionSuccess(timeout));
             _client.Connect($"{ip}:{port}", useMessageHandlers: false);
+
+            // After Connect, not before: Riptide's Client.TimeoutTime setter reaches through
+            // the connection, which Connect is what creates. Setting it first threw a
+            // NullReferenceException out of ConnectToHost and the join never started.
+            _client.TimeoutTime = timeout * 1000;
         }
 
         private void OnOtherClientDisconnected(object sender, ClientDisconnectedEventArgs e)

--- a/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ONI_Together/Networking/Transport/Riptide/RiptideServer.cs
@@ -92,9 +92,12 @@ namespace ONI_Together.Networking.Transport.Lan
             _client = new Client("Lan/Riptide/HostClient");
             _client.Connected += OnLocalClientConnected;
             _client.Disconnected += OnLocalClientDisconnected;
-            _client.TimeoutTime = Configuration.Instance.HostTimeoutSeconds * 1000;
             DebugConsole.Log("[RiptideServer] Connecting host client!");
             _client.Connect($"{ip}:{port}", useMessageHandlers: false);
+
+            // Same ordering as RiptideClient: the setter dereferences the connection Connect
+            // creates, so assigning it first threw straight out of Start().
+            _client.TimeoutTime = Configuration.Instance.HostTimeoutSeconds * 1000;
         }
 
         private void OnClientConnectionFailed(object sender, ServerConnectionFailedEventArgs e)


### PR DESCRIPTION
Riptide's `Client.TimeoutTime` setter reaches through the connection, which `Connect()` creates. Both call sites assigned it before connecting, so the setter dereferenced null and threw a `NullReferenceException`.

## Changes

- `RiptideClient.ConnectToHost`: assign `TimeoutTime` after `_client.Connect(...)`, reusing the local `timeout`. It previously threw out of `ConnectToHost` and the join never started.
- `RiptideServer`: same reordering for the host's loopback client. It previously threw out of `Start()` after the socket was up, so the log stopped at "Riptide server started!" and the host's loopback client never connected.

Unnoticed because no UI selects Riptide: every LAN entry point hardcodes `LITENETLIB` and the transport pickers offer only Steam and LiteNetLib.

## Testing

Two instance LAN session on Riptide: host loopback connects, a client joins as id 2, disconnects to load, returns as id 3, and the resume gate holds for the whole load window.