### PR TITLE
packet_handler: a client with no world dispatches only the connection flow

### DIFF
--- a/ONI_Together/Networking/Packets/Architecture/PacketHandler.cs
+++ b/ONI_Together/Networking/Packets/Architecture/PacketHandler.cs
@@ -3,6 +3,13 @@ using System.IO;
 using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Overlay;
+using ONI_Together.Networking.Packets.Core;
+using ONI_Together.Networking.Packets.Handshake;
+using ONI_Together.Networking.Packets.Social;
+using ONI_Together.Networking.Packets.Tools;
+using ONI_Together.Networking.Packets.World;
+using ONI_Together.Misc;
+using System.Collections.Generic;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -12,6 +19,75 @@ namespace ONI_Together.Networking.Packets.Architecture
 	public static class PacketHandler
 	{
 		private static bool _readyToProcess = true;
+
+		/// <summary>
+		/// The packets a client may act on while it has no world - in the frontend, waiting
+		/// for or downloading the host's save.
+		///
+		/// readyToProcess is switched on in the menu on purpose (GameClient.ContinueConnectionFlow),
+		/// because the save transfer itself arrives as packets. But the host does not filter
+		/// what it broadcasts by a client's readiness: SendToAllClients walks every connected
+		/// player, and MultiplayerPlayer.readyState is tracked but never consulted when
+		/// sending. So a client in the menu receives the live world - effect toggles for
+		/// duplicants it does not have, prefab spawns into a grid that does not exist,
+		/// tool packets against no buildings. With Grid.WidthInCells at zero those land as
+		/// DivideByZeroException inside Grid.CellToPos, NullReferenceException in
+		/// Workable.OnSpawn, Prioritizable.OnSpawn and SaveLoadRoot.OnSpawn, and a
+		/// DivideByZeroException in KBatchedAnimUpdater every frame until the world loads.
+		/// Measured on a client two seconds into a save download: 224 effect toggles for
+		/// missing minions, seven prefab spawns into no world, 76 anim-updater frames.
+		///
+		/// Everything outside this set is dropped, not queued. That is safe: HandleIncoming
+		/// already drops rather than queues while not ready, and the state those packets
+		/// describe is in the save the client is about to load.
+		///
+		/// BulkSenderPacket and ChunkedPacket are containers. Chunked re-enters
+		/// HandleIncoming, so it is gated by the same check; Bulk dispatches its inner
+		/// packets directly and applies ShouldDispatchWithoutWorld to each of them itself.
+		/// </summary>
+		private static readonly HashSet<Type> AllowedWithoutWorld = new HashSet<Type>
+		{
+			// connection flow and readiness
+			typeof(GameStateRequestPacket),
+			typeof(ClientReadyStatusPacket),
+			typeof(ClientReadyStatusUpdatePacket),
+			typeof(AllClientsReadyPacket),
+			typeof(HardSyncPacket),
+			typeof(HardSyncCompletePacket),
+			typeof(HostBroadcastPacket),
+			typeof(DedicatedServerMessagePacket),
+			typeof(DisconnectPacket),
+			typeof(PingPacket),
+			// save transfer
+			typeof(SaveFileRequestPacket),
+			typeof(SaveFileChunkPacket),
+			typeof(ChunkAckPacket),
+			typeof(TcpTransferStartPacket),
+			typeof(TcpFallbackRequestPacket),
+			typeof(SecureTransferPacket),
+			typeof(SyncProgressPacket),
+			typeof(WorldDataPacket),
+			typeof(WorldDataRequestPacket),
+			// chat is harmless without a world
+			typeof(ChatMessagePacket),
+			typeof(ChatHistorySyncPacket),
+			// containers
+			typeof(BulkSenderPacket),
+			typeof(ChunkedPacket),
+		};
+
+		/// <summary>
+		/// True when this packet may run on the local side right now. Only a client with no
+		/// world is restricted; a host, or a client in a loaded world, dispatches everything.
+		/// </summary>
+		public static bool ShouldDispatchWithoutWorld(IPacket packet)
+		{
+			using var _ = Profiler.Scope();
+
+			if (MultiplayerSession.IsHost) return true;
+			if (!Utils.IsInMenu()) return true;
+			return AllowedWithoutWorld.Contains(packet.GetType());
+		}
 		private static float _notReadySince = float.MaxValue;
 		private const float NOT_READY_TIMEOUT = 60f;
 
@@ -58,6 +134,10 @@ namespace ONI_Together.Networking.Packets.Architecture
 
                     var packet = PacketRegistry.Create(type);
 					packet.Deserialize(reader);
+
+					if (!ShouldDispatchWithoutWorld(packet))
+						return;
+
 					Dispatch(packet);
 
                     scope.End(packet.GetType().Name, data.Length);

--- a/ONI_Together/Networking/Packets/Core/BulkSenderPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/BulkSenderPacket.cs
@@ -74,7 +74,10 @@ namespace ONI_Together.Networking.Packets.Core
 				var ms = new MemoryStream(packetData);
 				var reader = new BinaryReader(ms);
 				innerPacket.Deserialize(reader);
-				innerPacket.OnDispatched();
+				// Inner packets bypass PacketHandler.HandleIncoming, so the no-world gate
+				// has to be applied here as well - see PacketHandler.AllowedWithoutWorld.
+				if (PacketHandler.ShouldDispatchWithoutWorld(innerPacket))
+					innerPacket.OnDispatched();
 				reader.Dispose();
 				ms.Dispose();
 			}


### PR DESCRIPTION
Wire format: unchanged

## Problem
Every client log since the transport rewrite carries "Could not find minion"
lines, and a client sitting in the frontend while the host's save downloads
throws:

    DivideByZeroException   Grid.CellToPos, inside the packet handler
    DivideByZeroException   KBatchedAnimUpdater.PosToChunkXY, every frame
    NullReferenceException  Workable.OnSpawn, Prioritizable.OnSpawn,
                            SaveLoadRoot.OnSpawn - the spawned prefabs

Measured on a client two seconds into a save download: 224 effect toggles for
missing minions, seven prefab spawns into no world, 76 anim-updater frames.

## Cause
`readyToProcess` is switched on in the menu on purpose - the save transfer
itself arrives as packets - but the host does not filter what it broadcasts by a
client's readiness: `SendToAllClients` walks every connected player and
`MultiplayerPlayer.readyState` is tracked but never consulted when sending. So
a client with `Grid.WidthInCells == 0` receives the live world.

## Fix
`PacketHandler` keeps a set of the packets a client may act on without a world
- connection flow, readiness, hard sync, the save transfer, chat, and the two
container packets - and drops everything else while the client is in the
frontend. Dropped, not queued: `HandleIncoming` already drops rather than
queues while not ready, and the state those packets describe is in the save
the client is about to load. A host, or a client in a loaded world, is not
restricted. `BulkSenderPacket` dispatches its inner packets directly rather than
through `HandleIncoming`, so it applies the same check to each of them itself;
`ChunkedPacket` re-enters `HandleIncoming` and needs nothing.

## Verified
Join on the one-PC rig while the host runs at speed 3: zero exceptions during
the save download, the "Could not find minion" lines are gone. Release build.
