### PR TITLE
Add class support to sync var

### DIFF
--- a/ONI_Together/DebugTools/PacketTracker.cs
+++ b/ONI_Together/DebugTools/PacketTracker.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using ImGuiNET;
 using ONI_Together.Misc;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Packets.Architecture;
+using Shared.OxySync;
 using Shared.Profiling;
-using Steamworks;
 using UnityEngine;
 
 namespace ONI_Together.DebugTools

--- a/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
-using ONI_Together.Misc;
 using ONI_Together.Networking;
 using ONI_Together.Networking.OxySync.Components;
 using ONI_Together.Networking.OxySync.Packets;
@@ -18,6 +17,57 @@ namespace ONI_Together.DebugTools.UnitTests
         private enum TestEnum
         {
             HighValue = 1000,
+        }
+
+        [Serializable]
+        private sealed class TestSyncClass
+        {
+            public int Count;
+            public string Label;
+            public TestSyncNested Nested;
+
+            [SerializeField]
+            private int _privateIncluded;
+
+            private int _privateIgnored;
+
+            [NonSerialized]
+            public string RuntimeOnly;
+
+            public int PrivateIncluded => _privateIncluded;
+            public int PrivateIgnored => _privateIgnored;
+
+            public void ConfigurePrivateFields(int included, int ignored)
+            {
+                _privateIncluded = included;
+                _privateIgnored = ignored;
+            }
+        }
+
+        [Serializable]
+        private sealed class TestSyncNested
+        {
+            public bool Enabled;
+            public float Temperature;
+        }
+
+        private sealed class TestExplicitFieldClass
+        {
+            [SerializeField]
+            private int _count;
+
+            public int Count => _count;
+            public string Ignored;
+
+            public TestExplicitFieldClass(int count, string ignored)
+            {
+                _count = count;
+                Ignored = ignored;
+            }
+
+            private TestExplicitFieldClass()
+            {
+            }
         }
 
 		[UnitTest(name: "OxySync protocol hashes are deterministic", category: "OxySync")]
@@ -386,6 +436,33 @@ namespace ONI_Together.DebugTools.UnitTests
 			if (nullVariant.Type != Variant.TypeCode.Null ||
 				VariantHelper.VariantToObject(nullVariant, typeof(string)) != null)
 				return UnitTestResult.Fail("A null SyncVar did not preserve its null state");
+
+            var classInput = new TestSyncClass { Count = 77, Label = "class-value" };
+            classInput.Nested = new TestSyncNested { Enabled = true, Temperature = 12.5f };
+            classInput.ConfigurePrivateFields(99, 1234);
+            classInput.RuntimeOnly = "ignore-me";
+            Variant classVariant = VariantHelper.ObjectToVariant(classInput);
+            if (classVariant.Type != Variant.TypeCode.VariantArray)
+                return UnitTestResult.Fail($"Expected VariantArray variant for class value, got {classVariant.Type}");
+            var classRoundTrip = VariantHelper.VariantToObject(classVariant, typeof(TestSyncClass)) as TestSyncClass;
+            if (classRoundTrip == null || classRoundTrip.Count != classInput.Count || classRoundTrip.Label != classInput.Label)
+                return UnitTestResult.Fail("A class SyncVar did not round-trip");
+            if (classRoundTrip.Nested == null || !classRoundTrip.Nested.Enabled || Math.Abs(classRoundTrip.Nested.Temperature - 12.5f) > 0.001f)
+                return UnitTestResult.Fail("A nested class SyncVar did not round-trip recursively");
+            if (classRoundTrip.PrivateIncluded != 99)
+                return UnitTestResult.Fail("[SerializeField] private field should round-trip in [Serializable] class mode");
+            if (classRoundTrip.PrivateIgnored != 0)
+                return UnitTestResult.Fail("Non-[SerializeField] private field should not round-trip in [Serializable] class mode");
+            if (classRoundTrip.RuntimeOnly != null)
+                return UnitTestResult.Fail("[NonSerialized] field should not round-trip in [Serializable] class mode");
+
+            var explicitInput = new TestExplicitFieldClass(31, "not-serialized");
+            Variant explicitVariant = VariantHelper.ObjectToVariant(explicitInput);
+            var explicitRoundTrip = VariantHelper.VariantToObject(explicitVariant, typeof(TestExplicitFieldClass)) as TestExplicitFieldClass;
+            if (explicitRoundTrip == null || explicitRoundTrip.Count != 31)
+                return UnitTestResult.Fail("A [SerializeField]-based class SyncVar did not round-trip");
+            if (explicitRoundTrip.Ignored != null)
+                return UnitTestResult.Fail("A non-[SerializeField] field should not be serialized for explicit-field class mode");
 
 			Variant testEnum = VariantHelper.ObjectToVariant(TestEnum.HighValue);
 			if ((TestEnum)VariantHelper.VariantToObject(testEnum, typeof(TestEnum)) != TestEnum.HighValue)

--- a/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
@@ -70,6 +70,67 @@ namespace ONI_Together.DebugTools.UnitTests
             }
         }
 
+        [Serializable]
+        private sealed class TestCycleNode
+        {
+            public int Value;
+            public TestCycleNode Next;
+        }
+
+        [Serializable]
+        private sealed class TestDeepNode
+        {
+            public int Level;
+            public TestDeepNode Next;
+        }
+
+        [Serializable]
+        private sealed class TestUnsupportedFieldClass
+        {
+            public Guid Id;
+        }
+
+        [Serializable]
+        private sealed class TestUnityObjectFieldClass
+        {
+            public GameObject Prefab;
+        }
+
+        [Serializable]
+        private class TestBaseSerializableClass
+        {
+            public int BaseValue;
+
+            [SerializeField]
+            private int _basePrivate;
+
+            public int BasePrivate => _basePrivate;
+
+            public void SetBasePrivate(int value)
+            {
+                _basePrivate = value;
+            }
+        }
+
+        [Serializable]
+        private sealed class TestDerivedSerializableClass : TestBaseSerializableClass
+        {
+            public int DerivedValue;
+
+            [SerializeField]
+            private int _derivedPrivate;
+
+            [NonSerialized]
+            public string RuntimeOnly;
+
+            public int DerivedPrivate => _derivedPrivate;
+
+            public void SetDerivedPrivate(int value)
+            {
+                _derivedPrivate = value;
+            }
+        }
+
 		[UnitTest(name: "OxySync protocol hashes are deterministic", category: "OxySync")]
 		public static UnitTestResult OxySyncProtocolHashIsDeterministic()
 		{
@@ -501,6 +562,145 @@ namespace ONI_Together.DebugTools.UnitTests
 
 			return UnitTestResult.Pass("Unsupported and oversized SyncVar values are rejected explicitly");
 		}
+
+        [UnitTest(name: "Variant class rejects circular references", category: "OxySync")]
+        public static UnitTestResult VariantClassRejectsCircularReferences()
+        {
+            var root = new TestCycleNode { Value = 1 };
+            root.Next = root;
+
+            try
+            {
+                VariantHelper.ObjectToVariant(root);
+                return UnitTestResult.Fail("Circular class graph should throw NotSupportedException");
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            return UnitTestResult.Pass("Circular class graph is rejected");
+        }
+
+        [UnitTest(name: "Variant class rejects over-depth graphs", category: "OxySync")]
+        public static UnitTestResult VariantClassRejectsOverDepthGraphs()
+        {
+            var root = new TestDeepNode { Level = 0 };
+            var cursor = root;
+            for (int i = 1; i <= ClassSerializationPolicy.MaxObjectGraphDepth + 1; i++)
+            {
+                var next = new TestDeepNode { Level = i };
+                cursor.Next = next;
+                cursor = next;
+            }
+
+            try
+            {
+                VariantHelper.ObjectToVariant(root);
+                return UnitTestResult.Fail("Over-depth class graph should throw NotSupportedException");
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            return UnitTestResult.Pass("Class depth guard rejects over-depth graphs");
+        }
+
+        [UnitTest(name: "Variant class rejects unsupported nested field type", category: "OxySync")]
+        public static UnitTestResult VariantClassRejectsUnsupportedNestedFieldType()
+        {
+            var input = new TestUnsupportedFieldClass { Id = Guid.NewGuid() };
+
+            try
+            {
+                VariantHelper.ObjectToVariant(input);
+                return UnitTestResult.Fail("Unsupported nested field type should throw NotSupportedException");
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            return UnitTestResult.Pass("Unsupported nested field types are rejected");
+        }
+
+        [UnitTest(name: "Variant class rejects UnityEngine.Object fields", category: "OxySync")]
+        public static UnitTestResult VariantClassRejectsUnityObjectFields()
+        {
+            var go = new GameObject("VariantUnityObjectFieldTest");
+            try
+            {
+                var input = new TestUnityObjectFieldClass { Prefab = go };
+                try
+                {
+                    VariantHelper.ObjectToVariant(input);
+                    return UnitTestResult.Fail("UnityEngine.Object fields should throw NotSupportedException");
+                }
+                catch (NotSupportedException)
+                {
+                }
+
+                return UnitTestResult.Pass("UnityEngine.Object fields are rejected");
+            }
+            finally
+            {
+                UnityEngine.Object.Destroy(go);
+            }
+        }
+
+        [UnitTest(name: "Variant class payload schema mismatch is rejected", category: "OxySync")]
+        public static UnitTestResult VariantClassSchemaMismatchRejected()
+        {
+            var input = new TestSyncClass
+            {
+                Count = 10,
+                Label = "schema",
+                Nested = new TestSyncNested { Enabled = true, Temperature = 42.0f },
+            };
+            input.ConfigurePrivateFields(7, 8);
+
+            Variant serialized = VariantHelper.ObjectToVariant(input);
+            if (serialized.Type != Variant.TypeCode.VariantArray || serialized.VariantArray == null || serialized.VariantArray.Length < 2)
+                return UnitTestResult.Fail("Precondition failed: expected class VariantArray payload");
+
+            var truncated = serialized;
+            truncated.VariantArray = new Variant[] { serialized.VariantArray[0] };
+
+            try
+            {
+                VariantHelper.VariantToObject(truncated, typeof(TestSyncClass));
+                return UnitTestResult.Fail("Schema mismatch should throw InvalidDataException");
+            }
+            catch (InvalidDataException)
+            {
+            }
+
+            return UnitTestResult.Pass("Class payload schema mismatch is rejected");
+        }
+
+        [UnitTest(name: "Variant class supports inheritance field round-trip", category: "OxySync")]
+        public static UnitTestResult VariantClassInheritanceRoundTrip()
+        {
+            var input = new TestDerivedSerializableClass
+            {
+                BaseValue = 11,
+                DerivedValue = 22,
+                RuntimeOnly = "skip-runtime",
+            };
+            input.SetBasePrivate(33);
+            input.SetDerivedPrivate(44);
+
+            Variant serialized = VariantHelper.ObjectToVariant(input);
+            var output = VariantHelper.VariantToObject(serialized, typeof(TestDerivedSerializableClass)) as TestDerivedSerializableClass;
+            if (output == null)
+                return UnitTestResult.Fail("Derived class round-trip returned null");
+            if (output.BaseValue != 11 || output.DerivedValue != 22)
+                return UnitTestResult.Fail("Public base/derived fields did not round-trip");
+            if (output.BasePrivate != 33 || output.DerivedPrivate != 44)
+                return UnitTestResult.Fail("[SerializeField] private base/derived fields did not round-trip");
+            if (output.RuntimeOnly != null)
+                return UnitTestResult.Fail("[NonSerialized] derived field should not round-trip");
+
+            return UnitTestResult.Pass("Inheritance fields round-trip with class serialization policy");
+        }
 
         [UnitTest(name: "RpcSerializer string handles null", category: "OxySync")]
         public static UnitTestResult RpcSerializerNullString()

--- a/ONI_Together/Misc/BuildingUtils.cs
+++ b/ONI_Together/Misc/BuildingUtils.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using HarmonyLib;
+using Shared.OxySync;
 using ONI_Together.DebugTools;
 using UnityEngine;
-using static LogicGateVisualizer;
 
 namespace ONI_Together.Misc
 {

--- a/ONI_Together/Networking/Components/LogicStateSyncer.cs
+++ b/ONI_Together/Networking/Components/LogicStateSyncer.cs
@@ -1,8 +1,6 @@
-using ONI_Together.DebugTools;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using System.Collections.Generic;
-using Shared.Profiling;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components

--- a/ONI_Together/Networking/Components/StructureStateSyncers/BatteryStateSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/BatteryStateSyncer.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using ONI_Together.DebugTools;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using ONI_Together.Patches.World;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers

--- a/ONI_Together/Networking/Components/StructureStateSyncers/EnergyGeneratorSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/EnergyGeneratorSyncer.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using ONI_Together.DebugTools;
-using ONI_Together.Misc;
+﻿using System.Collections.Generic;
 using ONI_Together.Networking.Packets.World;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers

--- a/ONI_Together/Networking/Components/StructureStateSyncers/GenericGeneratorSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/GenericGeneratorSyncer.cs
@@ -1,9 +1,6 @@
-﻿using System;
+﻿using Shared.OxySync;
 using System.Collections.Generic;
-using System.Text;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
-using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers
 {

--- a/ONI_Together/Networking/Components/StructureStateSyncers/StorageStateSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/StorageStateSyncer.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using Shared.OxySync;
 using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using UnityEngine;

--- a/ONI_Together/Networking/Components/StructureStateSyncers/StructureSyncerBase.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/StructureSyncerBase.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using ONI_Together.DebugTools;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
-using Shared.Interfaces.Networking;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers

--- a/ONI_Together/Networking/Components/StructureStateSyncers/ToiletSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/ToiletSyncer.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using HarmonyLib;
+﻿using System.Collections.Generic;
+using Shared.OxySync;
 using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using UnityEngine;
-using static STRINGS.UI.METERS;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers
 {

--- a/ONI_Together/Networking/OxySync/Packets/SyncVarBatchPacket.cs
+++ b/ONI_Together/Networking/OxySync/Packets/SyncVarBatchPacket.cs
@@ -56,6 +56,8 @@ namespace ONI_Together.Networking.OxySync.Packets
             BehaviourId = reader.ReadInt32();
             Timestamp = reader.ReadInt64();
             Count = reader.ReadInt32();
+            if (Count < 0 || Count > Variant.MaxArrayElements)
+                throw new InvalidDataException($"Invalid SyncVarBatch count: {Count}.");
             FieldHashes = new int[Count];
             Values = new Variant[Count];
             for (int i = 0; i < Count; i++)

--- a/ONI_Together/Networking/Packets/World/LogicStatePacket.cs
+++ b/ONI_Together/Networking/Packets/World/LogicStatePacket.cs
@@ -1,9 +1,8 @@
-using ONI_Together.Misc;
 using ONI_Together.Networking.Components;
 using ONI_Together.Networking.Packets.Architecture;
-using Shared.Interfaces.Networking;
 using System.Collections.Generic;
 using System.IO;
+using Shared.OxySync;
 using Shared.Profiling;
 using UnityEngine;
 

--- a/ONI_Together/Networking/Packets/World/StructureStatePacket.cs
+++ b/ONI_Together/Networking/Packets/World/StructureStatePacket.cs
@@ -1,14 +1,10 @@
 using ONI_Together.Networking.Packets.Architecture;
 using System.IO;
+using Shared.OxySync;
 using Shared.Profiling;
-using ONI_Together.Networking.Components;
-using static TUNING.NOISE_POLLUTION;
-using ONI_Together.Misc;
 using UnityEngine;
 using ONI_Together.Networking.Components.StructureStateSyncers;
-using static ONI_Together.STRINGS.UI.MP_OVERLAY;
 using System.Collections.Generic;
-using Shared.Interfaces.Networking;
 
 namespace ONI_Together.Networking.Packets.World
 {

--- a/Shared/OxySync/ClassSerializationPolicy.cs
+++ b/Shared/OxySync/ClassSerializationPolicy.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace Shared.OxySync
+{
+    public static class ClassSerializationPolicy
+    {
+        private const BindingFlags MEMBER_FLAGS = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        public const int MaxObjectGraphDepth = 32;
+
+        public readonly struct Rules
+        {
+            public readonly bool IsEligible;
+            public readonly bool IncludePublicFields;
+
+            public Rules(bool isEligible, bool includePublicFields)
+            {
+                IsEligible = isEligible;
+                IncludePublicFields = includePublicFields;
+            }
+        }
+
+        private static readonly Dictionary<Type, Rules> ClassSerializationRulesCache = new Dictionary<Type, Rules>();
+        private static readonly Dictionary<Type, FieldInfo[]> SerializableFieldCache = new Dictionary<Type, FieldInfo[]>();
+
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            public static readonly ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
+
+            public new bool Equals(object x, object y) => ReferenceEquals(x, y);
+
+            public int GetHashCode(object obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+        }
+
+        public static IEqualityComparer<object> ObjectReferenceComparer => ReferenceEqualityComparer.Instance;
+
+        public static FieldInfo[] GetSerializableFields(Type type)
+        {
+            if (SerializableFieldCache.TryGetValue(type, out FieldInfo[] cached))
+                return cached;
+
+            Rules rules = GetClassSerializationRules(type);
+            if (!rules.IsEligible)
+            {
+                SerializableFieldCache[type] = Array.Empty<FieldInfo>();
+                return SerializableFieldCache[type];
+            }
+
+            var list = new List<FieldInfo>();
+            var type_ = type;
+            while (type_ != null)
+            {
+                var fields = type_.GetFields(MEMBER_FLAGS | BindingFlags.DeclaredOnly);
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    FieldInfo field = fields[i];
+                    if (field.IsStatic || field.IsInitOnly || field.IsLiteral)
+                        continue;
+                    if (field.IsDefined(typeof(NonSerializedAttribute), true))
+                        continue;
+                    if (typeof(Delegate).IsAssignableFrom(field.FieldType))
+                        continue;
+
+                    bool hasSerializeField = field.IsDefined(typeof(SerializeField), true);
+                    bool isIncludedPublic = rules.IncludePublicFields && field.IsPublic;
+                    if (!hasSerializeField && !isIncludedPublic)
+                        continue;
+
+                    list.Add(field);
+                }
+
+                type_ = type_.BaseType;
+            }
+
+            list.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+            var result = list.ToArray();
+            SerializableFieldCache[type] = result;
+            return result;
+        }
+
+        public static Rules GetClassSerializationRules(Type type)
+        {
+            if (ClassSerializationRulesCache.TryGetValue(type, out Rules cached))
+                return cached;
+
+            Rules rules;
+            if (type.IsDefined(typeof(SerializableAttribute), true))
+            {
+                rules = new Rules(isEligible: true, includePublicFields: true);
+            }
+            else if (HasExplicitSerializeField(type))
+            {
+                rules = new Rules(isEligible: true, includePublicFields: false);
+            }
+            else
+            {
+                rules = new Rules(isEligible: false, includePublicFields: false);
+            }
+
+            ClassSerializationRulesCache[type] = rules;
+            return rules;
+        }
+
+        private static bool HasExplicitSerializeField(Type type)
+        {
+            var type_ = type;
+            while (type_ != null)
+            {
+                var fields = type_.GetFields(MEMBER_FLAGS | BindingFlags.DeclaredOnly);
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    FieldInfo field = fields[i];
+                    if (field.IsStatic || field.IsLiteral)
+                        continue;
+                    if (field.IsDefined(typeof(SerializeField), true))
+                        return true;
+                }
+
+                type_ = type_.BaseType;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Shared/OxySync/Variant.cs
+++ b/Shared/OxySync/Variant.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using UnityEngine;
 
-namespace ONI_Together.Misc
+namespace Shared.OxySync
 {
     /// <summary>
     /// A type-safe tagged union that holds one value of multiple possible types (Float, Int, Byte, String, Boolean, Vector3, Vector2) at a time,

--- a/Shared/OxySync/VariantHelper.cs
+++ b/Shared/OxySync/VariantHelper.cs
@@ -2,15 +2,27 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using UnityEngine;
 
 namespace Shared.OxySync
 {
     public static class VariantHelper
     {
-        public static Variant ObjectToVariant(object? value)
+        private const int MAX_OBJECT_GRAPH_DEPTH = ClassSerializationPolicy.MaxObjectGraphDepth;
+
+        public static Variant ObjectToVariant(object value)
+            => ObjectToVariantInternal(value, new HashSet<object>(ClassSerializationPolicy.ObjectReferenceComparer), 0);
+
+        private static Variant ObjectToVariantInternal(object value, HashSet<object> visitedRefs, int depth)
         {
+            if (depth > MAX_OBJECT_GRAPH_DEPTH)
+                throw new NotSupportedException($"OxySync Variant object graph exceeded max depth {MAX_OBJECT_GRAPH_DEPTH}.");
+
             if (value == null) return new Variant { Type = Variant.TypeCode.Null };
+            if (value is UnityEngine.Object)
+                throw new NotSupportedException(
+                    $"Type '{value.GetType().FullName}' is a UnityEngine.Object and is not supported by OxySync Variant serialization.");
             if (value is int i) return i;
             if (value is float f) return f;
             if (value is byte b) return b;
@@ -48,7 +60,7 @@ namespace Shared.OxySync
             {
                 var variants = new Variant[arr.Length];
                 for (int i2 = 0; i2 < arr.Length; i2++)
-                    variants[i2] = ObjectToVariant(arr.GetValue(i2));
+                    variants[i2] = ObjectToVariantInternal(arr.GetValue(i2), visitedRefs, depth + 1);
                 return new Variant { Type = Variant.TypeCode.VariantArray, VariantArray = variants };
             }
 
@@ -58,16 +70,17 @@ namespace Shared.OxySync
                 int idx = 0;
                 foreach (DictionaryEntry entry in dict)
                 {
-                    variants[idx++] = ObjectToVariant(entry.Key);
-                    variants[idx++] = ObjectToVariant(entry.Value);
+                    variants[idx++] = ObjectToVariantInternal(entry.Key, visitedRefs, depth + 1);
+                    variants[idx++] = ObjectToVariantInternal(entry.Value, visitedRefs, depth + 1);
                 }
                 return new Variant { Type = Variant.TypeCode.VariantArray, VariantArray = variants };
             }
 
+            var valueType = value.GetType();
+
             if (value is IEnumerable enumerable)
             {
-                var type = value.GetType();
-                bool isStack = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Stack<>);
+                bool isStack = valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Stack<>);
 
                 var items = new List<object>();
                 foreach (var item in enumerable)
@@ -78,8 +91,50 @@ namespace Shared.OxySync
 
                 var variants = new Variant[items.Count];
                 for (int i2 = 0; i2 < items.Count; i2++)
-                    variants[i2] = ObjectToVariant(items[i2]);
+                    variants[i2] = ObjectToVariantInternal(items[i2], visitedRefs, depth + 1);
                 return new Variant { Type = Variant.TypeCode.VariantArray, VariantArray = variants };
+            }
+
+            if (valueType.IsClass)
+            {
+                if (typeof(Delegate).IsAssignableFrom(valueType))
+                    throw new NotSupportedException(
+                        $"Type '{valueType.FullName}' is a delegate and is not supported by OxySync Variant serialization.");
+
+                var rules = ClassSerializationPolicy.GetClassSerializationRules(valueType);
+                if (!rules.IsEligible)
+                    throw new NotSupportedException(
+                        $"Type '{valueType.FullName}' is not eligible for OxySync class serialization." +
+                        " Mark the class with [Serializable] or mark at least one field with [SerializeField].");
+
+                if (!visitedRefs.Add(value))
+                    throw new NotSupportedException(
+                        $"Type '{valueType.FullName}' contains a circular reference and is not supported by OxySync Variant serialization.");
+
+                try
+                {
+                    var fields = ClassSerializationPolicy.GetSerializableFields(valueType);
+                    if (fields.Length == 0)
+                        throw new NotSupportedException(
+                            $"Type '{valueType.FullName}' has no serializable fields and is not supported by OxySync Variant serialization.");
+
+                    var members = new Variant[fields.Length];
+                    for (int fieldIndex = 0; fieldIndex < fields.Length; fieldIndex++)
+                    {
+                        FieldInfo field = fields[fieldIndex];
+                        members[fieldIndex] = ObjectToVariantInternal(field.GetValue(value), visitedRefs, depth + 1);
+                    }
+
+                    return new Variant
+                    {
+                        Type = Variant.TypeCode.VariantArray,
+                        VariantArray = members,
+                    };
+                }
+                finally
+                {
+                    visitedRefs.Remove(value);
+                }
             }
 
             throw new NotSupportedException(
@@ -87,7 +142,13 @@ namespace Shared.OxySync
         }
 
         public static object VariantToObject(Variant v, Type targetType)
+            => VariantToObjectInternal(v, targetType, 0);
+
+        private static object VariantToObjectInternal(Variant v, Type targetType, int depth)
         {
+            if (depth > MAX_OBJECT_GRAPH_DEPTH)
+                throw new InvalidDataException($"OxySync Variant object graph exceeded max depth {MAX_OBJECT_GRAPH_DEPTH}.");
+
             if (v.Type == Variant.TypeCode.Null)
             {
                 if (targetType.IsValueType && Nullable.GetUnderlyingType(targetType) == null)
@@ -119,12 +180,14 @@ namespace Shared.OxySync
             if (targetType == typeof(Color)) return v.Color;
             if (v.Type == Variant.TypeCode.VariantArray)
             {
+                var variantArray = v.VariantArray ?? Array.Empty<Variant>();
+
                 if (targetType.IsArray && targetType != typeof(byte[]))
                 {
                     var elementType = targetType.GetElementType();
-                    var arr = Array.CreateInstance(elementType, v.VariantArray.Length);
-                    for (int i = 0; i < v.VariantArray.Length; i++)
-                        arr.SetValue(VariantToObject(v.VariantArray[i], elementType), i);
+                    var arr = Array.CreateInstance(elementType, variantArray.Length);
+                    for (int i = 0; i < variantArray.Length; i++)
+                        arr.SetValue(VariantToObjectInternal(variantArray[i], elementType, depth + 1), i);
                     return arr;
                 }
 
@@ -136,8 +199,8 @@ namespace Shared.OxySync
                     {
                         var elementType = targetType.GetGenericArguments()[0];
                         var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType));
-                        for (int i = 0; i < v.VariantArray.Length; i++)
-                            list.Add(VariantToObject(v.VariantArray[i], elementType));
+                        for (int i = 0; i < variantArray.Length; i++)
+                            list.Add(VariantToObjectInternal(variantArray[i], elementType, depth + 1));
                         return list;
                     }
 
@@ -147,8 +210,8 @@ namespace Shared.OxySync
                         var hashSetType = typeof(HashSet<>).MakeGenericType(elementType);
                         var hashSet = Activator.CreateInstance(hashSetType);
                         var addMethod = hashSetType.GetMethod("Add");
-                        for (int i = 0; i < v.VariantArray.Length; i++)
-                            addMethod.Invoke(hashSet, new[] { VariantToObject(v.VariantArray[i], elementType) });
+                        for (int i = 0; i < variantArray.Length; i++)
+                            addMethod.Invoke(hashSet, new[] { VariantToObjectInternal(variantArray[i], elementType, depth + 1) });
                         return hashSet;
                     }
 
@@ -158,8 +221,8 @@ namespace Shared.OxySync
                         var queueType = typeof(Queue<>).MakeGenericType(elementType);
                         var queue = Activator.CreateInstance(queueType);
                         var enqueueMethod = queueType.GetMethod("Enqueue");
-                        for (int i = 0; i < v.VariantArray.Length; i++)
-                            enqueueMethod.Invoke(queue, new[] { VariantToObject(v.VariantArray[i], elementType) });
+                        for (int i = 0; i < variantArray.Length; i++)
+                            enqueueMethod.Invoke(queue, new[] { VariantToObjectInternal(variantArray[i], elementType, depth + 1) });
                         return queue;
                     }
 
@@ -169,27 +232,63 @@ namespace Shared.OxySync
                         var stackType = typeof(Stack<>).MakeGenericType(elementType);
                         var stack = Activator.CreateInstance(stackType);
                         var pushMethod = stackType.GetMethod("Push");
-                        for (int i = 0; i < v.VariantArray.Length; i++)
-                            pushMethod.Invoke(stack, new[] { VariantToObject(v.VariantArray[i], elementType) });
+                        for (int i = 0; i < variantArray.Length; i++)
+                            pushMethod.Invoke(stack, new[] { VariantToObjectInternal(variantArray[i], elementType, depth + 1) });
                         return stack;
                     }
 
                     if (def == typeof(Dictionary<,>))
                     {
-                        if ((v.VariantArray.Length & 1) != 0)
+                        if ((variantArray.Length & 1) != 0)
                             throw new InvalidDataException("OxySync dictionary Variant contains an unmatched key/value entry.");
                         var keyType = targetType.GetGenericArguments()[0];
                         var valType = targetType.GetGenericArguments()[1];
                         var dictType = typeof(Dictionary<,>).MakeGenericType(keyType, valType);
                         var dict = (IDictionary)Activator.CreateInstance(dictType);
-                        for (int i = 0; i < v.VariantArray.Length; i += 2)
+                        for (int i = 0; i < variantArray.Length; i += 2)
                         {
-                            var key = VariantToObject(v.VariantArray[i], keyType);
-                            var val = VariantToObject(v.VariantArray[i + 1], valType);
+                            var key = VariantToObjectInternal(variantArray[i], keyType, depth + 1);
+                            var val = VariantToObjectInternal(variantArray[i + 1], valType, depth + 1);
                             dict.Add(key, val);
                         }
                         return dict;
                     }
+                }
+
+                if (targetType.IsClass && targetType != typeof(string) && !typeof(IEnumerable).IsAssignableFrom(targetType))
+                {
+                    var rules = ClassSerializationPolicy.GetClassSerializationRules(targetType);
+                    if (!rules.IsEligible)
+                        throw new InvalidDataException(
+                            $"Type '{targetType.FullName}' is not eligible for OxySync class deserialization." +
+                            " Mark the class with [Serializable] or mark at least one field with [SerializeField].");
+
+                    object instance;
+                    try
+                    {
+                        instance = Activator.CreateInstance(targetType, true);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidDataException($"Unable to construct class '{targetType.FullName}' for OxySync Variant deserialization.", e);
+                    }
+
+                    var fields = ClassSerializationPolicy.GetSerializableFields(targetType);
+                    if (variantArray.Length != fields.Length)
+                    {
+                        throw new InvalidDataException(
+                            $"OxySync class payload field-count mismatch for '{targetType.FullName}'.");
+                    }
+
+                    for (int i = 0; i < fields.Length; i++)
+                    {
+                        FieldInfo field = fields[i];
+                        Variant memberValue = variantArray[i];
+                        object converted = VariantToObjectInternal(memberValue, field.FieldType, depth + 1);
+                        field.SetValue(instance, converted);
+                    }
+
+                    return instance;
                 }
             }
 

--- a/Shared/OxySync/VariantHelper.cs
+++ b/Shared/OxySync/VariantHelper.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace ONI_Together.Misc
+namespace Shared.OxySync
 {
     public static class VariantHelper
     {


### PR DESCRIPTION
This PR Require PR https://github.com/Lyraedan/Oxygen_Not_Included_Together/pull/207

Allow the Sync Var to have a serializable class type,
Internally, it use the existing `Variant[]` to store the class, and use recursion to support nested data type.

Unit Test included

No breaking changes. Should only do the a regression test.
