### PR TITLE
Feature rpc arg use Variant type 

### DIFF
--- a/ONI_Together/DebugTools/PacketTracker.cs
+++ b/ONI_Together/DebugTools/PacketTracker.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using ImGuiNET;
 using ONI_Together.Misc;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Packets.Architecture;
+using Shared.OxySync;
 using Shared.Profiling;
-using Steamworks;
 using UnityEngine;
 
 namespace ONI_Together.DebugTools

--- a/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
+++ b/ONI_Together/DebugTools/UnitTests/OxySyncTests.cs
@@ -714,6 +714,57 @@ namespace ONI_Together.DebugTools.UnitTests
             return UnitTestResult.Pass("Null byte[] falls back to empty");
         }
 
+        [UnitTest(name: "VariantToObject Nullable<T> direct conversions", category: "OxySync")]
+        public static UnitTestResult VariantToObjectNullableDirect()
+        {
+            var i = (int?)VariantHelper.VariantToObject((Variant)42, typeof(int?));
+            if (i == null || i.Value != 42)
+                return UnitTestResult.Fail("int? non-null conversion mismatch");
+
+            var f = (float?)VariantHelper.VariantToObject((Variant)3.5f, typeof(float?));
+            if (f == null || Mathf.Abs(f.Value - 3.5f) > 0.001f)
+                return UnitTestResult.Fail("float? non-null conversion mismatch");
+
+            var v3 = (Vector3?)VariantHelper.VariantToObject((Variant)new Vector3(7f, 8f, 9f), typeof(Vector3?));
+            if (v3 == null || Vector3.Distance(v3.Value, new Vector3(7f, 8f, 9f)) > 0.001f)
+                return UnitTestResult.Fail("Vector3? non-null conversion mismatch");
+
+            var b = (bool?)VariantHelper.VariantToObject((Variant)true, typeof(bool?));
+            if (b == null || b.Value != true)
+                return UnitTestResult.Fail("bool? non-null conversion mismatch");
+
+            var n = (int?)VariantHelper.VariantToObject(new Variant { Type = Variant.TypeCode.Null }, typeof(int?));
+            if (n != null)
+                return UnitTestResult.Fail("int? null conversion mismatch");
+
+            return UnitTestResult.Pass("Nullable<T> direct conversions succeed for null and non-null values");
+        }
+
+        [UnitTest(name: "VariantToObject Nullable<T> collections", category: "OxySync")]
+        public static UnitTestResult VariantToObjectNullableCollections()
+        {
+            var variant = new Variant
+            {
+                Type = Variant.TypeCode.VariantArray,
+                VariantArray = new[]
+                {
+                    (Variant)1,
+                    new Variant { Type = Variant.TypeCode.Null },
+                    (Variant)3,
+                },
+            };
+
+            var array = (int?[])VariantHelper.VariantToObject(variant, typeof(int?[]));
+            if (array.Length != 3 || array[0] != 1 || array[1] != null || array[2] != 3)
+                return UnitTestResult.Fail("int?[] conversion mismatch");
+
+            var list = (List<int?>)VariantHelper.VariantToObject(variant, typeof(List<int?>));
+            if (list.Count != 3 || list[0] != 1 || list[1] != null || list[2] != 3)
+                return UnitTestResult.Fail("List<int?> conversion mismatch");
+
+            return UnitTestResult.Pass("Nullable<T> collection elements preserve null and non-null values");
+        }
+
         [UnitTest(name: "VariantToObject collections round-trip", category: "OxySync")]
         public static UnitTestResult VariantToObjectCollections()
         {
@@ -1060,52 +1111,6 @@ namespace ONI_Together.DebugTools.UnitTests
                 return UnitTestResult.Fail("string[] null elements mismatch");
 
             return UnitTestResult.Pass("Null collection elements round-trip correctly");
-        }
-
-        [UnitTest(name: "RpcSerializer IsSupportedType covers new types", category: "OxySync")]
-        public static UnitTestResult RpcSerializerIsSupportedType()
-        {
-            Type[] supported = {
-                typeof(int), typeof(float), typeof(bool), typeof(byte),
-                typeof(long), typeof(double), typeof(string),
-                typeof(Vector2), typeof(Vector3), typeof(Color),
-                typeof(Quaternion), typeof(byte[]), typeof(ulong),
-                typeof(short), typeof(ushort), typeof(uint),
-                typeof(sbyte), typeof(char), typeof(decimal),
-                typeof(HashedString), typeof(KAnimHashedString),
-                typeof(int[]), typeof(string[]), typeof(Vector3[]),
-                typeof(List<int>), typeof(List<string>),
-                typeof(Dictionary<string, int>),
-                typeof(HashSet<float>), typeof(Queue<long>), typeof(Stack<bool>),
-                typeof(int?), typeof(float?), typeof(Vector3?),
-                typeof(List<List<int>>),
-                typeof(Dictionary<string, List<int>>),
-                typeof(int[][]),
-            };
-
-            foreach (var t in supported)
-            {
-                if (!RpcSerializer.IsSupportedType(t))
-                    return UnitTestResult.Fail($"Type {t} should be supported but is not");
-            }
-
-            Type[] unsupported = {
-                typeof(object),
-                typeof(Guid),
-                typeof(DateTime),
-                typeof(TimeSpan),
-                typeof(Tuple<int, int>),
-                typeof(System.Action),
-                typeof(Stream),
-            };
-
-            foreach (var t in unsupported)
-            {
-                if (RpcSerializer.IsSupportedType(t))
-                    return UnitTestResult.Fail($"Type {t} should NOT be supported but is");
-            }
-
-            return UnitTestResult.Pass("IsSupportedType correctly validates all types");
         }
     }
 

--- a/ONI_Together/Misc/BuildingUtils.cs
+++ b/ONI_Together/Misc/BuildingUtils.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using HarmonyLib;
+using Shared.OxySync;
 using ONI_Together.DebugTools;
 using UnityEngine;
-using static LogicGateVisualizer;
 
 namespace ONI_Together.Misc
 {

--- a/ONI_Together/Networking/Components/LogicStateSyncer.cs
+++ b/ONI_Together/Networking/Components/LogicStateSyncer.cs
@@ -1,8 +1,6 @@
-using ONI_Together.DebugTools;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using System.Collections.Generic;
-using Shared.Profiling;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components

--- a/ONI_Together/Networking/Components/StructureStateSyncers/BatteryStateSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/BatteryStateSyncer.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using ONI_Together.DebugTools;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using ONI_Together.Patches.World;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers

--- a/ONI_Together/Networking/Components/StructureStateSyncers/EnergyGeneratorSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/EnergyGeneratorSyncer.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using ONI_Together.DebugTools;
-using ONI_Together.Misc;
+﻿using System.Collections.Generic;
 using ONI_Together.Networking.Packets.World;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers

--- a/ONI_Together/Networking/Components/StructureStateSyncers/GenericGeneratorSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/GenericGeneratorSyncer.cs
@@ -1,9 +1,6 @@
-﻿using System;
+﻿using Shared.OxySync;
 using System.Collections.Generic;
-using System.Text;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
-using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers
 {

--- a/ONI_Together/Networking/Components/StructureStateSyncers/StorageStateSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/StorageStateSyncer.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using Shared.OxySync;
 using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using UnityEngine;

--- a/ONI_Together/Networking/Components/StructureStateSyncers/StructureSyncerBase.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/StructureSyncerBase.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using ONI_Together.DebugTools;
-using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
-using Shared.Interfaces.Networking;
+using Shared.OxySync;
 using UnityEngine;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers

--- a/ONI_Together/Networking/Components/StructureStateSyncers/ToiletSyncer.cs
+++ b/ONI_Together/Networking/Components/StructureStateSyncers/ToiletSyncer.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using HarmonyLib;
+﻿using System.Collections.Generic;
+using Shared.OxySync;
 using ONI_Together.Misc;
 using ONI_Together.Networking.Packets.World;
 using UnityEngine;
-using static STRINGS.UI.METERS;
 
 namespace ONI_Together.Networking.Components.StructureStateSyncers
 {

--- a/ONI_Together/Networking/Packets/World/LogicStatePacket.cs
+++ b/ONI_Together/Networking/Packets/World/LogicStatePacket.cs
@@ -1,9 +1,8 @@
-using ONI_Together.Misc;
 using ONI_Together.Networking.Components;
 using ONI_Together.Networking.Packets.Architecture;
-using Shared.Interfaces.Networking;
 using System.Collections.Generic;
 using System.IO;
+using Shared.OxySync;
 using Shared.Profiling;
 using UnityEngine;
 

--- a/ONI_Together/Networking/Packets/World/StructureStatePacket.cs
+++ b/ONI_Together/Networking/Packets/World/StructureStatePacket.cs
@@ -1,14 +1,10 @@
 using ONI_Together.Networking.Packets.Architecture;
 using System.IO;
+using Shared.OxySync;
 using Shared.Profiling;
-using ONI_Together.Networking.Components;
-using static TUNING.NOISE_POLLUTION;
-using ONI_Together.Misc;
 using UnityEngine;
 using ONI_Together.Networking.Components.StructureStateSyncers;
-using static ONI_Together.STRINGS.UI.MP_OVERLAY;
 using System.Collections.Generic;
-using Shared.Interfaces.Networking;
 
 namespace ONI_Together.Networking.Packets.World
 {

--- a/Shared/OxySync/RpcSerializer.cs
+++ b/Shared/OxySync/RpcSerializer.cs
@@ -1,76 +1,10 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Text;
-using UnityEngine;
 
 namespace Shared.OxySync
 {
     public static class RpcSerializer
     {
-        private enum ArgType : byte
-        {
-            Int, Float, Bool, Byte, Long, Double, String,
-            Vector2, Vector3, Color, Quaternion, ByteArray, ULong,
-            Array, List, Dict, Short, UShort, UInt, SByte, Char, Decimal,
-            Nullable, HashSet, Queue, Stack, HashedString, KAnimHashedString
-        }
-
-        private static readonly Dictionary<Type, ArgType> TypeToTag = new()
-        {
-            [typeof(int)] = ArgType.Int,
-            [typeof(float)] = ArgType.Float,
-            [typeof(bool)] = ArgType.Bool,
-            [typeof(byte)] = ArgType.Byte,
-            [typeof(long)] = ArgType.Long,
-            [typeof(double)] = ArgType.Double,
-            [typeof(string)] = ArgType.String,
-            [typeof(Vector2)] = ArgType.Vector2,
-            [typeof(Vector3)] = ArgType.Vector3,
-            [typeof(Color)] = ArgType.Color,
-            [typeof(Quaternion)] = ArgType.Quaternion,
-            [typeof(byte[])] = ArgType.ByteArray,
-            [typeof(ulong)] = ArgType.ULong,
-            [typeof(short)] = ArgType.Short,
-            [typeof(ushort)] = ArgType.UShort,
-            [typeof(uint)] = ArgType.UInt,
-            [typeof(sbyte)] = ArgType.SByte,
-            [typeof(char)] = ArgType.Char,
-            [typeof(decimal)] = ArgType.Decimal,
-            [typeof(HashedString)] = ArgType.HashedString,
-            [typeof(KAnimHashedString)] = ArgType.KAnimHashedString,
-        };
-
-        public static bool IsSupportedType(Type t)
-        {
-            if (t.IsEnum) return true;
-            if (t.IsSubclassOf(typeof(Delegate)) || t.IsSubclassOf(typeof(MulticastDelegate))) return false;
-            if (TypeToTag.ContainsKey(t)) return true;
-
-            if (t.IsArray)
-                return t == typeof(byte[]) || IsSupportedType(t.GetElementType());
-
-            if (t.IsGenericType)
-            {
-                var def = t.GetGenericTypeDefinition();
-                if (def == typeof(Nullable<>))
-                    return IsSupportedType(t.GetGenericArguments()[0]);
-
-                if (def == typeof(List<>) || def == typeof(HashSet<>) ||
-                    def == typeof(Queue<>) || def == typeof(Stack<>))
-                    return IsSupportedType(t.GetGenericArguments()[0]);
-
-                if (def == typeof(Dictionary<,>))
-                    return IsSupportedType(t.GetGenericArguments()[0]) &&
-                           IsSupportedType(t.GetGenericArguments()[1]);
-            }
-
-            return false;
-        }
-
         public static byte[] Serialize(object[] args, Type[] argTypes)
         {
             using var ms = new MemoryStream();
@@ -78,7 +12,22 @@ namespace Shared.OxySync
 
             for (int i = 0; i < args.Length; i++)
             {
-                WriteArg(writer, args[i], argTypes[i]);
+                try
+                {
+                    // Keep previous RPC behavior: null strings round-trip as empty strings.
+                    object value = argTypes[i] == typeof(string) && args[i] == null
+                        ? string.Empty
+                        : args[i];
+
+                    VariantHelper.ObjectToVariant(value).Write(writer);
+                }
+                catch (Exception)
+                {
+                    Debug.LogError($"[RpcSerializer] Serializing argType {argTypes[i]} failed");
+
+                    // Intended for debugging purposes, crashing here will help identify the problematic argument.
+                    throw;
+                }
             }
 
             return ms.ToArray();
@@ -92,347 +41,24 @@ namespace Shared.OxySync
             var result = new object[argTypes.Length];
             for (int i = 0; i < argTypes.Length; i++)
             {
-                result[i] = ReadArg(reader, argTypes[i]);
+                try
+                {
+                    Variant variant = Variant.Read(reader);
+                    object value = VariantHelper.VariantToObject(variant, argTypes[i]);
+                    if (argTypes[i] == typeof(string) && value == null)
+                        value = string.Empty;
+                    result[i] = value;
+                }
+                catch (Exception)
+                {
+                    Debug.LogError($"[RpcSerializer] Deserializing argType {argTypes[i]} failed");
+
+                    // Intended for debugging purposes, crashing here will help identify the problematic argument.
+                    throw;
+                }
             }
 
             return result;
-        }
-
-        private static void WriteArg(BinaryWriter writer, object value, Type type)
-        {
-            if (type.IsEnum)
-            {
-                writer.Write((byte)ArgType.Int);
-                writer.Write(Convert.ToInt32(value));
-                return;
-            }
-
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                writer.Write((byte)ArgType.Nullable);
-                bool hasValue = value != null;
-                writer.Write(hasValue);
-                if (hasValue)
-                    WriteArg(writer, value, Nullable.GetUnderlyingType(type));
-                return;
-            }
-
-            if (type.IsArray && type != typeof(byte[]))
-            {
-                writer.Write((byte)ArgType.Array);
-                var arr = (Array)value;
-                int len = arr?.Length ?? 0;
-                writer.Write(len);
-                if (arr != null)
-                {
-                    var elementType = type.GetElementType();
-                    for (int i = 0; i < len; i++)
-                        WriteCollectionElement(writer, arr.GetValue(i), elementType);
-                }
-                return;
-            }
-
-            if (type.IsGenericType)
-            {
-                var def = type.GetGenericTypeDefinition();
-
-                if (def == typeof(List<>) || def == typeof(HashSet<>) ||
-                    def == typeof(Queue<>) || def == typeof(Stack<>))
-                {
-                    var elementType = type.GetGenericArguments()[0];
-
-                    if (def == typeof(List<>))
-                        writer.Write((byte)ArgType.List);
-                    else if (def == typeof(HashSet<>))
-                        writer.Write((byte)ArgType.HashSet);
-                    else if (def == typeof(Queue<>))
-                        writer.Write((byte)ArgType.Queue);
-                    else
-                        writer.Write((byte)ArgType.Stack);
-
-                    var collection = (IEnumerable)value;
-                    var objs = collection?.Cast<object>().ToArray();
-                    if (def == typeof(Stack<>) && objs != null)
-                        Array.Reverse(objs);
-                    int count = objs?.Length ?? 0;
-                    writer.Write(count);
-                    if (objs != null)
-                    {
-                        for (int i = 0; i < count; i++)
-                            WriteCollectionElement(writer, objs[i], elementType);
-                    }
-                    return;
-                }
-
-                if (def == typeof(Dictionary<,>))
-                {
-                    writer.Write((byte)ArgType.Dict);
-                    var dict = (IDictionary)value;
-                    int count = dict?.Count ?? 0;
-                    writer.Write(count);
-                    if (dict != null)
-                    {
-                        var keyType = type.GetGenericArguments()[0];
-                        var valueType = type.GetGenericArguments()[1];
-                        foreach (DictionaryEntry entry in dict)
-                        {
-                            WriteCollectionElement(writer, entry.Key, keyType);
-                            WriteCollectionElement(writer, entry.Value, valueType);
-                        }
-                    }
-                    return;
-                }
-            }
-
-            ArgType tag = TypeToTag[type];
-            writer.Write((byte)tag);
-
-            switch (tag)
-            {
-                case ArgType.Int: writer.Write((int)value); break;
-                case ArgType.Float: writer.Write((float)value); break;
-                case ArgType.Bool: writer.Write((bool)value); break;
-                case ArgType.Byte: writer.Write((byte)value); break;
-                case ArgType.Long:      writer.Write((long)value); break;
-                case ArgType.ULong:     writer.Write((ulong)value); break;
-                case ArgType.Double:    writer.Write((double)value); break;
-                case ArgType.Short:     writer.Write((short)value); break;
-                case ArgType.UShort:    writer.Write((ushort)value); break;
-                case ArgType.UInt:      writer.Write((uint)value); break;
-                case ArgType.SByte:     writer.Write((sbyte)value); break;
-                case ArgType.Char:      writer.Write((char)value); break;
-                case ArgType.Decimal:   writer.Write((decimal)value); break;
-                case ArgType.String: writer.Write(CompressString((string)value) ?? string.Empty); break;
-                case ArgType.Vector2: writer.Write((Vector2)value); break;
-                case ArgType.Vector3: writer.Write((Vector3)value); break;
-                case ArgType.Color:
-                    var c = (Color)value;
-                    writer.Write(c.r);
-                    writer.Write(c.g);
-                    writer.Write(c.b);
-                    writer.Write(c.a);
-                    break;
-                case ArgType.Quaternion:
-                    var q = (Quaternion)value;
-                    writer.Write(q.x);
-                    writer.Write(q.y);
-                    writer.Write(q.z);
-                    writer.Write(q.w);
-                    break;
-                case ArgType.ByteArray:
-                    var ba = (byte[])value;
-                    writer.Write(ba.Length);
-                    writer.Write(ba);
-                    break;
-                case ArgType.HashedString:
-                    writer.Write(((HashedString)value).hash);
-                    break;
-                case ArgType.KAnimHashedString:
-                    writer.Write(((KAnimHashedString)value).hash);
-                    break;
-            }
-        }
-
-        private static object ReadArg(BinaryReader reader, Type type)
-        {
-            ArgType tag = (ArgType)reader.ReadByte();
-
-            switch (tag)
-            {
-                case ArgType.Int:
-                    int intVal = reader.ReadInt32();
-                    return type.IsEnum ? Enum.ToObject(type, intVal) : intVal;
-
-                case ArgType.Float: return reader.ReadSingle();
-                case ArgType.Bool: return reader.ReadBoolean();
-                case ArgType.Byte: return reader.ReadByte();
-                case ArgType.Long: return reader.ReadInt64();
-                case ArgType.ULong: return reader.ReadUInt64();
-                case ArgType.Double: return reader.ReadDouble();
-                case ArgType.Short: return reader.ReadInt16();
-                case ArgType.UShort: return reader.ReadUInt16();
-                case ArgType.UInt: return reader.ReadUInt32();
-                case ArgType.SByte: return reader.ReadSByte();
-                case ArgType.Char: return reader.ReadChar();
-                case ArgType.Decimal: return reader.ReadDecimal();
-                case ArgType.String: return DecompressString(reader.ReadString());
-                case ArgType.Vector2: return reader.ReadVector2();
-                case ArgType.Vector3: return reader.ReadVector3();
-                case ArgType.Color:
-                    return new Color(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-                case ArgType.Quaternion:
-                    return new Quaternion(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-                case ArgType.ByteArray:
-                    return reader.ReadBytes(reader.ReadInt32());
-
-                case ArgType.Array:
-                {
-                    int len = reader.ReadInt32();
-                    var elementType = type.GetElementType();
-                    var arr = Array.CreateInstance(elementType, len);
-                    for (int i = 0; i < len; i++)
-                        arr.SetValue(ReadCollectionElement(reader, elementType), i);
-                    return arr;
-                }
-
-                case ArgType.List:
-                {
-                    int count = reader.ReadInt32();
-                    var elementType = type.GetGenericArguments()[0];
-                    var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType));
-                    for (int i = 0; i < count; i++)
-                        list.Add(ReadCollectionElement(reader, elementType));
-                    return list;
-                }
-
-                case ArgType.Dict:
-                {
-                    int count = reader.ReadInt32();
-                    var keyType = type.GetGenericArguments()[0];
-                    var valueType = type.GetGenericArguments()[1];
-                    var dict = (IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valueType));
-                    for (int i = 0; i < count; i++)
-                    {
-                        var key = ReadCollectionElement(reader, keyType);
-                        var val = ReadCollectionElement(reader, valueType);
-                        dict.Add(key, val);
-                    }
-                    return dict;
-                }
-
-                case ArgType.HashSet:
-                {
-                    int count = reader.ReadInt32();
-                    var elementType = type.GetGenericArguments()[0];
-                    var hashSetType = typeof(HashSet<>).MakeGenericType(elementType);
-                    var hashSet = Activator.CreateInstance(hashSetType);
-                    var addMethod = hashSetType.GetMethod("Add");
-                    for (int i = 0; i < count; i++)
-                        addMethod.Invoke(hashSet, new[] { ReadCollectionElement(reader, elementType) });
-                    return hashSet;
-                }
-
-                case ArgType.Queue:
-                {
-                    int count = reader.ReadInt32();
-                    var elementType = type.GetGenericArguments()[0];
-                    var queueType = typeof(Queue<>).MakeGenericType(elementType);
-                    var queue = Activator.CreateInstance(queueType);
-                    var enqueueMethod = queueType.GetMethod("Enqueue");
-                    for (int i = 0; i < count; i++)
-                        enqueueMethod.Invoke(queue, new[] { ReadCollectionElement(reader, elementType) });
-                    return queue;
-                }
-
-                case ArgType.Stack:
-                {
-                    int count = reader.ReadInt32();
-                    var elementType = type.GetGenericArguments()[0];
-                    var stackType = typeof(Stack<>).MakeGenericType(elementType);
-                    var stack = Activator.CreateInstance(stackType);
-                    var pushMethod = stackType.GetMethod("Push");
-                    for (int i = 0; i < count; i++)
-                        pushMethod.Invoke(stack, new[] { ReadCollectionElement(reader, elementType) });
-                    return stack;
-                }
-
-                case ArgType.Nullable:
-                {
-                    bool hasValue = reader.ReadBoolean();
-                    if (!hasValue) return null;
-                    return ReadArg(reader, Nullable.GetUnderlyingType(type));
-                }
-
-                case ArgType.HashedString:
-                    return new HashedString(reader.ReadInt32());
-
-                case ArgType.KAnimHashedString:
-                    return new KAnimHashedString(reader.ReadInt32());
-
-                default:
-                    throw new InvalidDataException($"Unknown RPC arg type tag: {tag}");
-            }
-        }
-
-        private static void WriteCollectionElement(BinaryWriter writer, object value, Type elementType)
-        {
-            bool needsNullPrefix = !elementType.IsValueType ||
-                (elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(Nullable<>));
-
-            if (needsNullPrefix)
-            {
-                bool notNull = value != null;
-                writer.Write(notNull);
-                if (!notNull) return;
-            }
-
-            WriteArg(writer, value, elementType);
-        }
-
-        private static object ReadCollectionElement(BinaryReader reader, Type elementType)
-        {
-            bool needsNullPrefix = !elementType.IsValueType ||
-                (elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(Nullable<>));
-
-            if (needsNullPrefix)
-            {
-                bool notNull = reader.ReadBoolean();
-                if (!notNull) return null;
-            }
-
-            return ReadArg(reader, elementType);
-        }
-        
-        public static string CompressString(string text)
-        {
-            if (string.IsNullOrEmpty(text)) return string.Empty;
-            
-            byte[] buffer = Encoding.UTF8.GetBytes(text);
-            var memoryStream = new MemoryStream();
-            using (var gZipStream = new GZipStream(memoryStream, CompressionMode.Compress, true))
-            {
-                gZipStream.Write(buffer, 0, buffer.Length);
-            }
-
-            memoryStream.Position = 0;
-
-            var compressedData = new byte[memoryStream.Length];
-            memoryStream.Read(compressedData, 0, compressedData.Length);
-
-            var gZipBuffer = new byte[compressedData.Length + 4];
-            Buffer.BlockCopy(compressedData, 0, gZipBuffer, 4, compressedData.Length);
-            Buffer.BlockCopy(BitConverter.GetBytes(buffer.Length), 0, gZipBuffer, 0, 4);
-            return Convert.ToBase64String(gZipBuffer);
-        }
-    
-        public static string DecompressString(string compressedText)
-        {
-            if (string.IsNullOrEmpty(compressedText)) return string.Empty;
-            
-            try
-            {
-                //return compressedText.Trim('`');
-                byte[] gZipBuffer = Convert.FromBase64String(compressedText);
-                using (var memoryStream = new MemoryStream())
-                {
-                    int dataLength = BitConverter.ToInt32(gZipBuffer, 0);
-                    memoryStream.Write(gZipBuffer, 4, gZipBuffer.Length - 4);
-
-                    var buffer = new byte[dataLength];
-
-                    memoryStream.Position = 0;
-                    using (var gZipStream = new GZipStream(memoryStream, CompressionMode.Decompress))
-                    {
-                        gZipStream.Read(buffer, 0, buffer.Length);
-                    }
-
-                    return Encoding.UTF8.GetString(buffer);
-                }
-            }
-            catch (Exception ex) 
-            {
-                return string.Empty;
-            }
         }
     }
 }

--- a/Shared/OxySync/Variant.cs
+++ b/Shared/OxySync/Variant.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.IO.Compression;
+using System.Text;
 using UnityEngine;
 
 namespace Shared.OxySync
@@ -44,7 +46,7 @@ namespace Shared.OxySync
                 case TypeCode.Float: writer.Write(Float); break;
                 case TypeCode.Int: writer.Write(Int); break;
                 case TypeCode.Byte: writer.Write(Byte); break;
-                case TypeCode.String: writer.Write(String); break;
+                case TypeCode.String: writer.Write(CompressString((string)String) ?? string.Empty); break;
                 case TypeCode.Boolean: writer.Write(Boolean); break;
                 case TypeCode.Vector3: writer.Write(Vector3); break;
                 case TypeCode.Vector2: writer.Write(Vector2); break;
@@ -103,7 +105,7 @@ namespace Shared.OxySync
                 case TypeCode.Float: v.Float = reader.ReadSingle(); break;
                 case TypeCode.Int: v.Int = reader.ReadInt32(); break;
                 case TypeCode.Byte: v.Byte = reader.ReadByte(); break;
-                case TypeCode.String: v.String = reader.ReadString(); break;
+                case TypeCode.String: v.String = DecompressString(reader.ReadString()); break;
                 case TypeCode.Boolean: v.Boolean = reader.ReadBoolean(); break;
                 case TypeCode.Vector3: v.Vector3 = reader.ReadVector3(); break;
                 case TypeCode.Vector2: v.Vector2 = reader.ReadVector2(); break;
@@ -168,6 +170,58 @@ namespace Shared.OxySync
             if (length < 0 || length > maximum)
                 throw new InvalidDataException($"Invalid {label} length: {length}.");
             return length;
+        }
+
+        public static string CompressString(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            
+            byte[] buffer = Encoding.UTF8.GetBytes(text);
+            var memoryStream = new MemoryStream();
+            using (var gZipStream = new GZipStream(memoryStream, CompressionMode.Compress, true))
+            {
+                gZipStream.Write(buffer, 0, buffer.Length);
+            }
+
+            memoryStream.Position = 0;
+
+            var compressedData = new byte[memoryStream.Length];
+            memoryStream.Read(compressedData, 0, compressedData.Length);
+
+            var gZipBuffer = new byte[compressedData.Length + 4];
+            Buffer.BlockCopy(compressedData, 0, gZipBuffer, 4, compressedData.Length);
+            Buffer.BlockCopy(BitConverter.GetBytes(buffer.Length), 0, gZipBuffer, 0, 4);
+            return Convert.ToBase64String(gZipBuffer);
+        }
+    
+        public static string DecompressString(string compressedText)
+        {
+            if (string.IsNullOrEmpty(compressedText)) return string.Empty;
+            
+            try
+            {
+                //return compressedText.Trim('`');
+                byte[] gZipBuffer = Convert.FromBase64String(compressedText);
+                using (var memoryStream = new MemoryStream())
+                {
+                    int dataLength = BitConverter.ToInt32(gZipBuffer, 0);
+                    memoryStream.Write(gZipBuffer, 4, gZipBuffer.Length - 4);
+
+                    var buffer = new byte[dataLength];
+
+                    memoryStream.Position = 0;
+                    using (var gZipStream = new GZipStream(memoryStream, CompressionMode.Decompress))
+                    {
+                        gZipStream.Read(buffer, 0, buffer.Length);
+                    }
+
+                    return Encoding.UTF8.GetString(buffer);
+                }
+            }
+            catch (Exception ex) 
+            {
+                return string.Empty;
+            }
         }
 
         public static implicit operator Variant(float f) => new Variant { Type = TypeCode.Float, Float = f };

--- a/Shared/OxySync/Variant.cs
+++ b/Shared/OxySync/Variant.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using UnityEngine;
 
-namespace ONI_Together.Misc
+namespace Shared.OxySync
 {
     /// <summary>
     /// A type-safe tagged union that holds one value of multiple possible types (Float, Int, Byte, String, Boolean, Vector3, Vector2) at a time,

--- a/Shared/OxySync/VariantHelper.cs
+++ b/Shared/OxySync/VariantHelper.cs
@@ -96,6 +96,10 @@ namespace Shared.OxySync
                 return null;
             }
 
+            Type nullableUnderlying = Nullable.GetUnderlyingType(targetType);
+            if (nullableUnderlying != null)
+                return VariantToObject(v, nullableUnderlying);
+
             if (targetType == typeof(int)) return v.Int;
             if (targetType == typeof(float)) return v.Float;
             if (targetType == typeof(byte)) return v.Byte;

--- a/Shared/OxySync/VariantHelper.cs
+++ b/Shared/OxySync/VariantHelper.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace ONI_Together.Misc
+namespace Shared.OxySync
 {
     public static class VariantHelper
     {


### PR DESCRIPTION
Switch the Rpc arg serializer to use variant type so the supported rpc arg type match the sync var supported type.

This PR rely on the PR https://github.com/Lyraedan/Oxygen_Not_Included_Together/pull/207

Only the regression test is needed. The unit tests should cover all the cases relates to the changes.

The purpose of this PR is to let the rpc support the class type, which is in the PR https://github.com/Lyraedan/Oxygen_Not_Included_Together/pull/202 . 
However, this can still work without merging the PR #202 