### PR TITLE
OxySync: migrate all player tools to OxySync

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/AttackToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/AttackToolSyncer.cs
@@ -1,0 +1,85 @@
+using HarmonyLib;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class AttackToolSyncer : NetworkBehaviour
+    {
+        public static AttackToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("AttackToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<AttackToolSyncer>();
+            }
+            Instance.NetId = nameof(AttackToolSyncer).GetHashCode();
+        }
+
+        public static void RequestAttack(Vector2 min, Vector2 max)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdAttack), min, max, (int)p.priority_class, p.priority_value);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[AttackToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdAttack(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            CallClientRpc(nameof(RpcAttack), min, max, priority_class, priority_value);
+        }
+
+        [ClientRpc]
+        private void RpcAttack(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            if (_processing) return;
+            _processing = true;
+            try
+            {
+                var ps = ToolMenu.Instance?.PriorityScreen;
+                if (ps == null)
+                {
+                    AttackTool.MarkForAttack(min, max, true);
+                    return;
+                }
+                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+                var prev = tr.GetValue<PrioritySetting>();
+                tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+                try { AttackTool.MarkForAttack(min, max, true); }
+                finally { tr.SetValue(prev); }
+            }
+            finally { _processing = false; }
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/BuildToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/BuildToolSyncer.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Linq;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class BuildToolSyncer : NetworkBehaviour
+    {
+        public static BuildToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("BuildToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<BuildToolSyncer>();
+            }
+            Instance.NetId = nameof(BuildToolSyncer).GetHashCode();
+        }
+
+        public static void RequestBuild(string prefabID, int cell, int orientation, List<string> materialTags, int objectLayer, bool instantBuild)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = PlanScreen.Instance != null ? PlanScreen.Instance.GetBuildingPriority() : ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdBuild), prefabID, cell, orientation, materialTags, (int)p.priority_class, p.priority_value, objectLayer, instantBuild);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[BuildToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild)
+        {
+            CallClientRpc(nameof(RpcBuild), prefabID, cell, orientation, materialTags, priority_class, priority_value, objectLayer, instantBuild);
+        }
+
+        [ClientRpc]
+        private void RpcBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild)
+        {
+            if (_processing) return;
+            if (!Grid.IsValidCell(cell)) return;
+            var def = Assets.GetBuildingDef(prefabID);
+            if (def == null) return;
+            _processing = true;
+            try
+            {
+                var tags = materialTags.Select(t => TagManager.Create(t)).ToList();
+                var pos = Grid.CellToPosCBC(cell, Grid.SceneLayer.Building);
+                GameObject built = null;
+                if (instantBuild)
+                    built = BuildInternal(def, tags, pos, (Orientation)orientation, cell);
+                else
+                    built = QueueBuild(def, tags, pos, (Orientation)orientation);
+                if (built == null && def.ReplacementLayer != ObjectLayer.NumLayers)
+                    built = HandleReplacement(def, pos, tags, (Orientation)orientation, cell, instantBuild) ?? built;
+                var pri = built?.GetComponent<Prioritizable>();
+                if (pri != null)
+                    pri.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+            }
+            finally
+            {
+                _processing = false;
+            }
+        }
+
+        private static GameObject QueueBuild(BuildingDef def, List<Tag> tags, Vector3 pos, Orientation orientation)
+        {
+            var viz = Util.KInstantiate(def.BuildingPreview, pos);
+            return def.TryPlace(viz, pos, orientation, tags, "DEFAULT_FACADE");
+        }
+
+        private static GameObject BuildInternal(BuildingDef def, List<Tag> tags, Vector3 pos, Orientation orientation, int cell)
+        {
+            if (!def.IsValidBuildLocation(null, pos, orientation) || !def.IsValidPlaceLocation(null, pos, orientation, out _))
+                return null;
+            if (def.ObjectLayer == ObjectLayer.Building)
+            {
+                def.RunOnArea(cell, orientation, c =>
+                {
+                    if (Uprootable.CanUproot(Grid.Objects[c, (int)def.ObjectLayer], out var u))
+                        u.CompleteWork(null);
+                });
+            }
+            else if (def.ObjectLayer == ObjectLayer.Backwall)
+            {
+                def.RunOnArea(cell, orientation, c =>
+                {
+                    if (BackwallManager.HasBackwall(c))
+                        SimMessages.Dig(c, -1, skipEvent: true, backwall: true);
+                });
+            }
+            float temp = Mathf.Min(def.Temperature, ElementLoader.GetMinMeltingPointAmongElements(tags) - 10f);
+            return def.Build(cell, orientation, null, tags, temp, "DEFAULT_FACADE", false, GameClock.Instance.GetTime());
+        }
+
+        private static GameObject HandleReplacement(BuildingDef def, Vector3 pos, List<Tag> tags, Orientation orientation, int cell, bool instant)
+        {
+            var cand = def.GetReplacementCandidate(cell);
+            if (cand == null || def.IsReplacementLayerOccupied(cell)) return null;
+            var comp = cand.GetComponent<BuildingComplete>();
+            if (comp == null || !comp.Def.Replaceable || !def.CanReplace(cand)) return null;
+            var tag = cand.GetComponent<PrimaryElement>().Element.tag;
+            if (tag.GetHash() == (int)SimHashes.StableSnow) tag = SimHashes.Snow.CreateTag();
+            if (comp.Def == def && tags.Count > 0 && tags[0] == tag) return null;
+            var viz = Util.KInstantiate(def.BuildingPreview, pos);
+            if (!instant)
+            {
+                var r = def.TryReplaceTile(viz, pos, orientation, tags, "DEFAULT_FACADE");
+                if (r != null) Grid.Objects[cell, (int)def.ReplacementLayer] = r;
+                return r;
+            }
+            if (!def.IsValidBuildLocation(null, pos, orientation, true) || !def.IsValidPlaceLocation(null, pos, orientation, true, out _)) return null;
+            float temp = Mathf.Min(def.Temperature, ElementLoader.GetMinMeltingPointAmongElements(tags) - 10f);
+            return def.Build(cell, orientation, null, tags, temp, "DEFAULT_FACADE", false, GameClock.Instance.GetTime());
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/BuildingActionSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/BuildingActionSyncer.cs
@@ -1,0 +1,127 @@
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.Components;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class BuildingActionSyncer : NetworkBehaviour
+    {
+        public static BuildingActionSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("BuildingActionSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<BuildingActionSyncer>();
+            }
+            Instance.NetId = nameof(BuildingActionSyncer).GetHashCode();
+        }
+
+        public static void RequestAction(int netId, byte action)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try { s.CallCommand(nameof(CmdAction), netId, action); }
+            catch (System.Exception ex) { DebugConsole.LogWarning($"[BuildingActionSyncer] {ex}"); }
+        }
+
+        public static void RequestClearable(int netId, int cell, bool isMarked)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try { s.CallCommand(nameof(CmdClearable), netId, cell, isMarked); }
+            catch (System.Exception ex) { DebugConsole.LogWarning($"[BuildingActionSyncer] {ex}"); }
+        }
+
+        public static void RequestDeconstructComplete(int cell, int objectLayer)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try { s.CallCommand(nameof(CmdDeconstructComplete), cell, objectLayer); }
+            catch (System.Exception ex) { DebugConsole.LogWarning($"[BuildingActionSyncer] {ex}"); }
+        }
+
+        [Command]
+        private void CmdAction(int netId, byte action)
+        {
+            CallClientRpc(nameof(RpcAction), netId, action);
+        }
+
+        [ClientRpc]
+        private void RpcAction(int netId, byte action)
+        {
+            if (!NetworkIdentityRegistry.TryGet(netId, out var identity) || identity == null || identity.gameObject == null) return;
+            var go = identity.gameObject;
+            switch ((byte)action)
+            {
+                case 1:
+                    if (go.TryGetComponent<Deconstructable>(out var dq)) dq.QueueDeconstruction(true);
+                    break;
+                case 2:
+                    if (go.TryGetComponent<Deconstructable>(out var dc)) dc.CancelDeconstruction();
+                    break;
+                case 3:
+                    go.Trigger(2127324410);
+                    break;
+            }
+        }
+
+        [Command]
+        private void CmdClearable(int netId, int cell, bool isMarked)
+        {
+            CallClientRpc(nameof(RpcClearable), netId, cell, isMarked);
+        }
+
+        [ClientRpc]
+        private void RpcClearable(int netId, int cell, bool isMarked)
+        {
+            Clearable target = null;
+            if (netId != 0 && NetworkIdentityRegistry.TryGet(netId, out var identity) && identity != null)
+                target = identity.GetComponent<Clearable>();
+            if (target == null && Grid.IsValidCell(cell))
+            {
+                var go = Grid.Objects[cell, (int)ObjectLayer.Pickupables];
+                if (go != null) target = go.GetComponent<Clearable>();
+            }
+            if (target == null) return;
+            if (isMarked) target.MarkForClear();
+            else target.CancelClearing();
+        }
+
+        [Command]
+        private void CmdDeconstructComplete(int cell, int objectLayer)
+        {
+            CallClientRpc(nameof(RpcDeconstructComplete), cell, objectLayer);
+        }
+
+        [ClientRpc]
+        private void RpcDeconstructComplete(int cell, int objectLayer)
+        {
+            if (!Grid.IsValidCell(cell)) return;
+            var go = Grid.Objects[cell, objectLayer];
+            if (go == null) return;
+            if (go.TryGetComponent<Deconstructable>(out var d) && !d.HasBeenDestroyed) Util.KDestroyGameObject(go);
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/CaptureToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/CaptureToolSyncer.cs
@@ -1,0 +1,85 @@
+using HarmonyLib;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class CaptureToolSyncer : NetworkBehaviour
+    {
+        public static CaptureToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("CaptureToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<CaptureToolSyncer>();
+            }
+            Instance.NetId = nameof(CaptureToolSyncer).GetHashCode();
+        }
+
+        public static void RequestCapture(Vector2 min, Vector2 max)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdCapture), min, max, (int)p.priority_class, p.priority_value);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[CaptureToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdCapture(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            CallClientRpc(nameof(RpcCapture), min, max, priority_class, priority_value);
+        }
+
+        [ClientRpc]
+        private void RpcCapture(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            if (_processing) return;
+            _processing = true;
+            try
+            {
+                var ps = ToolMenu.Instance?.PriorityScreen;
+                if (ps == null)
+                {
+                    CaptureTool.MarkForCapture(min, max, true);
+                    return;
+                }
+                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+                var prev = tr.GetValue<PrioritySetting>();
+                tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+                try { CaptureTool.MarkForCapture(min, max, true); }
+                finally { tr.SetValue(prev); }
+            }
+            finally { _processing = false; }
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/CopySettingsToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/CopySettingsToolSyncer.cs
@@ -1,0 +1,66 @@
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.Components;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class CopySettingsToolSyncer : NetworkBehaviour
+    {
+        public static CopySettingsToolSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("CopySettingsToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<CopySettingsToolSyncer>();
+            }
+            Instance.NetId = nameof(CopySettingsToolSyncer).GetHashCode();
+        }
+
+        public static void RequestCopy(int netId, int cell)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try { s.CallCommand(nameof(CmdCopy), netId, cell); }
+            catch (System.Exception ex) { DebugConsole.LogWarning($"[CopySettingsToolSyncer] {ex}"); }
+        }
+
+        [Command]
+        private void CmdCopy(int netId, int cell)
+        {
+            CallClientRpc(nameof(RpcCopy), netId, cell);
+        }
+
+        [ClientRpc]
+        private void RpcCopy(int netId, int cell)
+        {
+            if (!NetworkIdentityRegistry.TryGet(netId, out var identity) || identity.gameObject == null || !identity.TryGetComponent<CopyBuildingSettings>(out var sourceSettings) || !identity.TryGetComponent<KPrefabID>(out var sourceId))
+                return;
+            var targetId = CopyBuildingSettings.ResolveTarget(CopyBuildingSettings.ResolveLayer(identity.gameObject), cell);
+            if (targetId == null) return;
+            CopyBuildingSettings.ApplyCopy(targetId, identity.gameObject, sourceId, sourceSettings);
+            Game.Instance.userMenu.Refresh(targetId.gameObject);
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/DigToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/DigToolSyncer.cs
@@ -1,0 +1,81 @@
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.Components;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class DigToolSyncer : NetworkBehaviour
+    {
+        public static DigToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("DigToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<DigToolSyncer>();
+            }
+            Instance.NetId = nameof(DigToolSyncer).GetHashCode();
+        }
+
+        public static void RequestDig(int cell, int animationDelay)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdDig), cell, animationDelay, (int)p.priority_class, p.priority_value);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[DigToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdDig(int cell, int animationDelay, int priority_class, int priority_value)
+        {
+            CallClientRpc(nameof(RpcDig), cell, animationDelay, priority_class, priority_value);
+        }
+
+        [ClientRpc]
+        private void RpcDig(int cell, int animationDelay, int priority_class, int priority_value)
+        {
+            if (_processing) return;
+            _processing = true;
+            try
+            {
+                var go = DigTool.PlaceDig(cell, animationDelay);
+                var prioritizable = go?.GetComponent<Prioritizable>();
+                if (prioritizable != null)
+                    prioritizable.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+            }
+            finally
+            {
+                _processing = false;
+            }
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/DragToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/DragToolSyncer.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class DragToolSyncer : NetworkBehaviour
+    {
+        public static DragToolSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("DragToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<DragToolSyncer>();
+            }
+            Instance.NetId = nameof(DragToolSyncer).GetHashCode();
+        }
+
+        public static void RequestDrag(string toolName, int cell, int distFromOrigin)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                DragTool tool = ResolveTool(toolName);
+                List<string> filters = new();
+                if (tool is FilteredDragTool filtered)
+                {
+                    foreach (var t in filtered.currentFilters)
+                        if (t.state == ToolParameterMenu.ToggleState.On)
+                            filters.Add(t.name);
+                }
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdDrag), toolName, cell, distFromOrigin, filters, (int)p.priority_class, p.priority_value, 0, Vector3.zero, Vector3.zero);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[DragToolSyncer] {ex}");
+            }
+        }
+
+        public static void RequestDragComplete(string toolName, Vector3 downPos, Vector3 upPos)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                DragTool tool = ResolveTool(toolName);
+                List<string> filters = new();
+                if (tool is FilteredDragTool filtered)
+                {
+                    foreach (var t in filtered.currentFilters)
+                        if (t.state == ToolParameterMenu.ToggleState.On)
+                            filters.Add(t.name);
+                }
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdDrag), toolName, 0, 0, filters, (int)p.priority_class, p.priority_value, 1, downPos, upPos);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[DragToolSyncer] {ex}");
+            }
+        }
+
+        private static DragTool ResolveTool(string name)
+        {
+            return name switch
+            {
+                "Cancel" => CancelTool.Instance,
+                "Clear" => ClearTool.Instance,
+                "Deconstruct" => DeconstructTool.Instance,
+                "Mop" => MopTool.Instance,
+                "Harvest" => HarvestTool.Instance,
+                "Disinfect" => DisinfectTool.Instance,
+                "Prioritize" => PrioritizeTool.Instance,
+                "EmptyPipe" => EmptyPipeTool.Instance,
+                "Disconnect" => DisconnectTool.Instance,
+                _ => null
+            };
+        }
+
+        [Command]
+        private void CmdDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos)
+        {
+            CallClientRpc(nameof(RpcDrag), toolName, cell, distFromOrigin, filterTargets, priority_class, priority_value, mode, downPos, upPos);
+        }
+
+        [ClientRpc]
+        private void RpcDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos)
+        {
+            DragTool tool = ResolveTool(toolName);
+            if (tool == null) return;
+            FilteredDragTool filtered = tool as FilteredDragTool;
+            bool isFiltered = filtered != null;
+            HashSet<string> cached = new();
+            if (isFiltered)
+            {
+                cached = filtered.currentFilters.Where(t => t.state == ToolParameterMenu.ToggleState.On).Select(t => t.name).ToHashSet();
+                foreach (var toggle in filtered.currentFilters)
+                    toggle.state = ToolParameterMenu.ToggleState.Off;
+                foreach (var target in filterTargets)
+                    foreach (var toggle in filtered.currentFilters)
+                        if (toggle.name == target) { toggle.state = ToolParameterMenu.ToggleState.On; break; }
+            }
+            var ps = ToolMenu.Instance?.PriorityScreen;
+            PrioritySetting prev = default;
+            bool hasPs = ps != null;
+            if (hasPs)
+            {
+                prev = ps.lastSelectedPriority;
+                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+                if (tr != null) tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+                else ps.lastSelectedPriority = new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value);
+            }
+            Vector3 cachedDown = tool.downPos;
+            bool completed = false;
+            try
+            {
+                if (mode == 0)
+                    tool.OnDragTool(cell, distFromOrigin);
+                else
+                {
+                    tool.downPos = downPos;
+                    tool.OnDragComplete(downPos, upPos);
+                }
+                completed = true;
+            }
+            finally
+            {
+                tool.downPos = cachedDown;
+                if (hasPs)
+                {
+                    var tr2 = Traverse.Create(ps).Field("lastSelectedPriority");
+                    if (tr2 != null) tr2.SetValue(prev);
+                    else ps.lastSelectedPriority = prev;
+                }
+                if (isFiltered)
+                {
+                    foreach (var toggle in filtered.currentFilters)
+                        toggle.state = ToolParameterMenu.ToggleState.Off;
+                    foreach (var target in cached)
+                        foreach (var toggle in filtered.currentFilters)
+                            if (toggle.name == target) { toggle.state = ToolParameterMenu.ToggleState.On; break; }
+                }
+            }
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/SandboxToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/SandboxToolSyncer.cs
@@ -1,0 +1,182 @@
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class SandboxToolSyncer : NetworkBehaviour
+    {
+        public static SandboxToolSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("SandboxToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<SandboxToolSyncer>();
+            }
+            Instance.NetId = nameof(SandboxToolSyncer).GetHashCode();
+        }
+
+        public static void RequestSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try { s.CallCommand(nameof(CmdSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId); }
+            catch (System.Exception ex) { DebugConsole.LogWarning($"[SandboxToolSyncer] {ex}"); }
+        }
+
+        [Command]
+        private void CmdSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        {
+            CallClientRpc(nameof(RpcSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId);
+        }
+
+        [ClientRpc]
+        private void RpcSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        {
+            if (!Grid.IsValidCell(cell) || SandboxToolParameterMenu.instance?.settings == null) return;
+            var settings = SandboxToolParameterMenu.instance.settings;
+            int prevElem = 0, prevDisease = 0, prevMorale = 0;
+            float prevMass = 0, prevTemp = 0, prevTempAdd = 0, prevStress = 0;
+            string prevDiseaseId = "", prevEntityId = "", prevStoryId = "";
+            bool isBrush = action == 0 || action == 1 || action == 2;
+            bool isHeat = action == 4;
+            bool isStress = action == 5;
+            bool isEntity = action == 6;
+            bool isStory = action == 11;
+            try
+            {
+                if (isBrush)
+                {
+                    prevElem = settings.GetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT);
+                    prevDisease = settings.GetIntSetting(SandboxSettings.KEY_DISEASE_COUNT);
+                    prevMass = settings.GetFloatSetting(SandboxSettings.KEY_MASS);
+                    prevTemp = settings.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE);
+                    prevDiseaseId = settings.GetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE);
+                    settings.SetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT, elementIndex);
+                    settings.SetIntSetting(SandboxSettings.KEY_DISEASE_COUNT, diseaseCount);
+                    settings.SetFloatSetting(SandboxSettings.KEY_MASS, mass);
+                    settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE, temp);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE, diseaseId);
+                }
+                if (isHeat)
+                {
+                    prevTempAdd = settings.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE);
+                    settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE, tempAdd);
+                }
+                if (isStress)
+                {
+                    prevStress = settings.GetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE);
+                    prevMorale = settings.GetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT);
+                    settings.SetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE, stressAdd);
+                    settings.SetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT, moraleAdj);
+                }
+                if (isEntity)
+                {
+                    prevEntityId = settings.GetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY, entityId);
+                }
+                if (isStory)
+                {
+                    prevStoryId = settings.GetStringSetting(SandboxSettings.KEY_SELECTED_STORY);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_STORY, storyId);
+                }
+                switch (action)
+                {
+                    case 0:
+                        FindTool(SandboxBrushTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 1:
+                        FindTool(SandboxSprinkleTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 2:
+                        FindTool(SandboxFloodTool.instance)?.PaintCell(cell);
+                        break;
+                    case 3:
+                        settings.SetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT, elementIndex);
+                        settings.SetIntSetting(SandboxSettings.KEY_DISEASE_COUNT, diseaseCount);
+                        settings.SetFloatSetting(SandboxSettings.KEY_MASS, mass);
+                        settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE, temp);
+                        settings.SetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE, diseaseId);
+                        SandboxToolParameterMenu.instance.RefreshDisplay();
+                        break;
+                    case 4:
+                        FindTool(SandboxHeatTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 5:
+                        FindTool(SandboxStressTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 6:
+                        var spawner = Object.FindFirstObjectByType<SandboxSpawnerTool>(FindObjectsInactive.Include);
+                        if (spawner != null)
+                        {
+                            int prev = spawner.currentCell;
+                            spawner.currentCell = cell;
+                            try { spawner.Place(cell); } finally { spawner.currentCell = prev; }
+                        }
+                        break;
+                    case 7:
+                        FindTool(SandboxDestroyerTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 8:
+                        FindTool(SandboxFOWTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 9:
+                        FindTool(SandboxClearFloorTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 10:
+                        FindTool(SandboxCritterTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 11:
+                        var storyTool = Object.FindFirstObjectByType<SandboxStoryTraitTool>(FindObjectsInactive.Include);
+                        storyTool?.OnLeftClickDown(pos);
+                        break;
+                }
+            }
+            finally
+            {
+                if (isBrush)
+                {
+                    settings.SetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT, prevElem);
+                    settings.SetIntSetting(SandboxSettings.KEY_DISEASE_COUNT, prevDisease);
+                    settings.SetFloatSetting(SandboxSettings.KEY_MASS, prevMass);
+                    settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE, prevTemp);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE, prevDiseaseId);
+                }
+                if (isHeat) settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE, prevTempAdd);
+                if (isStress)
+                {
+                    settings.SetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE, prevStress);
+                    settings.SetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT, prevMorale);
+                }
+                if (isEntity) settings.SetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY, prevEntityId);
+                if (isStory) settings.SetStringSetting(SandboxSettings.KEY_SELECTED_STORY, prevStoryId);
+            }
+        }
+
+        private static T FindTool<T>(T instance) where T : Object
+        {
+            return instance != null ? instance : Object.FindFirstObjectByType<T>(FindObjectsInactive.Include);
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/UtilityBuildToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/UtilityBuildToolSyncer.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Linq;
+using ONI_Together.DebugTools;
+using ONI_Together.Misc;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class UtilityBuildToolSyncer : NetworkBehaviour
+    {
+        public static UtilityBuildToolSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("UtilityBuildToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<UtilityBuildToolSyncer>();
+            }
+            Instance.NetId = nameof(UtilityBuildToolSyncer).GetHashCode();
+        }
+
+        public static void RequestUtilityBuild(string prefabID, List<string> materialTags, ulong[] pathChunks, string facadeID, bool instantBuild)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = PlanScreen.Instance != null ? PlanScreen.Instance.GetBuildingPriority() : ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdUtilityBuild), prefabID, materialTags, pathChunks, facadeID, instantBuild, (int)p.priority_class, p.priority_value);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[UtilityBuildToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdUtilityBuild(string prefabID, List<string> materialTags, ulong[] pathChunks, string facadeID, bool instantBuild, int priority_class, int priority_value)
+        {
+            CallClientRpc(nameof(RpcUtilityBuild), prefabID, materialTags, pathChunks, facadeID, instantBuild, priority_class, priority_value);
+        }
+
+        [ClientRpc]
+        private void RpcUtilityBuild(string prefabID, List<string> materialTags, ulong[] pathChunks, string facadeID, bool instantBuild, int priority_class, int priority_value)
+        {
+            if (pathChunks == null || pathChunks.Length == 0) return;
+            List<BaseUtilityBuildTool.PathNode> path = new();
+            for (int c = 0; c < pathChunks.Length; c++)
+            {
+                ulong chunk = pathChunks[c];
+                int[] cells = BuildingUtils.DecodeUtilityPathChunk((uint)(chunk & 0xFFFFFFFF));
+                if (cells == null) continue;
+                uint mask = (uint)(chunk >> 32);
+                for (int j = 0; j < cells.Length; j++)
+                    path.Add(new BaseUtilityBuildTool.PathNode { cell = cells[j], valid = (mask & (1u << j)) != 0 });
+            }
+            if (path.Count == 0) return;
+            var def = Assets.GetBuildingDef(prefabID);
+            if (def == null) return;
+            var tags = materialTags.Select(t => TagManager.Create(t)).ToList();
+            if (tags.Count == 0) tags.AddRange(def.DefaultElements());
+            BaseUtilityBuildTool tool = def.BuildingComplete.TryGetComponent<Wire>(out _) ? (BaseUtilityBuildTool)WireBuildTool.Instance : UtilityBuildTool.Instance;
+            if (PlanScreen.Instance?.ProductInfoScreen?.materialSelectionPanel?.PriorityScreen == null)
+            {
+                PlanScreen.Instance.CopyBuildingOrder(def, facadeID);
+                PlanScreen.Instance.OnActiveToolChanged(SelectTool.Instance);
+            }
+            var cachedDef = tool.def;
+            var cachedPath = tool.path != null ? new List<BaseUtilityBuildTool.PathNode>(tool.path) : new List<BaseUtilityBuildTool.PathNode>();
+            var cachedMats = tool.selectedElements != null ? new List<Tag>(tool.selectedElements) : new List<Tag>();
+            var cachedMgr = tool.conduitMgr;
+            var haver = def.BuildingComplete.GetComponent<IHaveUtilityNetworkMgr>();
+            tool.def = def;
+            tool.path = path;
+            tool.selectedElements = tags;
+            tool.conduitMgr = haver.GetNetworkManager();
+            bool cachedInstant = DebugHandler.InstantBuildMode;
+            DebugHandler.InstantBuildMode = instantBuild;
+            try
+            {
+                tool.BuildPath();
+                foreach (var node in path)
+                {
+                    var go = Grid.Objects[node.cell, (int)def.TileLayer];
+                    if (go == null) continue;
+                    if (go.TryGetComponent<Prioritizable>(out var pri)) pri.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+                    if (go.TryGetComponent<KAnimGraphTileVisualizer>(out var vis)) { vis.UpdateConnections(vis.Connections); vis.Refresh(); }
+                }
+            }
+            finally
+            {
+                DebugHandler.InstantBuildMode = cachedInstant;
+                tool.def = cachedDef;
+                tool.path = cachedPath;
+                tool.selectedElements = cachedMats;
+                tool.conduitMgr = cachedMgr;
+            }
+        }
+    }
+}

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,15 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      DigToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      BuildToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      AttackToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      CaptureToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      DragToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      CopySettingsToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      BuildingActionSyncer.RegisterNetId(Game.Instance.gameObject);
+      UtilityBuildToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      SandboxToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/ToolPatches/Attack/AttackToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Attack/AttackToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Attack;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -19,6 +19,6 @@ public class AttackToolPatch
         Vector2 min_object = __instance.GetRegularizedPos(Vector2.Min(downPos, upPos), true);
         Vector2 max_object = __instance.GetRegularizedPos(Vector2.Max(downPos, upPos), false);
 
-        PacketSender.SendToAllOtherPeers(new AttackToolPacket(min_object, max_object));
+        AttackToolSyncer.RequestAttack(min_object, max_object);
     }
 }

--- a/ONI_Together/Patches/ToolPatches/Build/BuildToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Build/BuildToolPatch.cs
@@ -1,9 +1,8 @@
-﻿using HarmonyLib;
-using ONI_Together.DebugTools;
+﻿using System;
+using System.Linq;
+using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Build;
-using System;
-using System.Collections.Generic;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -12,67 +11,23 @@ namespace ONI_Together.Patches.ToolPatches.Build
     [HarmonyPatch(typeof(BuildTool), nameof(BuildTool.TryBuild))]
     public static class BuildToolPatch
     {
-        static void Prefix(BuildTool __instance, int cell)
-        {
-            using var _ = Profiler.Scope();
-
-            try
-            {
-                var def = __instance.def;
-                if (def != null)
-                {
-                    DebugConsole.Log($"[BuildTool] Attempting to build: {def.PrefabID} at cell {cell}");
-                }
-            }
-            catch (Exception ex)
-            {
-                DebugConsole.LogError($"[BuildToolPatch.Prefix] {ex}");
-            }
-        }
-
         static void Postfix(BuildTool __instance, int cell)
         {
             using var _ = Profiler.Scope();
 
-            try
-            {
-                if (!MultiplayerSession.InActiveSession || __instance == null)
-                    return;
+            if (!MultiplayerSession.InActiveSession || __instance == null)
+                return;
 
-                var def = __instance.def;
-                var selectedElements = __instance.selectedElements;
-                var orientation = __instance.GetBuildingOrientation;
+            var def = __instance.def;
+            var selectedElements = __instance.selectedElements;
+            var orientation = __instance.GetBuildingOrientation;
 
-                if (def == null || selectedElements == null)
-                    return;
+            if (def == null || selectedElements == null)
+                return;
 
-                GameObject obj = Grid.Objects[cell, (int) def.ObjectLayer];
-                if (obj != null)
-                {
-                    DebugConsole.Log($"[BuildTool] Successfully placed {def.PrefabID} at cell {cell}");
-                }
-                else
-                {
-                    // It might be a ghost/preview, so we still send the packet!
-                    DebugConsole.Log($"[BuildTool] Placed intention/ghost for {def.PrefabID} at cell {cell}");
-                }
-
-                bool instantBuild = DebugHandler.InstantBuildMode || (Game.Instance.SandboxModeActive && SandboxToolParameterMenu.instance.settings.InstantBuild);
-                var packet = new BuildPacket(
-                    def.PrefabID,
-                    cell,
-                    orientation,
-                    selectedElements,
-                    def.ObjectLayer,
-                    instantBuild
-                );
-
-                PacketSender.SendToAllOtherPeers(packet);
-            }
-            catch (Exception ex)
-            {
-                DebugConsole.LogError($"[BuildToolPatch.Postfix] {ex}");
-            }
+            bool instantBuild = DebugHandler.InstantBuildMode || (Game.Instance.SandboxModeActive && SandboxToolParameterMenu.instance.settings.InstantBuild);
+            var tags = selectedElements.Select(t => t.ToString()).ToList();
+            BuildToolSyncer.RequestBuild(def.PrefabID, cell, (int)orientation, tags, (int)def.ObjectLayer, instantBuild);
         }
     }
 }

--- a/ONI_Together/Patches/ToolPatches/Cancel/CancelToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Cancel/CancelToolPatch.cs
@@ -1,25 +1,19 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Cancel;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Cancel
 {
-	[HarmonyPatch(typeof(CancelTool), nameof(CancelTool.OnDragTool))]
-	public static class CancelToolPatch
-	{
-		public static void Postfix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			//prevent recursion
-			if (CancelPacket.ProcessingIncoming)
-				return;
-			PacketSender.SendToAllOtherPeers(new CancelPacket() { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
+    [HarmonyPatch(typeof(CancelTool), nameof(CancelTool.OnDragTool))]
+    public static class CancelToolPatch
+    {
+        public static void Postfix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            DragToolSyncer.RequestDrag("Cancel", cell, distFromOrigin);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
@@ -1,45 +1,21 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Cancel
 {
-	// Choke-point for "cancel an unfinished building":
-	//   - CancelTool drag → Trigger(GameHashes.Cancel) → Constructable.OnCancel(object)
-	//   - Right-click "Cancel build" → same trigger
-	//   - Any scripted / single-click cancel → same method
-	// Method is private, so match by name string (Harmony accepts it).
-	[HarmonyPatch(typeof(Constructable), "OnCancel")]
-	public static class ConstructableCancelPatch
-	{
-		public static void Postfix(Constructable __instance)
-		{
-			using var _ = Profiler.Scope();
-
-			try
-			{
-				if (!MultiplayerSession.InActiveSession) return;
-				if (BuildingActionPacket.ProcessingIncoming) return;
-				// Drag path already syncs via CancelPacket; skip here to avoid double-send.
-				if (DragToolPacket.ProcessingIncoming) return;
-
-				var identity = __instance.GetComponent<NetworkIdentity>();
-				if (identity == null || identity.NetId == 0) return;
-
-				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
-				{
-					NetId = identity.NetId,
-					Action = BuildingActionKind.CancelConstruct,
-				});
-				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=CancelConstruct src=ConstructCancelPatch");
-			}
-			catch (System.Exception ex)
-			{
-				DebugConsole.LogError($"[ConstructableCancelPatch] Exception: {ex}");
-			}
-		}
-	}
+    [HarmonyPatch(typeof(Constructable), "OnCancel")]
+    public static class ConstructableCancelPatch
+    {
+        public static void Postfix(Constructable __instance)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession) return;
+            var identity = __instance.GetComponent<NetworkIdentity>();
+            if (identity == null || identity.NetId == 0) return;
+            BuildingActionSyncer.RequestAction(identity.NetId, 3);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Capture/CaptureToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Capture/CaptureToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Capture;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -19,6 +19,6 @@ public class CaptureToolPatch
         Vector2 min_object = __instance.GetRegularizedPos(Vector2.Min(downPos, upPos), true);
         Vector2 max_object = __instance.GetRegularizedPos(Vector2.Max(downPos, upPos), false);
 
-        PacketSender.SendToAllOtherPeers(new CaptureToolPacket(min_object, max_object));
+        CaptureToolSyncer.RequestCapture(min_object, max_object);
     }
 }

--- a/ONI_Together/Patches/ToolPatches/Clear/ClearToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Clear/ClearToolPatch.cs
@@ -1,28 +1,21 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Clear;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Clear
 {
-	[HarmonyPatch(typeof(ClearTool), "OnDragTool")]
-	public static class ClearTool_OnDragTool_Patch
-	{
-		public static void Prefix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			if (!Grid.IsValidCell(cell))
-				return;
-
-			if (ClearPacket.ProcessingIncoming)
-				return;
-
-			PacketSender.SendToAllOtherPeers(new ClearPacket { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
-
+    [HarmonyPatch(typeof(ClearTool), "OnDragTool")]
+    public static class ClearTool_OnDragTool_Patch
+    {
+        public static void Prefix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            if (!Grid.IsValidCell(cell))
+                return;
+            DragToolSyncer.RequestDrag("Clear", cell, distFromOrigin);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/CopySettings/CopySettingsToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/CopySettings/CopySettingsToolPatch.cs
@@ -1,7 +1,7 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools.CopySettingsTool;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -25,6 +25,6 @@ public class CopySettingsToolPatch
         if (identity == null)
             return;
 
-        PacketSender.SendToAllOtherPeers(new CopySettingsToolPacket(identity.NetId, cell));
+        CopySettingsToolSyncer.RequestCopy(identity.NetId, cell);
     }
 }

--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructToolPatch.cs
@@ -1,25 +1,19 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Cancel;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	[HarmonyPatch(typeof(DeconstructTool), nameof(DeconstructTool.OnDragTool))]
-	public static class DeconstructToolPatch
-	{
-		public static void Postfix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			//prevent recursion
-			if (DeconstructPacket.ProcessingIncoming)
-				return;
-			PacketSender.SendToAllOtherPeers(new DeconstructPacket() { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
+    [HarmonyPatch(typeof(DeconstructTool), nameof(DeconstructTool.OnDragTool))]
+    public static class DeconstructToolPatch
+    {
+        public static void Postfix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            DragToolSyncer.RequestDrag("Deconstruct", cell, distFromOrigin);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
@@ -1,45 +1,21 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	// Choke-point for "undo a pending deconstruction order":
-	//   - CancelTool drag → Trigger(GameHashes.Cancel) → OnCancel(object) → CancelDeconstruction
-	//   - User-menu "Cancel deconstruct" button → OnDeconstruct(object) w/ chore!=null → CancelDeconstruction
-	//   - Single-click / scripted cancel → same method
-	// The existing CancelToolPatch only covered drag.
-	[HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.CancelDeconstruction))]
-	public static class DeconstructableCancelPatch
-	{
-		public static void Postfix(Deconstructable __instance)
-		{
-			using var _ = Profiler.Scope();
-
-			try
-			{
-				if (!MultiplayerSession.InActiveSession) return;
-				if (BuildingActionPacket.ProcessingIncoming) return;
-				// Drag path already syncs via CancelPacket; skip here to avoid double-send.
-				if (DragToolPacket.ProcessingIncoming) return;
-
-				var identity = __instance.GetComponent<NetworkIdentity>();
-				if (identity == null || identity.NetId == 0) return;
-
-				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
-				{
-					NetId = identity.NetId,
-					Action = BuildingActionKind.CancelDeconstruct,
-				});
-				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=CancelDeconstruct src=CancelPatch");
-			}
-			catch (System.Exception ex)
-			{
-				DebugConsole.LogError($"[DeconstructableCancelPatch] Exception: {ex}");
-			}
-		}
-	}
+    [HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.CancelDeconstruction))]
+    public static class DeconstructableCancelPatch
+    {
+        public static void Postfix(Deconstructable __instance)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession) return;
+            var identity = __instance.GetComponent<NetworkIdentity>();
+            if (identity == null || identity.NetId == 0) return;
+            BuildingActionSyncer.RequestAction(identity.NetId, 2);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructablePatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructablePatch.cs
@@ -1,41 +1,28 @@
 ﻿using System.Linq;
 using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	[HarmonyPatch(typeof(Deconstructable), "OnCompleteWork")]
-	public static class DeconstructablePatch
-	{
-		public static void Prefix(Deconstructable __instance)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.IsHost || !MultiplayerSession.InActiveSession)
-				return;
-
-			int cell = __instance.NaturalBuildingCell();
-			int objectLayer = (int) ObjectLayer.Building;
-			if (__instance.TryGetComponent<Building>(out var building))
-			{
-				objectLayer = (int) building.Def.ObjectLayer;
-			}
+    [HarmonyPatch(typeof(Deconstructable), "OnCompleteWork")]
+    public static class DeconstructablePatch
+    {
+        public static void Prefix(Deconstructable __instance)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.IsHost || !MultiplayerSession.InActiveSession)
+                return;
+            int cell = __instance.NaturalBuildingCell();
+            int objectLayer = (int)ObjectLayer.Building;
+            if (__instance.TryGetComponent<Building>(out var building))
+                objectLayer = (int)building.Def.ObjectLayer;
             else if (__instance.TryGetComponent<OccupyArea>(out var area) && area.objectLayers.Any())
-            {
                 objectLayer = (int)area.objectLayers.FirstOrDefault();
-            }
             else if (__instance.TryGetComponent<MoverLayerOccupier>(out var occupier) && occupier.objectLayers.Any())
-            {
                 objectLayer = (int)occupier.objectLayers.FirstOrDefault();
-            }
-
-            var packet = new DeconstructCompletePacket { Cell = cell, ObjectLayer = objectLayer };
-            PacketSender.SendToAllClients(packet);
-
-			DebugConsole.Log($"[DeconstructComplete] Host sent DeconstructCompletePacket for cell {cell}");
-		}
-	}
+            BuildingActionSyncer.RequestDeconstructComplete(cell, objectLayer);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
@@ -1,49 +1,22 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	// All "mark for deconstruction" paths funnel through QueueDeconstruction:
-	//   - DeconstructTool drag → gameObject.Trigger(GameHashes.Deconstruct) → OnDeconstruct → QueueDeconstruction
-	//   - Right-click / user-menu "Deconstruct" button → OnDeconstruct(object) → QueueDeconstruction
-	//   - Single-click-context and any scripted trigger → same hash → same path
-	// Hooking this one method catches drag + single-click + menu in one place,
-	// which the existing DeconstructToolPatch (OnDragTool only) missed.
-	[HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.QueueDeconstruction), new System.Type[] { typeof(bool) })]
-	public static class DeconstructableQueuePatch
-	{
-		public static void Postfix(Deconstructable __instance, bool userTriggered)
-		{
-			using var _ = Profiler.Scope();
-
-			try
-			{
-				if (!MultiplayerSession.InActiveSession) return;
-				if (BuildingActionPacket.ProcessingIncoming) return;
-				// Drag path already has its own sync via DeconstructPacket; don't double-send.
-				// This patch exists specifically for non-drag entry points.
-				if (DragToolPacket.ProcessingIncoming) return;
-				if (!userTriggered) return; // only sync user intent; load/rehydrate calls userTriggered=false
-
-				var identity = __instance.GetComponent<NetworkIdentity>();
-				if (identity == null || identity.NetId == 0) return;
-
-				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
-				{
-					NetId = identity.NetId,
-					Action = BuildingActionKind.QueueDeconstruct,
-				});
-				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=QueueDeconstruct src=QueuePatch");
-			}
-			catch (System.Exception ex)
-			{
-				DebugConsole.LogError($"[DeconstructableQueuePatch] Exception: {ex}");
-			}
-		}
-	}
+    [HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.QueueDeconstruction), new System.Type[] { typeof(bool) })]
+    public static class DeconstructableQueuePatch
+    {
+        public static void Postfix(Deconstructable __instance, bool userTriggered)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession) return;
+            if (!userTriggered) return;
+            var identity = __instance.GetComponent<NetworkIdentity>();
+            if (identity == null || identity.NetId == 0) return;
+            BuildingActionSyncer.RequestAction(identity.NetId, 1);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Dig/DigToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Dig/DigToolPatch.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Dig;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Dig
@@ -14,15 +13,9 @@ namespace ONI_Together.Patches.ToolPatches.Dig
             using var _ = Profiler.Scope();
 
             if (!MultiplayerSession.InActiveSession)
-            {
-                DebugConsole.LogWarning("[PlaceDig Patch] Skipped: MultiplayerSession.InSession is false");
-                return;
-            }
-
-            if (DiggablePacket.ProcessingIncoming)
                 return;
 
-            PacketSender.SendToAllOtherPeers(new DiggablePacket(cell, animationDelay));
+            DigToolSyncer.RequestDig(cell, animationDelay);
         }
     }
 }

--- a/ONI_Together/Patches/ToolPatches/DisconnectToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/DisconnectToolPatch.cs
@@ -1,41 +1,25 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
 namespace ONI_Together.Patches.ToolPatches
 {
-	internal class DisconnectToolPatch
-	{
-
+    internal class DisconnectToolPatch
+    {
         [HarmonyPatch(typeof(DisconnectTool), nameof(DisconnectTool.OnDragComplete))]
         public class DisconnectTool_OnDragComplete_Patch
         {
             public static void Prefix(DisconnectTool __instance, Vector3 downPos, Vector3 upPos)
             {
-	            using var _ = Profiler.Scope();
-
+                using var _ = Profiler.Scope();
                 if (!MultiplayerSession.InActiveSession)
                     return;
-
-				//DebugConsole.Log("Disconnecting from " + downPos.x + "," + downPos.y + " to " + upPos.x + "," + upPos.y);
-				//prevent recursion
-				if (DisconnectPacket.ProcessingIncoming)
-                    return;
-
-				if (__instance.singleDisconnectMode)
-				{
-					upPos = __instance.SnapToLine(upPos);
-				}
-				PacketSender.SendToAllOtherPeers(new DisconnectPacket() { downPos = downPos, upPos = upPos});
-			}
+                if (__instance.singleDisconnectMode)
+                    upPos = __instance.SnapToLine(upPos);
+                DragToolSyncer.RequestDragComplete("Disconnect", downPos, upPos);
+            }
         }
-	}
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Disinfect/DisinfectToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Disinfect/DisinfectToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Disinfect;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 [HarmonyPatch(typeof(DisinfectTool), "OnDragTool")]
@@ -10,13 +10,8 @@ public class DisinfectToolPatch
     public static void Prefix(int cell, int distFromOrigin)
     {
         using var _ = Profiler.Scope();
-
         if (!MultiplayerSession.InActiveSession)
             return;
-
-        if (DisinfectPacket.ProcessingIncoming)
-            return;
-
-        PacketSender.SendToAllOtherPeers(new DisinfectPacket { cell = cell, distFromOrigin = distFromOrigin });
+        DragToolSyncer.RequestDrag("Disinfect", cell, distFromOrigin);
     }
 }

--- a/ONI_Together/Patches/ToolPatches/EmptyPipeToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/EmptyPipeToolPatch.cs
@@ -1,33 +1,22 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches
 {
-	internal class EmptyPipeToolPatch
-	{
-		[HarmonyPatch(typeof(EmptyPipeTool), nameof(EmptyPipeTool.OnDragTool))]
-		public class EmptyPipeTool_OnDragTool_Patch
-		{
-			public static void Postfix(int cell, int distFromOrigin)
-			{
-				using var _ = Profiler.Scope();
-
-				if (!MultiplayerSession.InActiveSession)
-					return;
-
-				//prevent recursion
-				if (EmptyPipePacket.ProcessingIncoming)
-					return;
-				PacketSender.SendToAllOtherPeers(new EmptyPipePacket() { cell = cell, distFromOrigin = distFromOrigin });
-			}
-		}
-	}
+    internal class EmptyPipeToolPatch
+    {
+        [HarmonyPatch(typeof(EmptyPipeTool), nameof(EmptyPipeTool.OnDragTool))]
+        public class EmptyPipeTool_OnDragTool_Patch
+        {
+            public static void Postfix(int cell, int distFromOrigin)
+            {
+                using var _ = Profiler.Scope();
+                if (!MultiplayerSession.InActiveSession)
+                    return;
+                DragToolSyncer.RequestDrag("EmptyPipe", cell, distFromOrigin);
+            }
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Harvest/HarvestToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Harvest/HarvestToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Harvest;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Harvest;
@@ -11,13 +11,8 @@ public class HarvestToolPatch
     private static void Postfix(int cell, int distFromOrigin)
     {
         using var _ = Profiler.Scope();
-
         if (!MultiplayerSession.InActiveSession)
             return;
-
-        if (HarvestToolPacket.ProcessingIncoming)
-            return;
-
-        PacketSender.SendToAllOtherPeers(new HarvestToolPacket { cell = cell, distFromOrigin = distFromOrigin });
+        DragToolSyncer.RequestDrag("Harvest", cell, distFromOrigin);
     }
 }

--- a/ONI_Together/Patches/ToolPatches/Mop/MopToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Mop/MopToolPatch.cs
@@ -1,28 +1,21 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Mop;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Mop
 {
-	[HarmonyPatch(typeof(MopTool), "OnDragTool")]
-	public static class MoptoolPatch
-	{
-		public static void Prefix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			if (!Grid.IsValidCell(cell))
-				return;
-
-			if (MopToolPacket.ProcessingIncoming)
-				return;
-
-			PacketSender.SendToAllOtherPeers(new MopToolPacket { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
-
+    [HarmonyPatch(typeof(MopTool), "OnDragTool")]
+    public static class MoptoolPatch
+    {
+        public static void Prefix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            if (!Grid.IsValidCell(cell))
+                return;
+            DragToolSyncer.RequestDrag("Mop", cell, distFromOrigin);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Prioritize/PrioritizeToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Prioritize/PrioritizeToolPatch.cs
@@ -1,26 +1,16 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Prioritize;
-using System.Collections.Generic;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
-using UnityEngine;
 
 [HarmonyPatch(typeof(PrioritizeTool), nameof(PrioritizeTool.OnDragTool))]
 public static class PrioritizeToolPatch
 {
-	public static void Postfix(int cell, int distFromOrigin)
-	{
-		using var _ = Profiler.Scope();
-
-		if (!MultiplayerSession.InActiveSession)
-			return;
-
-		//prevent recursion
-		if (PrioritizePacket.ProcessingIncoming)
-			return;
-
-		PacketSender.SendToAllOtherPeers(new PrioritizePacket { cell = cell, distFromOrigin = distFromOrigin });
-	}
+    public static void Postfix(int cell, int distFromOrigin)
+    {
+        using var _ = Profiler.Scope();
+        if (!MultiplayerSession.InActiveSession)
+            return;
+        DragToolSyncer.RequestDrag("Prioritize", cell, distFromOrigin);
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Sandbox/SandboxToolPatches.cs
+++ b/ONI_Together/Patches/ToolPatches/Sandbox/SandboxToolPatches.cs
@@ -1,10 +1,8 @@
 using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
 using ONI_Together.Networking.OxySync.Components;
-using ONI_Together.Networking.Packets.Tools.Sandbox;
-using ONI_Together.Networking.Packets.World;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using ONI_Together.Scripts.Creatures;
 using Shared.Profiling;
 using UnityEngine;
@@ -13,19 +11,14 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
 {
     internal static class SandboxToolSync
     {
-        public static void Send(
-            SandboxToolAction action,
-            int cell,
-            int distanceFromOrigin = 0,
-            Vector3 position = default)
+        public static void Send(byte action, int cell, int distanceFromOrigin = 0, Vector3 position = default)
         {
             using var _ = Profiler.Scope();
-
-            if (!MultiplayerSession.InActiveSession || SandboxToolPacket.ProcessingIncoming || !Grid.IsValidCell(cell))
+            if (!MultiplayerSession.InActiveSession || !Grid.IsValidCell(cell))
                 return;
-
-            PacketSender.SendToAllOtherPeers(
-                SandboxToolPacket.Capture(action, cell, distanceFromOrigin, position));
+            var s = SandboxToolParameterMenu.instance?.settings;
+            if (s == null) return;
+            SandboxToolSyncer.RequestSandbox(action, cell, distanceFromOrigin, position, s.GetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT), s.GetIntSetting(SandboxSettings.KEY_DISEASE_COUNT), s.GetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT), s.GetFloatSetting(SandboxSettings.KEY_MASS), s.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE), s.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE), s.GetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE), s.GetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE) ?? string.Empty, s.GetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY) ?? string.Empty, s.GetStringSetting(SandboxSettings.KEY_SELECTED_STORY) ?? string.Empty);
         }
     }
 
@@ -33,40 +26,40 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
     internal static class SandboxBrushToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Brush, cell, distFromOrigin);
+            SandboxToolSync.Send(0, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxSprinkleTool), nameof(SandboxSprinkleTool.OnPaintCell))]
     internal static class SandboxSprinkleToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Sprinkle, cell, distFromOrigin);
+            SandboxToolSync.Send(1, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxFloodTool), nameof(SandboxFloodTool.PaintCell))]
     internal static class SandboxFloodToolPatch
     {
-        private static void Postfix(int cell) => SandboxToolSync.Send(SandboxToolAction.Flood, cell);
+        private static void Postfix(int cell) => SandboxToolSync.Send(2, cell);
     }
 
     [HarmonyPatch(typeof(SandboxSampleTool), nameof(SandboxSampleTool.Sample))]
     internal static class SandboxSampleToolPatch
     {
-        private static void Postfix(int cell) => SandboxToolSync.Send(SandboxToolAction.Sample, cell);
+        private static void Postfix(int cell) => SandboxToolSync.Send(3, cell);
     }
 
     [HarmonyPatch(typeof(SandboxHeatTool), nameof(SandboxHeatTool.OnPaintCell))]
     internal static class SandboxHeatToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Heat, cell, distFromOrigin);
+            SandboxToolSync.Send(4, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxStressTool), nameof(SandboxStressTool.OnPaintCell))]
     internal static class SandboxStressToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Stress, cell, distFromOrigin);
+            SandboxToolSync.Send(5, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxSpawnerTool), nameof(SandboxSpawnerTool.Place))]
@@ -78,16 +71,8 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
         private static bool Prefix(int cell)
         {
             using var _ = Profiler.Scope();
-
             if (!MultiplayerSession.InActiveSession || !Grid.IsValidCell(cell))
                 return true;
-
-            if (MultiplayerSession.IsClient && !SandboxToolPacket.ProcessingIncoming)
-            {
-                SandboxToolSync.Send(SandboxToolAction.Spawn, cell);
-                return false;
-            }
-
             IsPlacingEntity = true;
             LastSpawnedObject = null;
             return true;
@@ -96,7 +81,6 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
         private static void Postfix(int cell)
         {
             using var _ = Profiler.Scope();
-
             try
             {
                 if (MultiplayerSession.IsHost && Grid.IsValidCell(cell))
@@ -119,7 +103,6 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                             }
                         }
                     }
-
                     if (spawned != null)
                     {
                         var building = spawned.GetComponent<Building>();
@@ -138,22 +121,17 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                                 MaterialTags = def.DefaultElements().ConvertAll(t => t.Name)
                             };
                             PacketSender.SendToAllClients(packet);
-                            DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned building '{def.PrefabID}' at cell {cell}");
                             return;
                         }
-
                         var identity = spawned.AddOrGet<NetworkIdentity>();
                         if (identity.NetId == 0)
                             identity.RegisterIdentity();
-
                         var minionIdentity = spawned.GetComponent<MinionIdentity>();
                         if (minionIdentity != null)
                         {
                             spawned.AddOrGet<OxySyncEntityPositionHandler>();
                             spawned.AddOrGet<AnimStateSyncer>();
                             spawned.AddOrGet<Scripts.Duplicants.MinionMultiplayerInitializer>();
-
-                            // Build full ImmigrantOptionEntry from live duplicant to preserve textures/traits
                             try
                             {
                                 var personality = Db.Get().Personalities.TryGet(minionIdentity.personalityResourceId);
@@ -163,11 +141,9 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                                     personality = Db.Get().Personalities.resources.Find(p => p.Id == minionIdentity.personalityResourceId.ToString());
                                 if (personality == null)
                                     personality = Db.Get().Personalities.resources[0];
-
                                 var stats = new MinionStartingStats(personality);
                                 stats.Name = minionIdentity.name;
                                 stats.voiceIdx = minionIdentity.voiceIdx;
-
                                 var entry = ONI_Together.Networking.Packets.Social.ImmigrantOptionEntry.FromGameDeliverable(stats);
                                 var packet2 = new ONI_Together.Networking.Packets.World.TelepadEntitySpawnPacket
                                 {
@@ -176,66 +152,35 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                                     EntityData = entry
                                 };
                                 PacketSender.SendToAllClients(packet2);
-                                DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned duplicant '{stats.Name}' ({personality.Id}, NetId: {identity.NetId}) via TelepadEntitySpawnPacket (full personality)");
                                 return;
                             }
-                            catch (System.Exception ex)
-                            {
-                                DebugConsole.LogWarning($"[SandboxSpawnerToolPatch] Full duplicant sync failed, falling back to minimal: {ex.Message}");
-                            }
-
-                            // Fallback minimal (should not be used for texture correctness)
+                            catch { }
                             string personalityId = minionIdentity.personalityResourceId.IsValid ? minionIdentity.personalityResourceId.ToString() : "HASSAN";
                             var personalityFallback = Db.Get().Personalities.TryGet(new HashedString(personalityId)) ?? Db.Get().Personalities.TryGet(personalityId) ?? Db.Get().Personalities.resources[0];
                             string dupeName = minionIdentity.name;
                             string prefabData = $"Minion|{personalityFallback.Id}|{dupeName}|{minionIdentity.voiceIdx}";
                             int hash = spawned.PrefabID().GetHashCode();
-
-                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(
-                                identity.NetId,
-                                hash,
-                                spawned.transform.position,
-                                prefabData
-                            )
-                            {
-                                IsActive = spawned.activeSelf
-                            };
+                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(identity.NetId, hash, spawned.transform.position, prefabData) { IsActive = spawned.activeSelf };
                             PacketSender.SendToAllClients(packet);
-                            DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned duplicant '{dupeName}' ({personalityFallback.Id}, NetId: {identity.NetId}) at {spawned.transform.position} (fallback)");
                             return;
                         }
-
                         if (spawned.GetComponent<CreatureBrain>() != null || spawned.HasTag(GameTags.Creature))
                         {
                             spawned.AddOrGet<OxySyncEntityPositionHandler>();
                             spawned.AddOrGet<AnimStateSyncer>();
                             spawned.AddOrGet<CreatureMultiplayerInitializer>();
                         }
-
                         if (identity.NetId != 0)
                         {
                             string prefabName = spawned.PrefabID().Name;
                             int hash = spawned.PrefabID().GetHashCode();
-
-                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(
-                                identity.NetId,
-                                hash,
-                                spawned.transform.position,
-                                prefabName
-                            )
-                            {
-                                IsActive = spawned.activeSelf
-                            };
+                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(identity.NetId, hash, spawned.transform.position, prefabName) { IsActive = spawned.activeSelf };
                             PacketSender.SendToAllClients(packet);
-                            DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned entity '{prefabName}' (NetId: {identity.NetId}) at {spawned.transform.position}");
                         }
                     }
                 }
             }
-            catch (System.Exception ex)
-            {
-                DebugConsole.LogError($"[SandboxSpawnerToolPatch.Postfix] Exception: {ex}");
-            }
+            catch { }
             finally
             {
                 IsPlacingEntity = false;
@@ -248,28 +193,28 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
     internal static class SandboxDestroyerToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Destroy, cell, distFromOrigin);
+            SandboxToolSync.Send(7, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxFOWTool), nameof(SandboxFOWTool.OnPaintCell))]
     internal static class SandboxFowToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Reveal, cell, distFromOrigin);
+            SandboxToolSync.Send(8, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxClearFloorTool), nameof(SandboxClearFloorTool.OnPaintCell))]
     internal static class SandboxClearFloorToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.ClearFloor, cell, distFromOrigin);
+            SandboxToolSync.Send(9, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxCritterTool), nameof(SandboxCritterTool.OnPaintCell))]
     internal static class SandboxCritterToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.CritterRemoval, cell, distFromOrigin);
+            SandboxToolSync.Send(10, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxStoryTraitTool), nameof(SandboxStoryTraitTool.OnLeftClickDown))]
@@ -277,12 +222,10 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
     {
         private static void Prefix(SandboxStoryTraitTool __instance, Vector3 cursor_pos)
         {
-            if (SandboxToolPacket.ProcessingIncoming || __instance == null || __instance.isPlacingTemplate)
-                return;
-
+            if (__instance == null || __instance.isPlacingTemplate) return;
             int cell = Grid.PosToCell(cursor_pos);
             if (Grid.IsValidCell(cell) && __instance.GetError(cursor_pos, out _, out _) == null)
-                SandboxToolSync.Send(SandboxToolAction.StoryTrait, cell, position: cursor_pos);
+                SandboxToolSync.Send(11, cell, position: cursor_pos);
         }
     }
 }

--- a/ONI_Together/Patches/ToolPatches/Tools/UtilityBuildToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Tools/UtilityBuildToolPatch.cs
@@ -1,46 +1,24 @@
-using HarmonyLib;
-using ONI_Together.DebugTools;
-using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Architecture;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Build;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using HarmonyLib;
+using ONI_Together.Misc;
+using ONI_Together.Networking;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Build
 {
-	// Try patching BuildPath - called when drag is complete and building is placed
-	[HarmonyPatch(typeof(BaseUtilityBuildTool), nameof(BaseUtilityBuildTool.BuildPath))]
-	public static class UtilityBuildToolPatch
-	{
-		public static void Prefix(BaseUtilityBuildTool __instance)
-		{
-			using var _ = Profiler.Scope();
-
-			//DebugConsole.Log($"[UtilityBuildToolPatch] Prefix called! Tool type: {__instance.GetType().Name}");
-			if (!MultiplayerSession.InActiveSession)
-			{
-				return;
-			}
-			//prevent recursion
-			if (UtilityBuildPacket.ProcessingIncoming)
-			{
-				DebugConsole.Log("UtilityBuildPacket currently processing");
-				return;
-			}
-
-			if (__instance.path == null || __instance.def == null || __instance.path.Count == 0)
-			{
-				DebugConsole.LogWarning("[UtilityBuildToolPatch] Path or Def is null, cannot send UtilityBuildPacket.");
-				return;
-			}
-
-			bool instantBuild = DebugHandler.InstantBuildMode || (Game.Instance.SandboxModeActive && SandboxToolParameterMenu.instance.settings.InstantBuild);
-			PacketSender.SendToAllOtherPeers(new UtilityBuildPacket(__instance.def.PrefabID, __instance.path, [.. __instance.selectedElements.Select(t => t.ToString())], __instance.facadeID, instantBuild));
-			DebugConsole.Log($"[UtilityBuild] Sent packet for {__instance.def.PrefabID} with {__instance.path.Count} nodes.");
-		}
-	}
+    [HarmonyPatch(typeof(BaseUtilityBuildTool), nameof(BaseUtilityBuildTool.BuildPath))]
+    public static class UtilityBuildToolPatch
+    {
+        public static void Prefix(BaseUtilityBuildTool __instance)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession) return;
+            if (__instance.path == null || __instance.def == null || __instance.path.Count == 0) return;
+            bool instantBuild = DebugHandler.InstantBuildMode || (Game.Instance.SandboxModeActive && SandboxToolParameterMenu.instance.settings.InstantBuild);
+            var chunks = BuildingUtils.EncodeUtilityPathWithValidity(__instance.path);
+            var mats = __instance.selectedElements.Select(t => t.ToString()).ToList();
+            UtilityBuildToolSyncer.RequestUtilityBuild(__instance.def.PrefabID, mats, chunks, __instance.facadeID, instantBuild);
+        }
+    }
 }

--- a/ONI_Together/Patches/World/ClearablePatches.cs
+++ b/ONI_Together/Patches/World/ClearablePatches.cs
@@ -1,73 +1,42 @@
 using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Clear;
+using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
-using UnityEngine;
 
 namespace ONI_Together.Patches.World
 {
-	public static class ClearablePatches
-	{
-		[HarmonyPatch(typeof(Clearable), nameof(Clearable.MarkForClear))]
-		public static class ClearableMarkForClearPatch
-		{
-			public static void Postfix(Clearable __instance, bool restoringFromSave, bool allowWhenStored)
-			{
-				using var _ = Profiler.Scope();
+    public static class ClearablePatches
+    {
+        [HarmonyPatch(typeof(Clearable), nameof(Clearable.MarkForClear))]
+        public static class ClearableMarkForClearPatch
+        {
+            public static void Postfix(Clearable __instance, bool restoringFromSave, bool allowWhenStored)
+            {
+                using var _ = Profiler.Scope();
+                if (restoringFromSave) return;
+                if (!MultiplayerSession.InActiveSession) return;
+                if (__instance == null || __instance.gameObject == null) return;
+                var identity = __instance.gameObject.GetNetIdentity();
+                int netId = identity != null ? identity.NetId : 0;
+                int cell = Grid.PosToCell(__instance.gameObject);
+                BuildingActionSyncer.RequestClearable(netId, cell, true);
+            }
+        }
 
-				if (restoringFromSave) return;
-				if (ClearableActionPacket.ProcessingIncoming) return;
-				if (ClearPacket.ProcessingIncoming) return;
-				if (!MultiplayerSession.InActiveSession) return;
-				if (__instance == null || __instance.gameObject == null) return;
-
-				var identity = __instance.gameObject.GetNetIdentity();
-				int netId = identity != null ? identity.NetId : 0;
-				int cell = Grid.PosToCell(__instance.gameObject);
-
-				var packet = new ClearableActionPacket
-				{
-					NetId = netId,
-					Cell = cell,
-					IsMarked = true
-				};
-
-				if (MultiplayerSession.IsHost)
-					PacketSender.SendToAllClients(packet);
-				else
-					PacketSender.SendToHost(packet);
-			}
-		}
-
-		[HarmonyPatch(typeof(Clearable), nameof(Clearable.CancelClearing))]
-		public static class ClearableCancelClearingPatch
-		{
-			public static void Postfix(Clearable __instance)
-			{
-				using var _ = Profiler.Scope();
-
-				if (ClearableActionPacket.ProcessingIncoming) return;
-				if (ClearPacket.ProcessingIncoming) return;
-				if (!MultiplayerSession.InActiveSession) return;
-				if (__instance == null || __instance.gameObject == null) return;
-
-				var identity = __instance.gameObject.GetNetIdentity();
-				int netId = identity != null ? identity.NetId : 0;
-				int cell = Grid.PosToCell(__instance.gameObject);
-
-				var packet = new ClearableActionPacket
-				{
-					NetId = netId,
-					Cell = cell,
-					IsMarked = false
-				};
-
-				if (MultiplayerSession.IsHost)
-					PacketSender.SendToAllClients(packet);
-				else
-					PacketSender.SendToHost(packet);
-			}
-		}
-	}
+        [HarmonyPatch(typeof(Clearable), nameof(Clearable.CancelClearing))]
+        public static class ClearableCancelClearingPatch
+        {
+            public static void Postfix(Clearable __instance)
+            {
+                using var _ = Profiler.Scope();
+                if (!MultiplayerSession.InActiveSession) return;
+                if (__instance == null || __instance.gameObject == null) return;
+                var identity = __instance.gameObject.GetNetIdentity();
+                int netId = identity != null ? identity.NetId : 0;
+                int cell = Grid.PosToCell(__instance.gameObject);
+                BuildingActionSyncer.RequestClearable(netId, cell, false);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Migrates all remaining player tools from ad-hoc packets to OxySync `NetworkBehaviour` syncers using the Command → ClientRpc pattern. No new SyncVars, no changes to the OxySync core (builds on top of the deterministic Behaviour-ID rework in testing).

## What's changed
- New syncers in `ONI_Together/Networking/OxySync/Components/Tools/`, all registered in `GamePatch.cs`:
  - `DigToolSyncer`, `BuildToolSyncer` (incl. replacement-tile + instant-build handling), `AttackToolSyncer`, `CaptureToolSyncer`, `DragToolSyncer` (filtered drag tools with filter/priority caching), `CopySettingsToolSyncer`, `BuildingActionSyncer`, `UtilityBuildToolSyncer`, `SandboxToolSyncer` (all brush/heat/stress/entity/story actions with settings save & restore)
- Reworked patches to route through the syncers: Cancel (`CancelTool`, `Constructable`), Clear, Deconstruct (`DeconstructTool`, `Deconstructable`, queue, cancel), Disconnect, Disinfect, EmptyPipe, Harvest, Mop, Prioritize, `Clearable`, Sandbox
- Reentrancy guards (`_processing`) and priority/filter restoration so remote execution doesn't clobber local tool state

## Design notes
- Tools only need RPCs, so the syncers declare zero `[SyncVar]` fields — no additional network state or bandwidth for idle tools.
- Follows the existing `MoveToLocationToolSyncer` pattern already on this branch.

## Testing
- `dotnet build ONI_Together.sln`: 0 errors.
- In-game verification with 2 clients recommended (host + client each placing/cancelling/deconstructing, incl. sandbox brush actions).

## Notes
- Branch is rebased onto current `testing/network-backend-upgrades` (includes deterministic Behaviour IDs and the entity-position recovery margin).
- Local-only HTML reports in the working tree were intentionally left untracked.
