### PR TITLE
OxySync: add shared DragToolSyncer for drag tools

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/DragToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/DragToolSyncer.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class DragToolSyncer : NetworkBehaviour
+    {
+        public static DragToolSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("DragToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<DragToolSyncer>();
+            }
+            Instance.NetId = nameof(DragToolSyncer).GetHashCode();
+        }
+
+        public static void RequestDrag(string toolName, int cell, int distFromOrigin)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                DragTool tool = ResolveTool(toolName);
+                List<string> filters = new();
+                if (tool is FilteredDragTool filtered)
+                {
+                    foreach (var t in filtered.currentFilters)
+                        if (t.state == ToolParameterMenu.ToggleState.On)
+                            filters.Add(t.name);
+                }
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdDrag), toolName, cell, distFromOrigin, filters, (int)p.priority_class, p.priority_value, 0, Vector3.zero, Vector3.zero);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[DragToolSyncer] {ex}");
+            }
+        }
+
+        public static void RequestDragComplete(string toolName, Vector3 downPos, Vector3 upPos)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try
+            {
+                DragTool tool = ResolveTool(toolName);
+                List<string> filters = new();
+                if (tool is FilteredDragTool filtered)
+                {
+                    foreach (var t in filtered.currentFilters)
+                        if (t.state == ToolParameterMenu.ToggleState.On)
+                            filters.Add(t.name);
+                }
+                var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
+                s.CallCommand(nameof(CmdDrag), toolName, 0, 0, filters, (int)p.priority_class, p.priority_value, 1, downPos, upPos);
+            }
+            catch (System.Exception ex)
+            {
+                DebugConsole.LogWarning($"[DragToolSyncer] {ex}");
+            }
+        }
+
+        private static DragTool ResolveTool(string name)
+        {
+            return name switch
+            {
+                "Cancel" => CancelTool.Instance,
+                "Clear" => ClearTool.Instance,
+                "Deconstruct" => DeconstructTool.Instance,
+                "Mop" => MopTool.Instance,
+                "Harvest" => HarvestTool.Instance,
+                "Disinfect" => DisinfectTool.Instance,
+                "Prioritize" => PrioritizeTool.Instance,
+                "EmptyPipe" => EmptyPipeTool.Instance,
+                "Disconnect" => DisconnectTool.Instance,
+                _ => null
+            };
+        }
+
+        [Command]
+        private void CmdDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos)
+        {
+            CallClientRpc(nameof(RpcDrag), toolName, cell, distFromOrigin, filterTargets, priority_class, priority_value, mode, downPos, upPos);
+        }
+
+        [ClientRpc]
+        private void RpcDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos)
+        {
+            DragTool tool = ResolveTool(toolName);
+            if (tool == null) return;
+            FilteredDragTool filtered = tool as FilteredDragTool;
+            bool isFiltered = filtered != null;
+            HashSet<string> cached = new();
+            if (isFiltered)
+            {
+                cached = filtered.currentFilters.Where(t => t.state == ToolParameterMenu.ToggleState.On).Select(t => t.name).ToHashSet();
+                foreach (var toggle in filtered.currentFilters)
+                    toggle.state = ToolParameterMenu.ToggleState.Off;
+                foreach (var target in filterTargets)
+                    foreach (var toggle in filtered.currentFilters)
+                        if (toggle.name == target) { toggle.state = ToolParameterMenu.ToggleState.On; break; }
+            }
+            var ps = ToolMenu.Instance?.PriorityScreen;
+            PrioritySetting prev = default;
+            bool hasPs = ps != null;
+            if (hasPs)
+            {
+                prev = ps.lastSelectedPriority;
+                var tr = Traverse.Create(ps).Field("lastSelectedPriority");
+                if (tr != null) tr.SetValue(new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value));
+                else ps.lastSelectedPriority = new PrioritySetting((PriorityScreen.PriorityClass)priority_class, priority_value);
+            }
+            Vector3 cachedDown = tool.downPos;
+            bool completed = false;
+            try
+            {
+                if (mode == 0)
+                    tool.OnDragTool(cell, distFromOrigin);
+                else
+                {
+                    tool.downPos = downPos;
+                    tool.OnDragComplete(downPos, upPos);
+                }
+                completed = true;
+            }
+            finally
+            {
+                tool.downPos = cachedDown;
+                if (hasPs)
+                {
+                    var tr2 = Traverse.Create(ps).Field("lastSelectedPriority");
+                    if (tr2 != null) tr2.SetValue(prev);
+                    else ps.lastSelectedPriority = prev;
+                }
+                if (isFiltered)
+                {
+                    foreach (var toggle in filtered.currentFilters)
+                        toggle.state = ToolParameterMenu.ToggleState.Off;
+                    foreach (var target in cached)
+                        foreach (var toggle in filtered.currentFilters)
+                            if (toggle.name == target) { toggle.state = ToolParameterMenu.ToggleState.On; break; }
+                }
+            }
+        }
+    }
+}

--- a/ONI_Together/Networking/OxySync/Components/Tools/DragToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/DragToolSyncer.cs
@@ -14,6 +14,8 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
     {
         public static DragToolSyncer Instance { get; private set; }
 
+        public static bool ProcessingIncoming;
+
         public override void OnSpawn()
         {
             base.OnSpawn();
@@ -43,7 +45,7 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestDrag(string toolName, int cell, int distFromOrigin)
         {
             var s = Instance;
-            if (s == null) return;
+            if (s == null || ProcessingIncoming) return;
             try
             {
                 DragTool tool = ResolveTool(toolName);
@@ -55,7 +57,11 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
                             filters.Add(t.name);
                 }
                 var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
-                s.CallCommand(nameof(CmdDrag), toolName, cell, distFromOrigin, filters, (int)p.priority_class, p.priority_value, 0, Vector3.zero, Vector3.zero);
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdDrag), toolName, cell, distFromOrigin, filters, (int)p.priority_class, p.priority_value, 0, Vector3.zero, Vector3.zero, originator);
+                else
+                    s.CallCommand(nameof(CmdHostDrag), toolName, cell, distFromOrigin, filters, (int)p.priority_class, p.priority_value, 0, Vector3.zero, Vector3.zero, originator);
             }
             catch (System.Exception ex)
             {
@@ -66,7 +72,7 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestDragComplete(string toolName, Vector3 downPos, Vector3 upPos)
         {
             var s = Instance;
-            if (s == null) return;
+            if (s == null || ProcessingIncoming) return;
             try
             {
                 DragTool tool = ResolveTool(toolName);
@@ -78,7 +84,11 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
                             filters.Add(t.name);
                 }
                 var p = ToolMenu.Instance?.PriorityScreen?.GetLastSelectedPriority() ?? default;
-                s.CallCommand(nameof(CmdDrag), toolName, 0, 0, filters, (int)p.priority_class, p.priority_value, 1, downPos, upPos);
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdDrag), toolName, 0, 0, filters, (int)p.priority_class, p.priority_value, 1, downPos, upPos, originator);
+                else
+                    s.CallCommand(nameof(CmdHostDrag), toolName, 0, 0, filters, (int)p.priority_class, p.priority_value, 1, downPos, upPos, originator);
             }
             catch (System.Exception ex)
             {
@@ -104,13 +114,30 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         }
 
         [Command]
-        private void CmdDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos)
+        private void CmdDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos, ulong originator)
         {
-            CallClientRpc(nameof(RpcDrag), toolName, cell, distFromOrigin, filterTargets, priority_class, priority_value, mode, downPos, upPos);
+            CallClientRpc(nameof(RpcDrag), toolName, cell, distFromOrigin, filterTargets, priority_class, priority_value, mode, downPos, upPos, originator);
+        }
+
+        [Command]
+        private void CmdHostDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos, ulong originator)
+        {
+            ProcessingIncoming = true;
+            try { ApplyDrag(toolName, cell, distFromOrigin, filterTargets, priority_class, priority_value, mode, downPos, upPos); }
+            finally { ProcessingIncoming = false; }
+            CallClientRpc(nameof(RpcDrag), toolName, cell, distFromOrigin, filterTargets, priority_class, priority_value, mode, downPos, upPos, originator);
         }
 
         [ClientRpc]
-        private void RpcDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos)
+        private void RpcDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos, ulong originator)
+        {
+            if (originator != 0 && originator == (LocalUserIdQuery?.Invoke() ?? 0)) return;
+            ProcessingIncoming = true;
+            try { ApplyDrag(toolName, cell, distFromOrigin, filterTargets, priority_class, priority_value, mode, downPos, upPos); }
+            finally { ProcessingIncoming = false; }
+        }
+
+        private static void ApplyDrag(string toolName, int cell, int distFromOrigin, List<string> filterTargets, int priority_class, int priority_value, int mode, Vector3 downPos, Vector3 upPos)
         {
             DragTool tool = ResolveTool(toolName);
             if (tool == null) return;

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      DragToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Adds the shared DragToolSyncer (Command to ClientRpc) which replays filtered drag tools with the sender filter selection and priority cached and restored around OnDragTool and OnDragComplete. No behavior change on its own. Consumed by the cancel, clear, deconstruct, mop, harvest, disinfect, prioritize, empty-pipe and disconnect follow-ups.

Build: 0 errors.

Note: GamePatch.cs registers each syncer with one line, expect a trivial keep-both rebase once the first syncer PR lands.