### PR TITLE
testing: add an env-gated harness for driving two instances on one PC

### DIFF
--- a/ONI_Together/DebugTools/TestHarness.cs
+++ b/ONI_Together/DebugTools/TestHarness.cs
@@ -363,6 +363,16 @@ namespace ONI_Together.DebugTools
 					int r = a.Length > 2 ? int.Parse(a[2]) : 2;
 					return Marks(cell, r);
 				}
+				case "filter":
+				{
+					int cell = ParseCell(a[1]);
+					var go = Grid.Objects[cell, (int)ObjectLayer.Building];
+					var filterable = go != null ? go.GetComponent<TreeFilterable>() : null;
+					if (filterable == null) return "no TreeFilterable at cell";
+					if (a.Length > 2 && a[2] == "clear") filterable.UpdateFilters(new HashSet<Tag>());
+					var tags = filterable.AcceptedTags;
+					return $"{Describe(go)} filter tags={tags.Count}: {string.Join(",", tags.Take(6).Select(t => t.Name))}";
+				}
 				case "copysettings":
 				{
 					// copysettings SRC_CELL DST_CELL: the copy-settings tool from the building at SRC onto DST.
@@ -375,6 +385,7 @@ namespace ONI_Together.DebugTools
 					tool.SetSourceObject(source);
 					PlayerController.Instance.ActivateTool(tool);
 					tool.OnDragTool(dst, 0);
+					tool.OnDragComplete(Vector3.zero, Vector3.zero);
 					PlayerController.Instance.ActivateTool(SelectTool.Instance);
 					return $"copied from {Describe(source)} to {Describe(Grid.Objects[dst, (int)ObjectLayer.Building])}";
 				}
@@ -488,16 +499,19 @@ namespace ONI_Together.DebugTools
 		{
 			Grid.CellToXY(cell, out int x, out int y);
 			var rows = new List<string>();
-			foreach (var brain in global::Components.Brains.Items)
-			{
-				if (brain == null) continue;
-				int c = Grid.PosToCell(brain);
-				Grid.CellToXY(c, out int cx, out int cy);
-				if (cx < x - r || cx > x + r || cy < y - r || cy > y + r) continue;
-				var faction = brain.GetComponent<FactionAlignment>();
-				var capturable = brain.GetComponent<Capturable>();
-				rows.Add($"{Describe(brain.gameObject)} attack={(faction != null && faction.IsPlayerTargeted() ? "y" : "n")} capture={(capturable != null && capturable.IsMarkedForCapture ? "y" : "n")}");
-			}
+			for (int cy = y - r; cy <= y + r; cy++)
+				for (int cx = x - r; cx <= x + r; cx++)
+				{
+					int c = Grid.XYToCell(cx, cy);
+					if (!Grid.IsValidCell(c)) continue;
+					foreach (var go in ItemsAt(c))
+					{
+						var faction = go.GetComponent<FactionAlignment>();
+						var capturable = go.GetComponent<Capturable>();
+						if (faction == null && capturable == null) continue;
+						rows.Add($"{Describe(go)} attack={(faction != null && faction.IsPlayerTargeted() ? "y" : "n")} capture={(capturable != null && capturable.IsMarkedForCapture ? "y" : "n")}");
+					}
+				}
 			return rows.Count == 0 ? "no creatures in box" : string.Join("; ", rows);
 		}
 

--- a/ONI_Together/DebugTools/TestHarness.cs
+++ b/ONI_Together/DebugTools/TestHarness.cs
@@ -309,6 +309,14 @@ namespace ONI_Together.DebugTools
 					var orientation = a.Length > 4 ? (Orientation)int.Parse(a[4]) : Orientation.Neutral;
 					var tool = BuildTool.Instance;
 					if (tool == null) return "no BuildTool";
+					// BuildTool.PostProcessBuild reads the priority from the product info screen's
+					// material panel, which only exists once that screen was shown for a building.
+					var info = PlanScreen.Instance != null ? PlanScreen.Instance.ProductInfoScreen : null;
+					if (info == null) return "no ProductInfoScreen";
+					info.ConfigureScreen(def);
+					info.Show(true);
+					if (info.materialSelectionPanel == null) return "no materialSelectionPanel after Show";
+					if (info.materialSelectionPanel.PriorityScreen == null) return "no PriorityScreen on the material panel";
 					tool.Activate(def, elements);
 					tool.buildingOrientation = orientation;
 					tool.lastDragCell = -1;
@@ -316,6 +324,7 @@ namespace ONI_Together.DebugTools
 					var built = Grid.Objects[cell, (int)def.ObjectLayer];
 					if (built == null && def.ReplacementLayer != ObjectLayer.NumLayers) built = Grid.Objects[cell, (int)def.ReplacementLayer];
 					PlayerController.Instance.ActivateTool(SelectTool.Instance);
+					info.Show(false);
 					return built != null ? $"placed {Describe(built)}" : "nothing at cell after TryBuild (invalid location?)";
 				}
 				case "buildraw":

--- a/ONI_Together/DebugTools/TestHarness.cs
+++ b/ONI_Together/DebugTools/TestHarness.cs
@@ -181,6 +181,8 @@ namespace ONI_Together.DebugTools
 			string cmd = a[0].ToLowerInvariant();
 			switch (cmd)
 			{
+				case "seed":
+					return $"seed={CustomGameSettings.Instance?.GetCurrentWorldgenSeed()} save={SaveGame.Instance?.BaseName} world={ClusterManager.Instance?.activeWorld?.name} grid={Grid.WidthInCells}x{Grid.HeightInCells}";
 				case "status":
 					return $"host={MultiplayerSession.IsHost} loss={DropUnreliableChance} dropped={_droppedUnreliable} inSession={MultiplayerSession.InActiveSession} client={GameClient.State} players={MultiplayerSession.PlayerCount} inGame={Utils.IsInGame()} speed={SpeedControlScreen.Instance?.GetSpeed()} paused={SpeedControlScreen.Instance?.IsPaused} cycle={GameClock.Instance?.GetCycle()} time={GameClock.Instance?.GetTime():F1} ids={NetworkIdentityRegistry.Count} grid={Grid.WidthInCells}x{Grid.HeightInCells}";
 				case "xy":
@@ -297,6 +299,28 @@ namespace ONI_Together.DebugTools
 				}
 				case "build":
 				{
+					// The path a click takes: BuildTool.Activate creates the visualizer and
+					// TryBuild places, so whatever the mod patches on the tool runs as well.
+					string prefab = a[1];
+					int cell = ParseCell(a[2]);
+					var def = Assets.GetBuildingDef(prefab);
+					if (def == null) return $"unknown def {prefab}";
+					var elements = new List<Tag> { TagManager.Create(a[3]) };
+					var orientation = a.Length > 4 ? (Orientation)int.Parse(a[4]) : Orientation.Neutral;
+					var tool = BuildTool.Instance;
+					if (tool == null) return "no BuildTool";
+					tool.Activate(def, elements);
+					tool.buildingOrientation = orientation;
+					tool.lastDragCell = -1;
+					tool.TryBuild(cell);
+					var built = Grid.Objects[cell, (int)def.ObjectLayer];
+					if (built == null && def.ReplacementLayer != ObjectLayer.NumLayers) built = Grid.Objects[cell, (int)def.ReplacementLayer];
+					PlayerController.Instance.ActivateTool(SelectTool.Instance);
+					return built != null ? $"placed {Describe(built)}" : "nothing at cell after TryBuild (invalid location?)";
+				}
+				case "buildraw":
+				{
+					// Places without the tool and sends the packet by hand; kept for branches where TryBuild is not patched.
 					string prefab = a[1];
 					int cell = ParseCell(a[2]);
 					var def = Assets.GetBuildingDef(prefab);

--- a/ONI_Together/DebugTools/TestHarness.cs
+++ b/ONI_Together/DebugTools/TestHarness.cs
@@ -311,12 +311,8 @@ namespace ONI_Together.DebugTools
 					if (tool == null) return "no BuildTool";
 					// BuildTool.PostProcessBuild reads the priority from the product info screen's
 					// material panel, which only exists once that screen was shown for a building.
-					var info = PlanScreen.Instance != null ? PlanScreen.Instance.ProductInfoScreen : null;
-					if (info == null) return "no ProductInfoScreen";
-					info.ConfigureScreen(def);
-					info.Show(true);
-					if (info.materialSelectionPanel == null) return "no materialSelectionPanel after Show";
-					if (info.materialSelectionPanel.PriorityScreen == null) return "no PriorityScreen on the material panel";
+					// CopyBuildingOrder is the game's own "select this building in the menu" path.
+					if (!SelectInPlanScreen(def, out string why)) return why;
 					tool.Activate(def, elements);
 					tool.buildingOrientation = orientation;
 					tool.lastDragCell = -1;
@@ -324,8 +320,107 @@ namespace ONI_Together.DebugTools
 					var built = Grid.Objects[cell, (int)def.ObjectLayer];
 					if (built == null && def.ReplacementLayer != ObjectLayer.NumLayers) built = Grid.Objects[cell, (int)def.ReplacementLayer];
 					PlayerController.Instance.ActivateTool(SelectTool.Instance);
-					info.Show(false);
 					return built != null ? $"placed {Describe(built)}" : "nothing at cell after TryBuild (invalid location?)";
+				}
+				case "ubuild":
+				{
+					// ubuild PREFAB ELEMENT CELL CELL ... : a wire/pipe path through the utility build tool.
+					var def = Assets.GetBuildingDef(a[1]);
+					if (def == null) return $"unknown def {a[1]}";
+					var elements = new List<Tag> { TagManager.Create(a[2]) };
+					var path = new List<BaseUtilityBuildTool.PathNode>();
+					for (int i = 3; i < a.Length; i++) path.Add(new BaseUtilityBuildTool.PathNode { cell = ParseCell(a[i]), valid = true });
+					if (path.Count == 0) return "no cells";
+					if (!SelectInPlanScreen(def, out string why)) return why;
+					BaseUtilityBuildTool tool = def.BuildingComplete.GetComponent<Wire>() != null ? (BaseUtilityBuildTool)WireBuildTool.Instance : UtilityBuildTool.Instance;
+					if (tool == null) return "no utility build tool";
+					tool.Activate(def, elements);
+					tool.path = path;
+					tool.BuildPath();
+					PlayerController.Instance.ActivateTool(SelectTool.Instance);
+					var placed = path.Select(n => Grid.Objects[n.cell, (int)def.TileLayer]).Where(g => g != null).ToList();
+					return $"path {path.Count} cells -> {placed.Count} objects: {string.Join(", ", placed.Select(Describe))}";
+				}
+				case "attack":
+				case "capture":
+				{
+					// attack|capture CELL [R]: the drag box a player would draw around the cell.
+					int cell = ParseCell(a[1]);
+					int r = a.Length > 2 ? int.Parse(a[2]) : 2;
+					Grid.CellToXY(cell, out int x, out int y);
+					Vector3 down = Grid.CellToPosCCC(Grid.XYToCell(x - r, y - r), Grid.SceneLayer.Move);
+					Vector3 up = Grid.CellToPosCCC(Grid.XYToCell(x + r, y + r), Grid.SceneLayer.Move);
+					DragTool tool = cmd == "attack" ? FindTool<AttackTool>() : (DragTool)FindTool<CaptureTool>();
+					if (tool == null) return $"no {cmd} tool";
+					PlayerController.Instance.ActivateTool(tool);
+					tool.OnDragComplete(down, up);
+					PlayerController.Instance.ActivateTool(SelectTool.Instance);
+					return $"{cmd} box {x - r},{y - r}..{x + r},{y + r}: " + Marks(cell, r);
+				}
+				case "marks":
+				{
+					int cell = ParseCell(a[1]);
+					int r = a.Length > 2 ? int.Parse(a[2]) : 2;
+					return Marks(cell, r);
+				}
+				case "copysettings":
+				{
+					// copysettings SRC_CELL DST_CELL: the copy-settings tool from the building at SRC onto DST.
+					int src = ParseCell(a[1]);
+					int dst = ParseCell(a[2]);
+					var source = Grid.Objects[src, (int)ObjectLayer.Building];
+					if (source == null) return "no building at source cell";
+					var tool = CopySettingsTool.Instance;
+					if (tool == null) return "no CopySettingsTool";
+					tool.SetSourceObject(source);
+					PlayerController.Instance.ActivateTool(tool);
+					tool.OnDragTool(dst, 0);
+					PlayerController.Instance.ActivateTool(SelectTool.Instance);
+					return $"copied from {Describe(source)} to {Describe(Grid.Objects[dst, (int)ObjectLayer.Building])}";
+				}
+				case "sandbox":
+				{
+					// sandbox on | brush CELL ELEMENT [MASS] | spawn CELL PREFAB | destroy CELL
+					switch (a[1])
+					{
+						case "on":
+							SaveGame.Instance.sandboxEnabled = true;
+							Game.Instance.SandboxModeActive = true;
+							return $"sandbox active={Game.Instance.SandboxModeActive} menu={(SandboxToolParameterMenu.instance != null)} settings={(SandboxToolParameterMenu.instance?.settings != null)}";
+						case "brush":
+						{
+							var settings = SandboxToolParameterMenu.instance?.settings;
+							if (settings == null) return "no sandbox settings (sandbox on first)";
+							var element = ElementLoader.FindElementByName(a[3]);
+							if (element == null) return $"unknown element {a[3]}";
+							settings.SetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT, ElementLoader.GetElementIndex(element.id));
+							if (a.Length > 4) settings.SetFloatSetting(SandboxSettings.KEY_MASS, float.Parse(a[4]));
+							var tool = SandboxBrushTool.instance;
+							if (tool == null) return "no SandboxBrushTool";
+							tool.OnPaintCell(ParseCell(a[2]), 0);
+							return $"brushed {element.id} at {ParseCell(a[2])}";
+						}
+						case "spawn":
+						{
+							var settings = SandboxToolParameterMenu.instance?.settings;
+							if (settings == null) return "no sandbox settings (sandbox on first)";
+							settings.SetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY, a[3]);
+							var spawner = FindTool<SandboxSpawnerTool>();
+							if (spawner == null) return "no SandboxSpawnerTool";
+							int cell = ParseCell(a[2]);
+							spawner.currentCell = cell;
+							spawner.Place(cell);
+							return $"spawned {a[3]} at {cell}: {string.Join(", ", ItemsAt(cell).Select(Describe))}";
+						}
+						case "destroy":
+						{
+							var tool = SandboxDestroyerTool.instance;
+							if (tool == null) return "no SandboxDestroyerTool";
+							tool.OnPaintCell(ParseCell(a[2]), 0);
+							return $"destroyed at {ParseCell(a[2])}";
+						}
+						default: return "sandbox on|brush|spawn|destroy";
+					}
 				}
 				case "buildraw":
 				{
@@ -365,6 +460,45 @@ namespace ONI_Together.DebugTools
 				default:
 					return "unknown command";
 			}
+		}
+
+		private static T FindTool<T>() where T : InterfaceTool
+		{
+			var tools = PlayerController.Instance != null ? PlayerController.Instance.tools : null;
+			if (tools != null)
+				foreach (var t in tools)
+					if (t is T match) return match;
+			return UnityEngine.Object.FindFirstObjectByType<T>(FindObjectsInactive.Include);
+		}
+
+		/// <summary>Selects the building in the build menu the way a player does, so the product info screen and its material panel exist.</summary>
+		private static bool SelectInPlanScreen(BuildingDef def, out string why)
+		{
+			why = null;
+			if (PlanScreen.Instance == null) { why = "no PlanScreen"; return false; }
+			PlanScreen.Instance.CopyBuildingOrder(def, "DEFAULT_FACADE");
+			var info = PlanScreen.Instance.ProductInfoScreen;
+			if (info == null) { why = "no ProductInfoScreen"; return false; }
+			if (info.materialSelectionPanel == null) { why = "no materialSelectionPanel after CopyBuildingOrder"; return false; }
+			if (info.materialSelectionPanel.PriorityScreen == null) { why = "no PriorityScreen on the material panel"; return false; }
+			return true;
+		}
+
+		private static string Marks(int cell, int r)
+		{
+			Grid.CellToXY(cell, out int x, out int y);
+			var rows = new List<string>();
+			foreach (var brain in global::Components.Brains.Items)
+			{
+				if (brain == null) continue;
+				int c = Grid.PosToCell(brain);
+				Grid.CellToXY(c, out int cx, out int cy);
+				if (cx < x - r || cx > x + r || cy < y - r || cy > y + r) continue;
+				var faction = brain.GetComponent<FactionAlignment>();
+				var capturable = brain.GetComponent<Capturable>();
+				rows.Add($"{Describe(brain.gameObject)} attack={(faction != null && faction.IsPlayerTargeted() ? "y" : "n")} capture={(capturable != null && capturable.IsMarkedForCapture ? "y" : "n")}");
+			}
+			return rows.Count == 0 ? "no creatures in box" : string.Join("; ", rows);
 		}
 
 		private static int ParseCell(string s)

--- a/ONI_Together/DebugTools/TestHarness.cs
+++ b/ONI_Together/DebugTools/TestHarness.cs
@@ -1,0 +1,493 @@
+using HarmonyLib;
+using Newtonsoft.Json;
+using ONI_Together.Misc;
+using ONI_Together.Misc.World;
+using ONI_Together.Networking;
+using ONI_Together.Networking.Components;
+using ONI_Together.Networking.Packets.Architecture;
+using ONI_Together.Networking.Packets.Tools.Build;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace ONI_Together.DebugTools
+{
+	/// <summary>
+	/// Scripted test rig, inactive unless the process was started with the environment
+	/// variable ONI_TOGETHER_TEST_DIR. It exists so that a host and a client can run on
+	/// one machine, be driven from a script and compared without anyone clicking:
+	///  - ONI_TOGETHER_KLEI_ROOT: replaces Documents\Klei for save files, prefs and mods,
+	///    so a second game instance never touches the real profile.
+	///  - ONI_TOGETHER_AUTO: "host:<save path>[:<ip>:<port>]" loads that save and starts a
+	///    LAN server from the main menu; "join:<ip>:<port>" connects as a client.
+	///  - <TEST_DIR>\commands.txt is polled twice a second; every new line is a command
+	///    (see Execute) and its result is appended to <TEST_DIR>\results.txt. Dumps of a
+	///    world region go to <TEST_DIR>\dump_<name>.json so the two sides can be diffed.
+	/// Nothing here runs for ordinary players.
+	/// </summary>
+	internal static class TestHarness
+	{
+		internal static readonly string Dir = Environment.GetEnvironmentVariable("ONI_TOGETHER_TEST_DIR");
+		internal static readonly string KleiRoot = Environment.GetEnvironmentVariable("ONI_TOGETHER_KLEI_ROOT");
+		internal static readonly string Auto = Environment.GetEnvironmentVariable("ONI_TOGETHER_AUTO");
+		internal static bool Enabled => !string.IsNullOrEmpty(Dir);
+
+		/// <summary>ONI_TOGETHER_TEST_LOSS: share (0..1) of outgoing unreliable datagrams to drop; simulates a lossy link.</summary>
+		internal static readonly float DropUnreliableChance = ParseLoss(Environment.GetEnvironmentVariable("ONI_TOGETHER_TEST_LOSS"));
+		private static int _droppedUnreliable;
+		internal static void CountDroppedUnreliable() => _droppedUnreliable++;
+
+		private static float ParseLoss(string text)
+		{
+			return float.TryParse(text, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value) ? Mathf.Clamp01(value) : 0f;
+		}
+
+		private static long _consumed;
+		private static float _nextPoll;
+		private static bool _autoDone;
+
+		/// <summary>
+		/// The profile redirect starts at the main menu, not at mod load: KMod.Manager
+		/// clears mods.json's mod_load_in_progress flag right after the mods loaded, and
+		/// with the redirect already active that write landed in the test profile while
+		/// the real file kept "true", so the next instance booted in mod safe mode.
+		/// </summary>
+		internal static bool RedirectActive;
+		private static string CommandsPath => Path.Combine(Dir, "commands.txt");
+		private static string ResultsPath => Path.Combine(Dir, "results.txt");
+
+		internal static void Init(GameObject modules)
+		{
+			if (!Enabled) return;
+			try
+			{
+				Directory.CreateDirectory(Dir);
+				modules.AddComponent<TestHarnessBehaviour>();
+				Result($"harness ready; kleiRoot={KleiRoot}; auto={Auto}");
+			}
+			catch (Exception ex)
+			{
+				DebugConsole.LogError($"[TestHarness] Init failed: {ex}");
+			}
+		}
+
+		internal static void OnMainMenu()
+		{
+			if (!Enabled) return;
+			RedirectActive = !string.IsNullOrEmpty(KleiRoot);
+			if (_autoDone || string.IsNullOrEmpty(Auto)) return;
+			_autoDone = true;
+			try
+			{
+				// One frame later: MainMenu.OnSpawn is still on the stack.
+				CoroutineRunner.RunOne(AutoFlow());
+			}
+			catch (Exception ex)
+			{
+				Result($"auto failed: {ex}");
+			}
+		}
+
+		private static System.Collections.IEnumerator AutoFlow()
+		{
+			yield return new WaitForSecondsRealtime(2f);
+			// host|<save path>|<ip>|<port>   or   join|<ip>|<port>
+			var parts = Auto.Split('|');
+			if (parts[0] == "host" && parts.Length >= 2)
+			{
+				string save = parts[1];
+				string ip = parts.Length >= 3 ? parts[2] : "127.0.0.1";
+				int port = parts.Length >= 4 ? int.Parse(parts[3]) : 8090;
+				Configuration.Instance.Host.LanSettings.Ip = ip;
+				Configuration.Instance.Host.LanSettings.Port = port;
+				Configuration.Instance.Host.LanSettings.Transport = LanTransportType.LiteNetLib;
+				NetworkConfig.UpdateLanTransport();
+				MultiplayerSession.ShouldHostAfterLoad = true;
+				KCrashReporter.MOST_RECENT_SAVEFILE = save;
+				SaveLoader.SetActiveSaveFilePath(save);
+				Result($"auto host: loading {save}, will listen on {ip}:{port}");
+				App.LoadScene("backend");
+			}
+			else if (parts[0] == "join" && parts.Length >= 3)
+			{
+				string ip = parts[1];
+				int port = int.Parse(parts[2]);
+				Configuration.Instance.Host.LanSettings.Transport = LanTransportType.LiteNetLib;
+				NetworkConfig.UpdateLanTransport();
+				Configuration.Instance.Client.LanSettings.Ip = ip;
+				Configuration.Instance.Client.LanSettings.Port = port;
+				Result($"auto join: {ip}:{port}");
+				GameClient.ConnectToHost(ip: ip, port: port);
+			}
+			else
+			{
+				Result($"auto: unrecognised '{Auto}'");
+			}
+		}
+
+		internal static void Tick()
+		{
+			if (Time.realtimeSinceStartup < _nextPoll) return;
+			_nextPoll = Time.realtimeSinceStartup + 0.5f;
+			try
+			{
+				if (!File.Exists(CommandsPath)) return;
+				string[] lines;
+				using (var fs = new FileStream(CommandsPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+				{
+					if (fs.Length <= _consumed) return;
+					fs.Seek(_consumed, SeekOrigin.Begin);
+					using var reader = new StreamReader(fs, Encoding.UTF8);
+					string text = reader.ReadToEnd();
+					_consumed = fs.Length;
+					lines = text.Split('\n');
+				}
+				foreach (var raw in lines)
+				{
+					string line = raw.Trim();
+					if (line.Length == 0 || line.StartsWith("#")) continue;
+					string result;
+					try { result = Execute(line); }
+					catch (Exception ex) { result = "EXCEPTION " + ex; }
+					Result($"{line} => {result}");
+				}
+			}
+			catch (Exception ex)
+			{
+				DebugConsole.LogError($"[TestHarness] Tick failed: {ex}");
+			}
+		}
+
+		private static void Result(string text)
+		{
+			string line = $"[{System.DateTime.UtcNow:HH:mm:ss.fff}] {text}";
+			DebugConsole.Log("[TestHarness] " + text);
+			try { File.AppendAllText(ResultsPath, line + "\n"); } catch { }
+		}
+
+		/// <summary>
+		/// Commands (cells are Grid cell indices; "x,y" is accepted too):
+		///  dig CELL | cancel CELL | deconstruct CELL | sweep CELL | sweepitem CELL | unsweepitem CELL
+		///  build PREFAB CELL ELEMENT [ORIENTATION 0-3] | prio CELL VALUE | speed 0-3 | pause | unpause
+		///  camera CELL | dump NAME X0 Y0 X1 Y1 | dupes NAME | hardsync | fps N
+		///  log TEXT | status | xy CELL | dumpc NAME CELL RADIUS | items CELL | quit
+		/// </summary>
+		private static string Execute(string line)
+		{
+			var a = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+			string cmd = a[0].ToLowerInvariant();
+			switch (cmd)
+			{
+				case "status":
+					return $"host={MultiplayerSession.IsHost} loss={DropUnreliableChance} dropped={_droppedUnreliable} inSession={MultiplayerSession.InActiveSession} client={GameClient.State} players={MultiplayerSession.PlayerCount} inGame={Utils.IsInGame()} speed={SpeedControlScreen.Instance?.GetSpeed()} paused={SpeedControlScreen.Instance?.IsPaused} cycle={GameClock.Instance?.GetCycle()} time={GameClock.Instance?.GetTime():F1} ids={NetworkIdentityRegistry.Count} grid={Grid.WidthInCells}x{Grid.HeightInCells}";
+				case "xy":
+				{
+					int cell = ParseCell(a[1]);
+					Grid.CellToXY(cell, out int x, out int y);
+					return $"cell {cell} = {x},{y}";
+				}
+				case "census":
+				{
+					var byPrefab = new SortedDictionary<string, int[]>();
+					int total = 0, local = 0;
+					foreach (var identity in NetworkIdentityRegistry.AllIdentities)
+					{
+						if (identity == null) continue;
+						string prefab;
+						bool pickupable;
+						try { prefab = identity.gameObject.PrefabID().ToString(); pickupable = identity.GetComponent<Pickupable>() != null; }
+						catch { continue; }
+						total++;
+						if (!byPrefab.TryGetValue(prefab, out var counts)) byPrefab[prefab] = counts = new int[3];
+						counts[0]++;
+						// the local-vs-host origin column needs NetworkIdentity.HostAssigned (identity PR); left at 0 here
+						if (pickupable) counts[2]++;
+					}
+					return WriteJson("census_" + a[1], new Dictionary<string, object>
+					{
+						["host"] = MultiplayerSession.IsHost,
+						["cycle"] = GameClock.Instance?.GetCycle(),
+						["time"] = GameClock.Instance != null ? Math.Round(GameClock.Instance.GetTime(), 1) : 0,
+						["ids"] = total,
+						["local"] = local,
+						["pending"] = 0, // PendingRemovals arrives with the identity PR
+						["prefabs"] = byPrefab,
+					});
+				}
+				case "dumpc":
+				{
+					int cell = ParseCell(a[2]);
+					int radius = int.Parse(a[3]);
+					Grid.CellToXY(cell, out int x, out int y);
+					return WriteJson("dump_" + a[1], DumpRegion(x - radius, y - radius, x + radius, y + radius));
+				}
+				case "items":
+				{
+					int cell = ParseCell(a[1]);
+					var sb = new StringBuilder();
+					foreach (var go in ItemsAt(cell))
+					{
+						var clearable = go.GetComponent<Clearable>();
+						sb.Append(Describe(go)).Append(clearable != null && clearable.isMarkedForClear ? " [sweep]" : "").Append("; ");
+					}
+					return sb.Length > 0 ? sb.ToString() : "no items";
+				}
+				case "log":
+					return "logged";
+				case "quit":
+					App.Quit();
+					return "quitting";
+				case "fps":
+					Application.targetFrameRate = int.Parse(a[1]);
+					return $"targetFrameRate={Application.targetFrameRate}";
+				case "speed":
+					SpeedControlScreen.Instance.SetSpeed(int.Parse(a[1]));
+					return $"speed={SpeedControlScreen.Instance.GetSpeed()}";
+				case "pause":
+					SpeedControlScreen.Instance.Pause(false);
+					return "paused";
+				case "unpause":
+					SpeedControlScreen.Instance.Unpause(false);
+					return "unpaused";
+				case "camera":
+				{
+					int cell = ParseCell(a[1]);
+					float size = a.Length > 2 ? float.Parse(a[2]) : 12f;
+					CameraController.Instance.SetTargetPos(Grid.CellToPosCCC(cell, Grid.SceneLayer.Move), size, false);
+					return $"camera -> {cell}";
+				}
+				case "dig":
+				{
+					int cell = ParseCell(a[1]);
+					var go = DigTool.PlaceDig(cell, 0);
+					return go != null ? $"diggable {Describe(go)}" : "nothing placed";
+				}
+				case "cancel":
+					CancelTool.Instance.OnDragTool(ParseCell(a[1]), 0);
+					return "cancel sent";
+				case "deconstruct":
+					DeconstructTool.Instance.OnDragTool(ParseCell(a[1]), 0);
+					return "deconstruct sent";
+				case "sweep":
+					ClearTool.Instance.OnDragTool(ParseCell(a[1]), 0);
+					return "sweep sent";
+				case "sweepitem":
+				case "unsweepitem":
+				{
+					int cell = ParseCell(a[1]);
+					var items = ItemsAt(cell);
+					if (items.Count == 0) return "no item at cell";
+					var clearable = items[0].GetComponent<Clearable>();
+					if (clearable == null) return "first item has no Clearable";
+					if (cmd == "sweepitem") clearable.MarkForClear(false, false); else clearable.CancelClearing();
+					return $"{cmd} {Describe(items[0])}";
+				}
+				case "prio":
+				{
+					int cell = ParseCell(a[1]);
+					int value = int.Parse(a[2]);
+					var go = Grid.Objects[cell, (int)ObjectLayer.Building] ?? Grid.Objects[cell, (int)ObjectLayer.DigPlacer] ?? Grid.Objects[cell, (int)ObjectLayer.FoundationTile];
+					var prioritizable = go != null ? go.GetComponent<Prioritizable>() : null;
+					if (prioritizable == null) return "nothing prioritizable at cell";
+					prioritizable.SetMasterPriority(new PrioritySetting(PriorityScreen.PriorityClass.basic, value));
+					return $"priority {value} on {Describe(go)}";
+				}
+				case "build":
+				{
+					string prefab = a[1];
+					int cell = ParseCell(a[2]);
+					var def = Assets.GetBuildingDef(prefab);
+					if (def == null) return $"unknown def {prefab}";
+					var elements = new List<Tag> { TagManager.Create(a[3]) };
+					var orientation = a.Length > 4 ? (Orientation)int.Parse(a[4]) : Orientation.Neutral;
+					Vector3 pos = Grid.CellToPosCBC(cell, Grid.SceneLayer.Building);
+					GameObject built;
+					if (def.ReplacementLayer != ObjectLayer.NumLayers && def.GetReplacementCandidate(cell) != null && !def.IsReplacementLayerOccupied(cell))
+					{
+						var visualizer = Util.KInstantiate(def.BuildingPreview, pos);
+						built = def.TryReplaceTile(visualizer, pos, orientation, elements, "DEFAULT_FACADE");
+						if (built != null) Grid.Objects[cell, (int)def.ReplacementLayer] = built;
+					}
+					else
+					{
+						var visualizer = Util.KInstantiate(def.BuildingPreview, pos);
+						built = def.TryPlace(visualizer, pos, orientation, elements, "DEFAULT_FACADE");
+					}
+					if (built == null) return "TryPlace returned null (invalid location?)";
+					// What BuildToolPatch does after BuildTool.TryBuild placed something.
+					DebugConsole.Log($"[BuildTool] Placed {def.PrefabID} at cell {cell}");
+					PacketSender.SendToAllOtherPeers(new BuildPacket(def.PrefabID, cell, orientation, elements, def.ObjectLayer, false));
+					return $"placed {Describe(built)}";
+				}
+				case "hardsync":
+					GameServerHardSync.PerformHardSync();
+					return "hard sync requested";
+				case "dupes":
+					return WriteJson("dupes_" + a[1], DumpDupes());
+				case "dump":
+					return WriteJson("dump_" + a[1], DumpRegion(int.Parse(a[2]), int.Parse(a[3]), int.Parse(a[4]), int.Parse(a[5])));
+				default:
+					return "unknown command";
+			}
+		}
+
+		private static int ParseCell(string s)
+		{
+			if (s.Contains(","))
+			{
+				var xy = s.Split(',');
+				return Grid.XYToCell(int.Parse(xy[0]), int.Parse(xy[1]));
+			}
+			return int.Parse(s);
+		}
+
+		private static string Describe(GameObject go)
+		{
+			if (go == null) return "null";
+			var identity = go.GetExistingNetIdentity();
+			return $"{go.name} cell={Grid.PosToCell(go)} netId={(identity != null ? identity.NetId : 0)}";
+		}
+
+		private static List<GameObject> ItemsAt(int cell)
+		{
+			var result = new List<GameObject>();
+			var head = Grid.Objects[cell, (int)ObjectLayer.Pickupables];
+			var item = head != null ? head.GetComponent<Pickupable>()?.objectLayerListItem : null;
+			int guard = 0;
+			while (item != null && guard++ < 10000)
+			{
+				if (item.gameObject != null) result.Add(item.gameObject);
+				item = item.nextItem;
+			}
+			return result;
+		}
+
+		private static string WriteJson(string name, object data)
+		{
+			string path = Path.Combine(Dir, name + ".json");
+			File.WriteAllText(path, JsonConvert.SerializeObject(data, Formatting.Indented));
+			return path;
+		}
+
+		private static readonly ObjectLayer[] DumpLayers =
+		{
+			ObjectLayer.Building, ObjectLayer.FoundationTile, ObjectLayer.ReplacementTile, ObjectLayer.DigPlacer,
+			ObjectLayer.Wire, ObjectLayer.LiquidConduit, ObjectLayer.GasConduit, ObjectLayer.LogicWire,
+			ObjectLayer.Backwall, ObjectLayer.Plants,
+		};
+
+		/// <summary>Per cell: element, mass, the object on each structural layer, the items lying there.</summary>
+		private static object DumpRegion(int x0, int y0, int x1, int y1)
+		{
+			var cells = new List<object>();
+			for (int y = Math.Min(y0, y1); y <= Math.Max(y0, y1); y++)
+			for (int x = Math.Min(x0, x1); x <= Math.Max(x0, x1); x++)
+			{
+				int cell = Grid.XYToCell(x, y);
+				if (!Grid.IsValidCell(cell)) continue;
+				var entry = new Dictionary<string, object>
+				{
+					["cell"] = cell,
+					["el"] = Grid.Element[cell].id.ToString(),
+					["mass"] = Math.Round(Grid.Mass[cell], 1),
+					["solid"] = Grid.Solid[cell],
+				};
+				foreach (var layer in DumpLayers)
+				{
+					var go = Grid.Objects[cell, (int)layer];
+					if (go == null) continue;
+					var obj = new Dictionary<string, object> { ["prefab"] = go.PrefabID().ToString() };
+					var identity = go.GetExistingNetIdentity();
+					if (identity != null) obj["netId"] = identity.NetId;
+					if (go.GetComponent<Constructable>() != null) obj["state"] = "constructable";
+					else if (go.GetComponent<BuildingComplete>() != null) obj["state"] = "complete";
+					var prioritizable = go.GetComponent<Prioritizable>();
+					if (prioritizable != null) obj["prio"] = prioritizable.GetMasterPriority().priority_value;
+					var deconstructable = go.GetComponent<Deconstructable>();
+					if (deconstructable != null && deconstructable.IsMarkedForDeconstruction()) obj["deconstruct"] = true;
+					var primary = go.GetComponent<PrimaryElement>();
+					if (primary != null) { obj["pel"] = primary.ElementID.ToString(); obj["pmass"] = Math.Round(primary.Mass, 1); }
+					entry[layer.ToString()] = obj;
+				}
+				var items = ItemsAt(cell);
+				if (items.Count > 0)
+				{
+					var list = new List<object>();
+					foreach (var go in items)
+					{
+						var obj = new Dictionary<string, object> { ["prefab"] = go.PrefabID().ToString() };
+						var identity = go.GetExistingNetIdentity();
+						if (identity != null) obj["netId"] = identity.NetId;
+						var primary = go.GetComponent<PrimaryElement>();
+						if (primary != null) obj["mass"] = Math.Round(primary.Mass, 2);
+						var clearable = go.GetComponent<Clearable>();
+						if (clearable != null && clearable.isMarkedForClear) obj["sweep"] = true;
+						list.Add(obj);
+					}
+					entry["items"] = list;
+				}
+				cells.Add(entry);
+			}
+			return new Dictionary<string, object>
+			{
+				["host"] = MultiplayerSession.IsHost,
+				["cycle"] = GameClock.Instance?.GetCycle(),
+				["time"] = GameClock.Instance != null ? Math.Round(GameClock.Instance.GetTime(), 1) : 0,
+				["ids"] = NetworkIdentityRegistry.Count,
+				["cells"] = cells,
+			};
+		}
+
+		private static object DumpDupes()
+		{
+			var list = new List<object>();
+			foreach (var identity in global::Components.MinionIdentities.Items)
+			{
+				if (identity == null) continue;
+				var go = identity.gameObject;
+				var netIdentity = go.GetExistingNetIdentity();
+				var chore = identity.GetComponent<ChoreDriver>()?.GetCurrentChore();
+				list.Add(new Dictionary<string, object>
+				{
+					["name"] = identity.GetProperName(),
+					["netId"] = netIdentity != null ? netIdentity.NetId : 0,
+					["cell"] = Grid.PosToCell(go),
+					["chore"] = chore != null ? chore.GetType().Name : "none",
+					["target"] = chore?.target != null ? Grid.PosToCell(chore.target.gameObject) : -1,
+				});
+			}
+			return list;
+		}
+	}
+
+	internal class TestHarnessBehaviour : MonoBehaviour
+	{
+		private void Update()
+		{
+			TestHarness.Tick();
+		}
+	}
+
+	[HarmonyPatch(typeof(Util), nameof(Util.GetKleiRootPath))]
+	internal static class TestHarness_KleiRootPatch
+	{
+		private static bool Prefix(ref string __result)
+		{
+			if (!TestHarness.RedirectActive || string.IsNullOrEmpty(TestHarness.KleiRoot)) return true;
+			__result = TestHarness.KleiRoot;
+			return false;
+		}
+	}
+
+	[HarmonyPatch(typeof(MainMenu), "OnSpawn")]
+	internal static class TestHarness_MainMenuPatch
+	{
+		private static void Postfix()
+		{
+			TestHarness.OnMainMenu();
+		}
+	}
+}

--- a/ONI_Together/MultiplayerMod.cs
+++ b/ONI_Together/MultiplayerMod.cs
@@ -91,6 +91,7 @@ namespace ONI_Together
 				go.AddComponent<OxySyncManager>();
 				go.AddComponent<NetIdActivityTracker>();
 				go.AddComponent<DiscordRichPresence>();
+				TestHarness.Init(go);
 
 				// CHECKPOINT 5
 				System.IO.File.AppendAllText(logPath, "[Trace] Checkpoint 5: Pre-Listeners\n");

--- a/ONI_Together/Networking/Extensions.cs
+++ b/ONI_Together/Networking/Extensions.cs
@@ -51,6 +51,48 @@ namespace ONI_Together.Networking
 			return identity != null;
 		}
 
+		/// <summary>
+		/// The identity this object already has, or null. Never attaches one.
+		///
+		/// GetNetIdentity above ends in AddComponent, which is right when the caller is
+		/// about to address the object and wrong when it is only asking. Five places in
+		/// the mod already need the asking version and spell it out by hand as
+		/// GetComponent&lt;NetworkIdentity&gt;() - both overlay draw paths, both overlay
+		/// hover paths, and the cell fallback in BuildingConfigPacket - so they lose the
+		/// null check and the profiler scope the helpers have.
+		///
+		/// The overlay is the clearest case: drawing a network overlay should not attach
+		/// a NetworkIdentity to whatever the cursor passes over.
+		/// </summary>
+		public static NetworkIdentity GetExistingNetIdentity(this GameObject go)
+		{
+			using var _ = Profiler.Scope();
+
+			if (go.IsNullOrDestroyed())
+				return null;
+
+			return go.TryGetComponent<NetworkIdentity>(out var identity) ? identity : null;
+		}
+
+		/// <summary>Same, from a component - the overload GetNetIdentity already has.</summary>
+		public static NetworkIdentity GetExistingNetIdentity(this MonoBehaviour behaviour)
+		{
+			using var _ = Profiler.Scope();
+
+			if (behaviour.IsNullOrDestroyed())
+				return null;
+
+			return behaviour.gameObject.GetExistingNetIdentity();
+		}
+
+		/// <summary>The asking form of TryGetNetIdentity: reports what is there, adds nothing.</summary>
+		public static bool TryGetExistingNetIdentity(this GameObject go, out NetworkIdentity identity)
+		{
+			using var _ = Profiler.Scope();
+			identity = GetExistingNetIdentity(go);
+			return identity != null;
+		}
+
 		public static int GetNetId(this MonoBehaviour behaviour)
 		{
 			using var _ = Profiler.Scope();

--- a/ONI_Together/Networking/Overlay/NetworkingOverlayMode.cs
+++ b/ONI_Together/Networking/Overlay/NetworkingOverlayMode.cs
@@ -393,7 +393,7 @@ namespace ONI_Together.Networking.Overlay
 		{
 			if (root != null)
 			{
-				var identity = root.GetComponent<NetworkIdentity>();
+				var identity = root.GetExistingNetIdentity();
 				if (identity != null)
 					partition?.Add(identity);
 			}
@@ -403,7 +403,7 @@ namespace ONI_Together.Networking.Overlay
 		{
 			if (root != null && root.gameObject != null)
 			{
-				var identity = root.GetComponent<NetworkIdentity>();
+				var identity = root.GetExistingNetIdentity();
 				if (identity != null)
 				{
 					layerTargets.Remove(identity);

--- a/ONI_Together/Networking/Overlay/NetworkingOverlayPatches.cs
+++ b/ONI_Together/Networking/Overlay/NetworkingOverlayPatches.cs
@@ -275,7 +275,7 @@ namespace ONI_Together.Networking.Overlay
 			internal static void Postfix(SelectToolHoverTextCard __instance)
 			{
 				__instance.modeFilters[NetworkingOverlayMode.ID] =
-					(KSelectable sel) => sel.GetComponent<NetworkIdentity>() != null;
+					(KSelectable sel) => sel.GetExistingNetIdentity() != null;
 				__instance.overlayFilterMap[NetworkingOverlayMode.ID] = () => false;
 			}
 		}
@@ -290,7 +290,7 @@ namespace ONI_Together.Networking.Overlay
 
 				var hover = SelectTool.Instance?.hover;
 				if (hover == null) return;
-				var identity = hover.GetComponent<NetworkIdentity>();
+				var identity = hover.GetExistingNetIdentity();
 				if (identity == null || identity.NetId == 0) return;
 
 				var tracker = NetIdActivityTracker.Instance;


### PR DESCRIPTION
Wire format: unchanged
Note: the first commit is #176 by @younatics (the non-creating identity lookup this needs); the census columns that need NetworkIdentity.HostAssigned / PendingRemovals from later identity work read 0 here.

## Problem
Reproducing the desyncs players report needs a host and a client at the same
time, driven from a script rather than by hand, and most of us have one PC.
Two copies of the game share the Klei folder (mods.json, saves), so they cannot
even run side by side out of the box.

## What this adds
Nothing runs unless the environment variables are set; without them the mod
behaves exactly as before.

- `ONI_TOGETHER_TEST_DIR` - polls `commands.txt` twice a second and answers in
  `results.txt`: status, xy, dig, cancel, deconstruct, sweep, sweepitem, prio,
  build, speed, pause/unpause, camera, region dumps (every layer with prefab,
  NetId, state, priority, mass), identity census, dupes, hardsync, quit.
- `ONI_TOGETHER_KLEI_ROOT` - redirects the Klei folder once the main menu is
  up (any earlier and the real mods.json is left with `mod_load_in_progress`
  set, so the next boot is in safe mode), so two copies keep separate mods and
  saves.
- `ONI_TOGETHER_AUTO=host|<save>|<ip>|<port>` or `join|<ip>|<port>` - hosts a
  save or joins an address without clicking through the menus.
- `ONI_TOGETHER_TEST_LOSS` - drops a share of unreliable datagrams to exercise
  the recovery paths.

## Verified
This is the rig every other PR from me was tested on: host + client on one
machine, orders issued from both sides through `commands.txt`, region dumps
diffed for identical NetIds, soaks of 30 min to 4.5 h with an identity census
before and after. Release build, no new warnings.
