### PR TITLE
OxySync: migrate build tool to OxySync

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/BuildToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/BuildToolSyncer.cs
@@ -12,7 +12,8 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
     public class BuildToolSyncer : NetworkBehaviour
     {
         public static BuildToolSyncer Instance { get; private set; }
-        private static bool _processing;
+
+        public static bool ProcessingIncoming;
 
         public override void OnSpawn()
         {
@@ -43,11 +44,15 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestBuild(string prefabID, int cell, int orientation, List<string> materialTags, int objectLayer, bool instantBuild)
         {
             var s = Instance;
-            if (s == null) return;
+            if (s == null || ProcessingIncoming) return;
             try
             {
                 var p = PlanScreen.Instance != null ? PlanScreen.Instance.GetBuildingPriority() : ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
-                s.CallCommand(nameof(CmdBuild), prefabID, cell, orientation, materialTags, (int)p.priority_class, p.priority_value, objectLayer, instantBuild);
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdBuild), prefabID, cell, orientation, materialTags, (int)p.priority_class, p.priority_value, objectLayer, instantBuild, originator);
+                else
+                    s.CallCommand(nameof(CmdHostBuild), prefabID, cell, orientation, materialTags, (int)p.priority_class, p.priority_value, objectLayer, instantBuild, originator);
             }
             catch (System.Exception ex)
             {
@@ -56,38 +61,46 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         }
 
         [Command]
-        private void CmdBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild)
+        private void CmdBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild, ulong originator)
         {
-            CallClientRpc(nameof(RpcBuild), prefabID, cell, orientation, materialTags, priority_class, priority_value, objectLayer, instantBuild);
+            CallClientRpc(nameof(RpcBuild), prefabID, cell, orientation, materialTags, priority_class, priority_value, objectLayer, instantBuild, originator);
+        }
+
+        [Command]
+        private void CmdHostBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild, ulong originator)
+        {
+            ProcessingIncoming = true;
+            try { ApplyBuild(prefabID, cell, orientation, materialTags, priority_class, priority_value, objectLayer, instantBuild); }
+            finally { ProcessingIncoming = false; }
+            CallClientRpc(nameof(RpcBuild), prefabID, cell, orientation, materialTags, priority_class, priority_value, objectLayer, instantBuild, originator);
         }
 
         [ClientRpc]
-        private void RpcBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild)
+        private void RpcBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild, ulong originator)
         {
-            if (_processing) return;
+            if (originator != 0 && originator == (LocalUserIdQuery?.Invoke() ?? 0)) return;
+            ProcessingIncoming = true;
+            try { ApplyBuild(prefabID, cell, orientation, materialTags, priority_class, priority_value, objectLayer, instantBuild); }
+            finally { ProcessingIncoming = false; }
+        }
+
+        private static void ApplyBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild)
+        {
             if (!Grid.IsValidCell(cell)) return;
             var def = Assets.GetBuildingDef(prefabID);
             if (def == null) return;
-            _processing = true;
-            try
-            {
-                var tags = materialTags.Select(t => TagManager.Create(t)).ToList();
-                var pos = Grid.CellToPosCBC(cell, Grid.SceneLayer.Building);
-                GameObject built = null;
-                if (instantBuild)
-                    built = BuildInternal(def, tags, pos, (Orientation)orientation, cell);
-                else
-                    built = QueueBuild(def, tags, pos, (Orientation)orientation);
-                if (built == null && def.ReplacementLayer != ObjectLayer.NumLayers)
-                    built = HandleReplacement(def, pos, tags, (Orientation)orientation, cell, instantBuild) ?? built;
-                var pri = built?.GetComponent<Prioritizable>();
-                if (pri != null)
-                    pri.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
-            }
-            finally
-            {
-                _processing = false;
-            }
+            var tags = materialTags.Select(t => TagManager.Create(t)).ToList();
+            var pos = Grid.CellToPosCBC(cell, Grid.SceneLayer.Building);
+            GameObject built = null;
+            if (instantBuild)
+                built = BuildInternal(def, tags, pos, (Orientation)orientation, cell);
+            else
+                built = QueueBuild(def, tags, pos, (Orientation)orientation);
+            if (built == null && def.ReplacementLayer != ObjectLayer.NumLayers)
+                built = HandleReplacement(def, pos, tags, (Orientation)orientation, cell, instantBuild) ?? built;
+            var pri = built?.GetComponent<Prioritizable>();
+            if (pri != null)
+                pri.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
         }
 
         private static GameObject QueueBuild(BuildingDef def, List<Tag> tags, Vector3 pos, Orientation orientation)

--- a/ONI_Together/Networking/OxySync/Components/Tools/BuildToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/BuildToolSyncer.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Linq;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class BuildToolSyncer : NetworkBehaviour
+    {
+        public static BuildToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("BuildToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<BuildToolSyncer>();
+            }
+            Instance.NetId = nameof(BuildToolSyncer).GetHashCode();
+        }
+
+        public static void RequestBuild(string prefabID, int cell, int orientation, List<string> materialTags, int objectLayer, bool instantBuild)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = PlanScreen.Instance != null ? PlanScreen.Instance.GetBuildingPriority() : ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdBuild), prefabID, cell, orientation, materialTags, (int)p.priority_class, p.priority_value, objectLayer, instantBuild);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[BuildToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild)
+        {
+            CallClientRpc(nameof(RpcBuild), prefabID, cell, orientation, materialTags, priority_class, priority_value, objectLayer, instantBuild);
+        }
+
+        [ClientRpc]
+        private void RpcBuild(string prefabID, int cell, int orientation, List<string> materialTags, int priority_class, int priority_value, int objectLayer, bool instantBuild)
+        {
+            if (_processing) return;
+            if (!Grid.IsValidCell(cell)) return;
+            var def = Assets.GetBuildingDef(prefabID);
+            if (def == null) return;
+            _processing = true;
+            try
+            {
+                var tags = materialTags.Select(t => TagManager.Create(t)).ToList();
+                var pos = Grid.CellToPosCBC(cell, Grid.SceneLayer.Building);
+                GameObject built = null;
+                if (instantBuild)
+                    built = BuildInternal(def, tags, pos, (Orientation)orientation, cell);
+                else
+                    built = QueueBuild(def, tags, pos, (Orientation)orientation);
+                if (built == null && def.ReplacementLayer != ObjectLayer.NumLayers)
+                    built = HandleReplacement(def, pos, tags, (Orientation)orientation, cell, instantBuild) ?? built;
+                var pri = built?.GetComponent<Prioritizable>();
+                if (pri != null)
+                    pri.SetMasterPriority(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+            }
+            finally
+            {
+                _processing = false;
+            }
+        }
+
+        private static GameObject QueueBuild(BuildingDef def, List<Tag> tags, Vector3 pos, Orientation orientation)
+        {
+            var viz = Util.KInstantiate(def.BuildingPreview, pos);
+            return def.TryPlace(viz, pos, orientation, tags, "DEFAULT_FACADE");
+        }
+
+        private static GameObject BuildInternal(BuildingDef def, List<Tag> tags, Vector3 pos, Orientation orientation, int cell)
+        {
+            if (!def.IsValidBuildLocation(null, pos, orientation) || !def.IsValidPlaceLocation(null, pos, orientation, out _))
+                return null;
+            if (def.ObjectLayer == ObjectLayer.Building)
+            {
+                def.RunOnArea(cell, orientation, c =>
+                {
+                    if (Uprootable.CanUproot(Grid.Objects[c, (int)def.ObjectLayer], out var u))
+                        u.CompleteWork(null);
+                });
+            }
+            else if (def.ObjectLayer == ObjectLayer.Backwall)
+            {
+                def.RunOnArea(cell, orientation, c =>
+                {
+                    if (BackwallManager.HasBackwall(c))
+                        SimMessages.Dig(c, -1, skipEvent: true, backwall: true);
+                });
+            }
+            float temp = Mathf.Min(def.Temperature, ElementLoader.GetMinMeltingPointAmongElements(tags) - 10f);
+            return def.Build(cell, orientation, null, tags, temp, "DEFAULT_FACADE", false, GameClock.Instance.GetTime());
+        }
+
+        private static GameObject HandleReplacement(BuildingDef def, Vector3 pos, List<Tag> tags, Orientation orientation, int cell, bool instant)
+        {
+            var cand = def.GetReplacementCandidate(cell);
+            if (cand == null || def.IsReplacementLayerOccupied(cell)) return null;
+            var comp = cand.GetComponent<BuildingComplete>();
+            if (comp == null || !comp.Def.Replaceable || !def.CanReplace(cand)) return null;
+            var tag = cand.GetComponent<PrimaryElement>().Element.tag;
+            if (tag.GetHash() == (int)SimHashes.StableSnow) tag = SimHashes.Snow.CreateTag();
+            if (comp.Def == def && tags.Count > 0 && tags[0] == tag) return null;
+            var viz = Util.KInstantiate(def.BuildingPreview, pos);
+            if (!instant)
+            {
+                var r = def.TryReplaceTile(viz, pos, orientation, tags, "DEFAULT_FACADE");
+                if (r != null) Grid.Objects[cell, (int)def.ReplacementLayer] = r;
+                return r;
+            }
+            if (!def.IsValidBuildLocation(null, pos, orientation, true) || !def.IsValidPlaceLocation(null, pos, orientation, true, out _)) return null;
+            float temp = Mathf.Min(def.Temperature, ElementLoader.GetMinMeltingPointAmongElements(tags) - 10f);
+            return def.Build(cell, orientation, null, tags, temp, "DEFAULT_FACADE", false, GameClock.Instance.GetTime());
+        }
+    }
+}

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      BuildToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/ToolPatches/Build/BuildToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Build/BuildToolPatch.cs
@@ -1,9 +1,8 @@
-﻿using HarmonyLib;
-using ONI_Together.DebugTools;
+﻿using System;
+using System.Linq;
+using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Build;
-using System;
-using System.Collections.Generic;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -12,67 +11,23 @@ namespace ONI_Together.Patches.ToolPatches.Build
     [HarmonyPatch(typeof(BuildTool), nameof(BuildTool.TryBuild))]
     public static class BuildToolPatch
     {
-        static void Prefix(BuildTool __instance, int cell)
-        {
-            using var _ = Profiler.Scope();
-
-            try
-            {
-                var def = __instance.def;
-                if (def != null)
-                {
-                    DebugConsole.Log($"[BuildTool] Attempting to build: {def.PrefabID} at cell {cell}");
-                }
-            }
-            catch (Exception ex)
-            {
-                DebugConsole.LogError($"[BuildToolPatch.Prefix] {ex}");
-            }
-        }
-
         static void Postfix(BuildTool __instance, int cell)
         {
             using var _ = Profiler.Scope();
 
-            try
-            {
-                if (!MultiplayerSession.InActiveSession || __instance == null)
-                    return;
+            if (!MultiplayerSession.InActiveSession || __instance == null)
+                return;
 
-                var def = __instance.def;
-                var selectedElements = __instance.selectedElements;
-                var orientation = __instance.GetBuildingOrientation;
+            var def = __instance.def;
+            var selectedElements = __instance.selectedElements;
+            var orientation = __instance.GetBuildingOrientation;
 
-                if (def == null || selectedElements == null)
-                    return;
+            if (def == null || selectedElements == null)
+                return;
 
-                GameObject obj = Grid.Objects[cell, (int) def.ObjectLayer];
-                if (obj != null)
-                {
-                    DebugConsole.Log($"[BuildTool] Successfully placed {def.PrefabID} at cell {cell}");
-                }
-                else
-                {
-                    // It might be a ghost/preview, so we still send the packet!
-                    DebugConsole.Log($"[BuildTool] Placed intention/ghost for {def.PrefabID} at cell {cell}");
-                }
-
-                bool instantBuild = DebugHandler.InstantBuildMode || (Game.Instance.SandboxModeActive && SandboxToolParameterMenu.instance.settings.InstantBuild);
-                var packet = new BuildPacket(
-                    def.PrefabID,
-                    cell,
-                    orientation,
-                    selectedElements,
-                    def.ObjectLayer,
-                    instantBuild
-                );
-
-                PacketSender.SendToAllOtherPeers(packet);
-            }
-            catch (Exception ex)
-            {
-                DebugConsole.LogError($"[BuildToolPatch.Postfix] {ex}");
-            }
+            bool instantBuild = DebugHandler.InstantBuildMode || (Game.Instance.SandboxModeActive && SandboxToolParameterMenu.instance.settings.InstantBuild);
+            var tags = selectedElements.Select(t => t.ToString()).ToList();
+            BuildToolSyncer.RequestBuild(def.PrefabID, cell, (int)orientation, tags, (int)def.ObjectLayer, instantBuild);
         }
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes BuildTool.TryBuild replication through the new BuildToolSyncer instead of the build packet, including replacement-tile handling, the instant-build path, materials, orientation and priority.

Build: 0 errors.

Note: GamePatch.cs registers each syncer with one line, expect a trivial keep-both rebase once the first syncer PR lands.