### PR TITLE
OxySync: migrate capture tool to OxySync

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/CaptureToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/CaptureToolSyncer.cs
@@ -11,7 +11,8 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
     public class CaptureToolSyncer : NetworkBehaviour
     {
         public static CaptureToolSyncer Instance { get; private set; }
-        private static bool _processing;
+
+        public static bool ProcessingIncoming;
 
         public override void OnSpawn()
         {
@@ -42,11 +43,15 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestCapture(Vector2 min, Vector2 max)
         {
             var s = Instance;
-            if (s == null) return;
+            if (s == null || ProcessingIncoming) return;
             try
             {
                 var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
-                s.CallCommand(nameof(CmdCapture), min, max, (int)p.priority_class, p.priority_value);
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdCapture), min, max, (int)p.priority_class, p.priority_value, originator);
+                else
+                    s.CallCommand(nameof(CmdHostCapture), min, max, (int)p.priority_class, p.priority_value, originator);
             }
             catch (System.Exception ex)
             {
@@ -55,31 +60,42 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         }
 
         [Command]
-        private void CmdCapture(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        private void CmdCapture(Vector2 min, Vector2 max, int priority_class, int priority_value, ulong originator)
         {
-            CallClientRpc(nameof(RpcCapture), min, max, priority_class, priority_value);
+            CallClientRpc(nameof(RpcCapture), min, max, priority_class, priority_value, originator);
+        }
+
+        [Command]
+        private void CmdHostCapture(Vector2 min, Vector2 max, int priority_class, int priority_value, ulong originator)
+        {
+            ProcessingIncoming = true;
+            try { ApplyCapture(min, max, priority_class, priority_value); }
+            finally { ProcessingIncoming = false; }
+            CallClientRpc(nameof(RpcCapture), min, max, priority_class, priority_value, originator);
         }
 
         [ClientRpc]
-        private void RpcCapture(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        private void RpcCapture(Vector2 min, Vector2 max, int priority_class, int priority_value, ulong originator)
         {
-            if (_processing) return;
-            _processing = true;
-            try
+            if (originator != 0 && originator == (LocalUserIdQuery?.Invoke() ?? 0)) return;
+            ProcessingIncoming = true;
+            try { ApplyCapture(min, max, priority_class, priority_value); }
+            finally { ProcessingIncoming = false; }
+        }
+
+        private static void ApplyCapture(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            var ps = ToolMenu.Instance?.PriorityScreen;
+            if (ps == null)
             {
-                var ps = ToolMenu.Instance?.PriorityScreen;
-                if (ps == null)
-                {
-                    CaptureTool.MarkForCapture(min, max, true);
-                    return;
-                }
-                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
-                var prev = tr.GetValue<PrioritySetting>();
-                tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
-                try { CaptureTool.MarkForCapture(min, max, true); }
-                finally { tr.SetValue(prev); }
+                CaptureTool.MarkForCapture(min, max, true);
+                return;
             }
-            finally { _processing = false; }
+            var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+            var prev = tr.GetValue<PrioritySetting>();
+            tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+            try { CaptureTool.MarkForCapture(min, max, true); }
+            finally { tr.SetValue(prev); }
         }
     }
 }

--- a/ONI_Together/Networking/OxySync/Components/Tools/CaptureToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/CaptureToolSyncer.cs
@@ -1,0 +1,85 @@
+using HarmonyLib;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class CaptureToolSyncer : NetworkBehaviour
+    {
+        public static CaptureToolSyncer Instance { get; private set; }
+        private static bool _processing;
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("CaptureToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<CaptureToolSyncer>();
+            }
+            Instance.NetId = nameof(CaptureToolSyncer).GetHashCode();
+        }
+
+        public static void RequestCapture(Vector2 min, Vector2 max)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdCapture), min, max, (int)p.priority_class, p.priority_value);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[CaptureToolSyncer] {ex}");
+            }
+        }
+
+        [Command]
+        private void CmdCapture(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            CallClientRpc(nameof(RpcCapture), min, max, priority_class, priority_value);
+        }
+
+        [ClientRpc]
+        private void RpcCapture(Vector2 min, Vector2 max, int priority_class, int priority_value)
+        {
+            if (_processing) return;
+            _processing = true;
+            try
+            {
+                var ps = ToolMenu.Instance?.PriorityScreen;
+                if (ps == null)
+                {
+                    CaptureTool.MarkForCapture(min, max, true);
+                    return;
+                }
+                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+                var prev = tr.GetValue<PrioritySetting>();
+                tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+                try { CaptureTool.MarkForCapture(min, max, true); }
+                finally { tr.SetValue(prev); }
+            }
+            finally { _processing = false; }
+        }
+    }
+}

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      CaptureToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/ToolPatches/Capture/CaptureToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Capture/CaptureToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Capture;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -19,6 +19,6 @@ public class CaptureToolPatch
         Vector2 min_object = __instance.GetRegularizedPos(Vector2.Min(downPos, upPos), true);
         Vector2 max_object = __instance.GetRegularizedPos(Vector2.Max(downPos, upPos), false);
 
-        PacketSender.SendToAllOtherPeers(new CaptureToolPacket(min_object, max_object));
+        CaptureToolSyncer.RequestCapture(min_object, max_object);
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes CaptureTool drag-box replication through the new CaptureToolSyncer instead of CaptureToolPacket, applying the sender priority around MarkForCapture with a reentrancy guard.

Build: 0 errors.

Note: GamePatch.cs registers each syncer with one line, expect a trivial keep-both rebase once the first syncer PR lands.