### PR TITLE
OxySync: migrate cancel tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/Cancel/CancelToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Cancel/CancelToolPatch.cs
@@ -1,25 +1,19 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Cancel;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Cancel
 {
-	[HarmonyPatch(typeof(CancelTool), nameof(CancelTool.OnDragTool))]
-	public static class CancelToolPatch
-	{
-		public static void Postfix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			//prevent recursion
-			if (CancelPacket.ProcessingIncoming)
-				return;
-			PacketSender.SendToAllOtherPeers(new CancelPacket() { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
+    [HarmonyPatch(typeof(CancelTool), nameof(CancelTool.OnDragTool))]
+    public static class CancelToolPatch
+    {
+        public static void Postfix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            DragToolSyncer.RequestDrag("Cancel", cell, distFromOrigin);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
@@ -1,45 +1,21 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Cancel
 {
-	// Choke-point for "cancel an unfinished building":
-	//   - CancelTool drag → Trigger(GameHashes.Cancel) → Constructable.OnCancel(object)
-	//   - Right-click "Cancel build" → same trigger
-	//   - Any scripted / single-click cancel → same method
-	// Method is private, so match by name string (Harmony accepts it).
-	[HarmonyPatch(typeof(Constructable), "OnCancel")]
-	public static class ConstructableCancelPatch
-	{
-		public static void Postfix(Constructable __instance)
-		{
-			using var _ = Profiler.Scope();
-
-			try
-			{
-				if (!MultiplayerSession.InActiveSession) return;
-				if (BuildingActionPacket.ProcessingIncoming) return;
-				// Drag path already syncs via CancelPacket; skip here to avoid double-send.
-				if (DragToolPacket.ProcessingIncoming) return;
-
-				var identity = __instance.GetComponent<NetworkIdentity>();
-				if (identity == null || identity.NetId == 0) return;
-
-				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
-				{
-					NetId = identity.NetId,
-					Action = BuildingActionKind.CancelConstruct,
-				});
-				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=CancelConstruct src=ConstructCancelPatch");
-			}
-			catch (System.Exception ex)
-			{
-				DebugConsole.LogError($"[ConstructableCancelPatch] Exception: {ex}");
-			}
-		}
-	}
+    [HarmonyPatch(typeof(Constructable), "OnCancel")]
+    public static class ConstructableCancelPatch
+    {
+        public static void Postfix(Constructable __instance)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession) return;
+            var identity = __instance.GetComponent<NetworkIdentity>();
+            if (identity == null || identity.NetId == 0) return;
+            BuildingActionSyncer.RequestAction(identity.NetId, 3);
+        }
+    }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes CancelTool drag and Constructable.OnCancel through DragToolSyncer and BuildingActionSyncer instead of CancelPacket and BuildingActionPacket.

Depends on split/oxysync-drag-core and split/oxysync-building-action, merge after those.