### PR TITLE
OxySync: migrate clear tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/Clear/ClearToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Clear/ClearToolPatch.cs
@@ -1,28 +1,21 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Clear;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Clear
 {
-	[HarmonyPatch(typeof(ClearTool), "OnDragTool")]
-	public static class ClearTool_OnDragTool_Patch
-	{
-		public static void Prefix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			if (!Grid.IsValidCell(cell))
-				return;
-
-			if (ClearPacket.ProcessingIncoming)
-				return;
-
-			PacketSender.SendToAllOtherPeers(new ClearPacket { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
-
+    [HarmonyPatch(typeof(ClearTool), "OnDragTool")]
+    public static class ClearTool_OnDragTool_Patch
+    {
+        public static void Prefix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            if (!Grid.IsValidCell(cell))
+                return;
+            DragToolSyncer.RequestDrag("Clear", cell, distFromOrigin);
+        }
+    }
 }

--- a/ONI_Together/Patches/World/ClearablePatches.cs
+++ b/ONI_Together/Patches/World/ClearablePatches.cs
@@ -1,73 +1,42 @@
 using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Clear;
+using ONI_Together.Networking.Components;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
-using UnityEngine;
 
 namespace ONI_Together.Patches.World
 {
-	public static class ClearablePatches
-	{
-		[HarmonyPatch(typeof(Clearable), nameof(Clearable.MarkForClear))]
-		public static class ClearableMarkForClearPatch
-		{
-			public static void Postfix(Clearable __instance, bool restoringFromSave, bool allowWhenStored)
-			{
-				using var _ = Profiler.Scope();
+    public static class ClearablePatches
+    {
+        [HarmonyPatch(typeof(Clearable), nameof(Clearable.MarkForClear))]
+        public static class ClearableMarkForClearPatch
+        {
+            public static void Postfix(Clearable __instance, bool restoringFromSave, bool allowWhenStored)
+            {
+                using var _ = Profiler.Scope();
+                if (restoringFromSave) return;
+                if (!MultiplayerSession.InActiveSession) return;
+                if (__instance == null || __instance.gameObject == null) return;
+                var identity = __instance.gameObject.GetNetIdentity();
+                int netId = identity != null ? identity.NetId : 0;
+                int cell = Grid.PosToCell(__instance.gameObject);
+                BuildingActionSyncer.RequestClearable(netId, cell, true);
+            }
+        }
 
-				if (restoringFromSave) return;
-				if (ClearableActionPacket.ProcessingIncoming) return;
-				if (ClearPacket.ProcessingIncoming) return;
-				if (!MultiplayerSession.InActiveSession) return;
-				if (__instance == null || __instance.gameObject == null) return;
-
-				var identity = __instance.gameObject.GetNetIdentity();
-				int netId = identity != null ? identity.NetId : 0;
-				int cell = Grid.PosToCell(__instance.gameObject);
-
-				var packet = new ClearableActionPacket
-				{
-					NetId = netId,
-					Cell = cell,
-					IsMarked = true
-				};
-
-				if (MultiplayerSession.IsHost)
-					PacketSender.SendToAllClients(packet);
-				else
-					PacketSender.SendToHost(packet);
-			}
-		}
-
-		[HarmonyPatch(typeof(Clearable), nameof(Clearable.CancelClearing))]
-		public static class ClearableCancelClearingPatch
-		{
-			public static void Postfix(Clearable __instance)
-			{
-				using var _ = Profiler.Scope();
-
-				if (ClearableActionPacket.ProcessingIncoming) return;
-				if (ClearPacket.ProcessingIncoming) return;
-				if (!MultiplayerSession.InActiveSession) return;
-				if (__instance == null || __instance.gameObject == null) return;
-
-				var identity = __instance.gameObject.GetNetIdentity();
-				int netId = identity != null ? identity.NetId : 0;
-				int cell = Grid.PosToCell(__instance.gameObject);
-
-				var packet = new ClearableActionPacket
-				{
-					NetId = netId,
-					Cell = cell,
-					IsMarked = false
-				};
-
-				if (MultiplayerSession.IsHost)
-					PacketSender.SendToAllClients(packet);
-				else
-					PacketSender.SendToHost(packet);
-			}
-		}
-	}
+        [HarmonyPatch(typeof(Clearable), nameof(Clearable.CancelClearing))]
+        public static class ClearableCancelClearingPatch
+        {
+            public static void Postfix(Clearable __instance)
+            {
+                using var _ = Profiler.Scope();
+                if (!MultiplayerSession.InActiveSession) return;
+                if (__instance == null || __instance.gameObject == null) return;
+                var identity = __instance.gameObject.GetNetIdentity();
+                int netId = identity != null ? identity.NetId : 0;
+                int cell = Grid.PosToCell(__instance.gameObject);
+                BuildingActionSyncer.RequestClearable(netId, cell, false);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes ClearTool drag and Clearable mark/cancel through DragToolSyncer and BuildingActionSyncer instead of the clear packets.

Depends on split/oxysync-drag-core and split/oxysync-building-action, merge after those.