### PR TITLE
Stop failing the duplicant position test on a minion that has not moved

### DIFF
--- a/ONI_Together/DebugTools/UnitTests/SyncTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/SyncTests.cs
@@ -21,6 +21,7 @@ namespace ONI_Together.DebugTools.UnitTests
 			const float MaxCellDelta = 2f;
 
 			int minionsChecked = 0;
+			int minionsSynced = 0;
 			foreach (var identity in NetworkIdentityRegistry.AllIdentities)
 			{
 				if (identity == null || identity.gameObject == null)
@@ -38,8 +39,10 @@ namespace ONI_Together.DebugTools.UnitTests
 				if (MultiplayerSession.IsHost)
 					continue;
 
-				if (handler._lastSyncTime == 0)
-					return UnitTestResult.Fail($"Minion '{identity.gameObject.name}' has not received a position packet yet");
+				// A minion that has not moved since this client joined has nothing to sync, so
+				// a zero timestamp on its own is not a fault - only every minion being silent is.
+				if (handler._lastSyncTime != 0)
+					minionsSynced++;
 
 				//float delta = Vector3.Distance(identity.gameObject.transform.position, handler.);
 				//if (delta > MaxCellDelta)
@@ -49,8 +52,18 @@ namespace ONI_Together.DebugTools.UnitTests
 			if (minionsChecked == 0)
 				return UnitTestResult.Fail("No minions found in registry");
 
+			// A paused sim produces no movement and therefore no position packets, so there is
+			// nothing to assert about - every minion legitimately reads zero.
+			if (!MultiplayerSession.IsHost && minionsSynced == 0)
+			{
+				bool paused = SpeedControlScreen.Instance == null || SpeedControlScreen.Instance.IsPaused;
+				return paused
+					? UnitTestResult.Pass($"skipped: sim is paused, none of the {minionsChecked} minions can have moved")
+					: UnitTestResult.Fail($"None of the {minionsChecked} minions has received a position packet");
+			}
+
 			string mode = MultiplayerSession.IsHost ? "host" : "client";
-			return UnitTestResult.Pass($"Checked {minionsChecked} minions ({mode})");
+			return UnitTestResult.Pass($"Checked {minionsChecked} minions ({mode}, {minionsSynced} synced)");
 		}
 
 		[UnitTest(name: "Build progress bar pipeline intact", category: "Sync")]


### PR DESCRIPTION
The "Duplicant positions in sync with host" test failed as soon as any minion on a client had `_lastSyncTime == 0`. A minion that has not moved since the client joined never generates a position packet, so that is a normal state, and the test failed on every client join with a large colony.

## Changes

- Count synced minions instead of failing on the first one with a zero sync timestamp, and report the count in the pass message.
- On a client, fail only when none of them has received a packet.
- Skip even that while the sim is paused: nothing can move, so every minion legitimately reads zero.

## Testing

Two instance and five instance LAN sessions. Before: the test failed on every client. After: it passes with a running sim and reports skipped with a paused one, across a host and four clients.
