### PR TITLE
Report a missing PlayerController once instead of throwing every frame

### DIFF
--- a/ONI_Together/Networking/Components/CursorManager.cs
+++ b/ONI_Together/Networking/Components/CursorManager.cs
@@ -68,12 +68,28 @@ namespace ONI_Together.Networking.Components
 			}
 		}
 
+		private bool warnedNoPlayerController;
+
 		private void Update()
 		{
 			using var _ = Profiler.Scope();
 
 			if (!Utils.IsInGame())
 				return;
+
+			// Both paths below dereference PlayerController.Instance, which stays null on a
+			// client whose world load failed. Report it once instead of throwing every frame.
+			if (PlayerController.Instance == null)
+			{
+				if (!warnedNoPlayerController)
+				{
+					warnedNoPlayerController = true;
+					DebugConsole.LogWarning("[CursorManager] No PlayerController - the world did not finish loading. Cursor sync is off.");
+				}
+				return;
+			}
+
+			warnedNoPlayerController = false;
 
 			if (!MultiplayerSession.InActiveSession || !MultiplayerSession.LocalUserID.IsValid())
 			{


### PR DESCRIPTION
`CursorManager.Update` dereferences `PlayerController.Instance` in both `SendCursorPosition` and `UpdateLocalAreaVisualizer`, and `Utils.IsInGame()` does not imply it exists. On a client whose world load failed it stays null, so `Update` threw once per frame with no recovery - 31258 NullReferenceExceptions in one measured session, burying the actual load error.

## Changes
- Bail out of `CursorManager.Update` when `PlayerController.Instance` is null, before either dereference.
- Log a warning once via a `warnedNoPlayerController` flag saying the world did not finish loading and cursor sync is off; the flag resets once the instance is back.

## Testing
Measured on a client whose world load failed. Five clients that loaded normally hit the new path 0 times.