### PR TITLE
OxySync: migrate attack tool to OxySync

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/AttackToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/AttackToolSyncer.cs
@@ -1,0 +1,85 @@
+using HarmonyLib;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class AttackToolSyncer : NetworkBehaviour
+    {
+        public static AttackToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("AttackToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<AttackToolSyncer>();
+            }
+            Instance.NetId = nameof(AttackToolSyncer).GetHashCode();
+        }
+
+        public static void RequestAttack(Vector2 min, Vector2 max)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdAttack), min, max, (int)p.priority_class, p.priority_value);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[AttackToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdAttack(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            CallClientRpc(nameof(RpcAttack), min, max, priority_class, priority_value);
+        }
+
+        [ClientRpc]
+        private void RpcAttack(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            if (_processing) return;
+            _processing = true;
+            try
+            {
+                var ps = ToolMenu.Instance?.PriorityScreen;
+                if (ps == null)
+                {
+                    AttackTool.MarkForAttack(min, max, true);
+                    return;
+                }
+                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+                var prev = tr.GetValue<PrioritySetting>();
+                tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+                try { AttackTool.MarkForAttack(min, max, true); }
+                finally { tr.SetValue(prev); }
+            }
+            finally { _processing = false; }
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/AttackToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/AttackToolSyncer.cs
@@ -11,7 +11,8 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
     public class AttackToolSyncer : NetworkBehaviour
     {
         public static AttackToolSyncer Instance { get; private set; }
-        private static bool _processing;
+
+        public static bool ProcessingIncoming;
 
         public override void OnSpawn()
         {
@@ -42,11 +43,15 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestAttack(Vector2 min, Vector2 max)
         {
             var s = Instance;
-            if (s == null) return;
+            if (s == null || ProcessingIncoming) return;
             try
             {
                 var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
-                s.CallCommand(nameof(CmdAttack), min, max, (int)p.priority_class, p.priority_value);
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdAttack), min, max, (int)p.priority_class, p.priority_value, originator);
+                else
+                    s.CallCommand(nameof(CmdHostAttack), min, max, (int)p.priority_class, p.priority_value, originator);
             }
             catch (System.Exception ex)
             {
@@ -55,31 +60,42 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         }
 
         [Command]
-        private void CmdAttack(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        private void CmdAttack(Vector2 min, Vector2 max, int priority_class, int priority_value, ulong originator)
         {
-            CallClientRpc(nameof(RpcAttack), min, max, priority_class, priority_value);
+            CallClientRpc(nameof(RpcAttack), min, max, priority_class, priority_value, originator);
+        }
+
+        [Command]
+        private void CmdHostAttack(Vector2 min, Vector2 max, int priority_class, int priority_value, ulong originator)
+        {
+            ProcessingIncoming = true;
+            try { ApplyAttack(min, max, priority_class, priority_value); }
+            finally { ProcessingIncoming = false; }
+            CallClientRpc(nameof(RpcAttack), min, max, priority_class, priority_value, originator);
         }
 
         [ClientRpc]
-        private void RpcAttack(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        private void RpcAttack(Vector2 min, Vector2 max, int priority_class, int priority_value, ulong originator)
         {
-            if (_processing) return;
-            _processing = true;
-            try
+            if (originator != 0 && originator == (LocalUserIdQuery?.Invoke() ?? 0)) return;
+            ProcessingIncoming = true;
+            try { ApplyAttack(min, max, priority_class, priority_value); }
+            finally { ProcessingIncoming = false; }
+        }
+
+        private static void ApplyAttack(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            var ps = ToolMenu.Instance?.PriorityScreen;
+            if (ps == null)
             {
-                var ps = ToolMenu.Instance?.PriorityScreen;
-                if (ps == null)
-                {
-                    AttackTool.MarkForAttack(min, max, true);
-                    return;
-                }
-                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
-                var prev = tr.GetValue<PrioritySetting>();
-                tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
-                try { AttackTool.MarkForAttack(min, max, true); }
-                finally { tr.SetValue(prev); }
+                AttackTool.MarkForAttack(min, max, true);
+                return;
             }
-            finally { _processing = false; }
+            var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+            var prev = tr.GetValue<PrioritySetting>();
+            tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+            try { AttackTool.MarkForAttack(min, max, true); }
+            finally { tr.SetValue(prev); }
         }
     }
 }

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      AttackToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/ToolPatches/Attack/AttackToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Attack/AttackToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Attack;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -19,6 +19,6 @@ public class AttackToolPatch
         Vector2 min_object = __instance.GetRegularizedPos(Vector2.Min(downPos, upPos), true);
         Vector2 max_object = __instance.GetRegularizedPos(Vector2.Max(downPos, upPos), false);
 
-        PacketSender.SendToAllOtherPeers(new AttackToolPacket(min_object, max_object));
+        AttackToolSyncer.RequestAttack(min_object, max_object);
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes AttackTool drag-box replication through the new AttackToolSyncer instead of AttackToolPacket, applying the sender priority around MarkForAttack with a reentrancy guard.

Build: 0 errors.

Note: GamePatch.cs registers each syncer with one line, expect a trivial keep-both rebase once the first syncer PR lands.