### PR TITLE
OxySync: migrate dig tool to OxySync

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/DigToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/DigToolSyncer.cs
@@ -1,0 +1,81 @@
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.Components;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class DigToolSyncer : NetworkBehaviour
+    {
+        public static DigToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("DigToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<DigToolSyncer>();
+            }
+            Instance.NetId = nameof(DigToolSyncer).GetHashCode();
+        }
+
+        public static void RequestDig(int cell, int animationDelay)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdDig), cell, animationDelay, (int)p.priority_class, p.priority_value);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[DigToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdDig(int cell, int animationDelay, int priority_class, int priority_value)
+        {
+            CallClientRpc(nameof(RpcDig), cell, animationDelay, priority_class, priority_value);
+        }
+
+        [ClientRpc]
+        private void RpcDig(int cell, int animationDelay, int priority_class, int priority_value)
+        {
+            if (_processing) return;
+            _processing = true;
+            try
+            {
+                var go = DigTool.PlaceDig(cell, animationDelay);
+                var prioritizable = go?.GetComponent<Prioritizable>();
+                if (prioritizable != null)
+                    prioritizable.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+            }
+            finally
+            {
+                _processing = false;
+            }
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/DigToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/DigToolSyncer.cs
@@ -11,7 +11,8 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
     public class DigToolSyncer : NetworkBehaviour
     {
         public static DigToolSyncer Instance { get; private set; }
-        private static bool _processing;
+
+        public static bool ProcessingIncoming;
 
         public override void OnSpawn()
         {
@@ -42,11 +43,15 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestDig(int cell, int animationDelay)
         {
             var s = Instance;
-            if (s == null) return;
+            if (s == null || ProcessingIncoming) return;
             try
             {
                 var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
-                s.CallCommand(nameof(CmdDig), cell, animationDelay, (int)p.priority_class, p.priority_value);
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdDig), cell, animationDelay, (int)p.priority_class, p.priority_value, originator);
+                else
+                    s.CallCommand(nameof(CmdHostDig), cell, animationDelay, (int)p.priority_class, p.priority_value, originator);
             }
             catch (System.Exception ex)
             {
@@ -55,27 +60,35 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         }
 
         [Command]
-        private void CmdDig(int cell, int animationDelay, int priority_class, int priority_value)
+        private void CmdDig(int cell, int animationDelay, int priority_class, int priority_value, ulong originator)
         {
-            CallClientRpc(nameof(RpcDig), cell, animationDelay, priority_class, priority_value);
+            CallClientRpc(nameof(RpcDig), cell, animationDelay, priority_class, priority_value, originator);
+        }
+
+        [Command]
+        private void CmdHostDig(int cell, int animationDelay, int priority_class, int priority_value, ulong originator)
+        {
+            ProcessingIncoming = true;
+            try { ApplyDig(cell, animationDelay, priority_class, priority_value); }
+            finally { ProcessingIncoming = false; }
+            CallClientRpc(nameof(RpcDig), cell, animationDelay, priority_class, priority_value, originator);
         }
 
         [ClientRpc]
-        private void RpcDig(int cell, int animationDelay, int priority_class, int priority_value)
+        private void RpcDig(int cell, int animationDelay, int priority_class, int priority_value, ulong originator)
         {
-            if (_processing) return;
-            _processing = true;
-            try
-            {
-                var go = DigTool.PlaceDig(cell, animationDelay);
-                var prioritizable = go?.GetComponent<Prioritizable>();
-                if (prioritizable != null)
-                    prioritizable.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
-            }
-            finally
-            {
-                _processing = false;
-            }
+            if (originator != 0 && originator == (LocalUserIdQuery?.Invoke() ?? 0)) return;
+            ProcessingIncoming = true;
+            try { ApplyDig(cell, animationDelay, priority_class, priority_value); }
+            finally { ProcessingIncoming = false; }
+        }
+
+        private static void ApplyDig(int cell, int animationDelay, int priority_class, int priority_value)
+        {
+            var go = DigTool.PlaceDig(cell, animationDelay);
+            var prioritizable = go?.GetComponent<Prioritizable>();
+            if (prioritizable != null)
+                prioritizable.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
         }
     }
 }

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      DigToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/ToolPatches/Dig/DigToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Dig/DigToolPatch.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Dig;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Dig
@@ -14,15 +13,9 @@ namespace ONI_Together.Patches.ToolPatches.Dig
             using var _ = Profiler.Scope();
 
             if (!MultiplayerSession.InActiveSession)
-            {
-                DebugConsole.LogWarning("[PlaceDig Patch] Skipped: MultiplayerSession.InSession is false");
-                return;
-            }
-
-            if (DiggablePacket.ProcessingIncoming)
                 return;
 
-            PacketSender.SendToAllOtherPeers(new DiggablePacket(cell, animationDelay));
+            DigToolSyncer.RequestDig(cell, animationDelay);
         }
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes DigTool.PlaceDig replication through the new DigToolSyncer (Command to ClientRpc) instead of DiggablePacket, preserving the selected priority. Removes the ProcessingIncoming echo guard and the session-skip warning.

Build: dotnet build ONI_Together.sln, 0 errors.

Note: GamePatch.cs registers each syncer with one line, expect a trivial keep-both rebase once the first syncer PR lands.