### PR TITLE
storage: skip disease transfer when the storage has no primary element

### DIFF
--- a/ONI_Together/Networking/Packets/World/StorageItemPacket.cs
+++ b/ONI_Together/Networking/Packets/World/StorageItemPacket.cs
@@ -149,6 +149,8 @@ namespace ONI_Together.Networking.Packets.World
             if (go == null || storage == null) return;
 
             PrimaryElement primaryElement = storage.primaryElement;
+            // Match Storage.TransferDiseaseWithObject: some storages have no primary element.
+            if (primaryElement == null) return;
             PrimaryElement component = go.GetComponent<PrimaryElement>();
             if(!(component == null))
             {


### PR DESCRIPTION
Wire format: unchanged

## Problem
Two client traces fail in `HandleDiseaseTransfer` at offset 0x64 (Player (4)
at 20:13:06.437 and Player-prev (2) at 16:34:17.709). The exception also skipped
the remaining pickupable removal and the rest of its bulk packet.

## Cause
`storage.primaryElement` may legitimately be null; the game's own
`Storage.TransferDiseaseWithObject` guards for it (Assembly-CSharp IL_0011
through IL_001f), the mod's handler did not.

## Fix
Return before the disease reads when the storage has no primary element; the
normal transfer math is unchanged.

## Verified
Release build; the built handler inspected with Mono.Cecil. No packet or
logging change.
