### PR TITLE
OxySync: migrate deconstruct tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructToolPatch.cs
@@ -1,25 +1,19 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Cancel;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	[HarmonyPatch(typeof(DeconstructTool), nameof(DeconstructTool.OnDragTool))]
-	public static class DeconstructToolPatch
-	{
-		public static void Postfix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			//prevent recursion
-			if (DeconstructPacket.ProcessingIncoming)
-				return;
-			PacketSender.SendToAllOtherPeers(new DeconstructPacket() { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
+    [HarmonyPatch(typeof(DeconstructTool), nameof(DeconstructTool.OnDragTool))]
+    public static class DeconstructToolPatch
+    {
+        public static void Postfix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            DragToolSyncer.RequestDrag("Deconstruct", cell, distFromOrigin);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
@@ -1,45 +1,21 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	// Choke-point for "undo a pending deconstruction order":
-	//   - CancelTool drag → Trigger(GameHashes.Cancel) → OnCancel(object) → CancelDeconstruction
-	//   - User-menu "Cancel deconstruct" button → OnDeconstruct(object) w/ chore!=null → CancelDeconstruction
-	//   - Single-click / scripted cancel → same method
-	// The existing CancelToolPatch only covered drag.
-	[HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.CancelDeconstruction))]
-	public static class DeconstructableCancelPatch
-	{
-		public static void Postfix(Deconstructable __instance)
-		{
-			using var _ = Profiler.Scope();
-
-			try
-			{
-				if (!MultiplayerSession.InActiveSession) return;
-				if (BuildingActionPacket.ProcessingIncoming) return;
-				// Drag path already syncs via CancelPacket; skip here to avoid double-send.
-				if (DragToolPacket.ProcessingIncoming) return;
-
-				var identity = __instance.GetComponent<NetworkIdentity>();
-				if (identity == null || identity.NetId == 0) return;
-
-				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
-				{
-					NetId = identity.NetId,
-					Action = BuildingActionKind.CancelDeconstruct,
-				});
-				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=CancelDeconstruct src=CancelPatch");
-			}
-			catch (System.Exception ex)
-			{
-				DebugConsole.LogError($"[DeconstructableCancelPatch] Exception: {ex}");
-			}
-		}
-	}
+    [HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.CancelDeconstruction))]
+    public static class DeconstructableCancelPatch
+    {
+        public static void Postfix(Deconstructable __instance)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession) return;
+            var identity = __instance.GetComponent<NetworkIdentity>();
+            if (identity == null || identity.NetId == 0) return;
+            BuildingActionSyncer.RequestAction(identity.NetId, 2);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructablePatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructablePatch.cs
@@ -1,41 +1,28 @@
 ﻿using System.Linq;
 using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	[HarmonyPatch(typeof(Deconstructable), "OnCompleteWork")]
-	public static class DeconstructablePatch
-	{
-		public static void Prefix(Deconstructable __instance)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.IsHost || !MultiplayerSession.InActiveSession)
-				return;
-
-			int cell = __instance.NaturalBuildingCell();
-			int objectLayer = (int) ObjectLayer.Building;
-			if (__instance.TryGetComponent<Building>(out var building))
-			{
-				objectLayer = (int) building.Def.ObjectLayer;
-			}
+    [HarmonyPatch(typeof(Deconstructable), "OnCompleteWork")]
+    public static class DeconstructablePatch
+    {
+        public static void Prefix(Deconstructable __instance)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.IsHost || !MultiplayerSession.InActiveSession)
+                return;
+            int cell = __instance.NaturalBuildingCell();
+            int objectLayer = (int)ObjectLayer.Building;
+            if (__instance.TryGetComponent<Building>(out var building))
+                objectLayer = (int)building.Def.ObjectLayer;
             else if (__instance.TryGetComponent<OccupyArea>(out var area) && area.objectLayers.Any())
-            {
                 objectLayer = (int)area.objectLayers.FirstOrDefault();
-            }
             else if (__instance.TryGetComponent<MoverLayerOccupier>(out var occupier) && occupier.objectLayers.Any())
-            {
                 objectLayer = (int)occupier.objectLayers.FirstOrDefault();
-            }
-
-            var packet = new DeconstructCompletePacket { Cell = cell, ObjectLayer = objectLayer };
-            PacketSender.SendToAllClients(packet);
-
-			DebugConsole.Log($"[DeconstructComplete] Host sent DeconstructCompletePacket for cell {cell}");
-		}
-	}
+            BuildingActionSyncer.RequestDeconstructComplete(cell, objectLayer);
+        }
+    }
 }

--- a/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
@@ -1,49 +1,22 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Deconstruct
 {
-	// All "mark for deconstruction" paths funnel through QueueDeconstruction:
-	//   - DeconstructTool drag → gameObject.Trigger(GameHashes.Deconstruct) → OnDeconstruct → QueueDeconstruction
-	//   - Right-click / user-menu "Deconstruct" button → OnDeconstruct(object) → QueueDeconstruction
-	//   - Single-click-context and any scripted trigger → same hash → same path
-	// Hooking this one method catches drag + single-click + menu in one place,
-	// which the existing DeconstructToolPatch (OnDragTool only) missed.
-	[HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.QueueDeconstruction), new System.Type[] { typeof(bool) })]
-	public static class DeconstructableQueuePatch
-	{
-		public static void Postfix(Deconstructable __instance, bool userTriggered)
-		{
-			using var _ = Profiler.Scope();
-
-			try
-			{
-				if (!MultiplayerSession.InActiveSession) return;
-				if (BuildingActionPacket.ProcessingIncoming) return;
-				// Drag path already has its own sync via DeconstructPacket; don't double-send.
-				// This patch exists specifically for non-drag entry points.
-				if (DragToolPacket.ProcessingIncoming) return;
-				if (!userTriggered) return; // only sync user intent; load/rehydrate calls userTriggered=false
-
-				var identity = __instance.GetComponent<NetworkIdentity>();
-				if (identity == null || identity.NetId == 0) return;
-
-				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
-				{
-					NetId = identity.NetId,
-					Action = BuildingActionKind.QueueDeconstruct,
-				});
-				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=QueueDeconstruct src=QueuePatch");
-			}
-			catch (System.Exception ex)
-			{
-				DebugConsole.LogError($"[DeconstructableQueuePatch] Exception: {ex}");
-			}
-		}
-	}
+    [HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.QueueDeconstruction), new System.Type[] { typeof(bool) })]
+    public static class DeconstructableQueuePatch
+    {
+        public static void Postfix(Deconstructable __instance, bool userTriggered)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession) return;
+            if (!userTriggered) return;
+            var identity = __instance.GetComponent<NetworkIdentity>();
+            if (identity == null || identity.NetId == 0) return;
+            BuildingActionSyncer.RequestAction(identity.NetId, 1);
+        }
+    }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes DeconstructTool drag plus QueueDeconstruction, CancelDeconstruction and OnCompleteWork through DragToolSyncer and BuildingActionSyncer instead of the deconstruct packets.

Depends on split/oxysync-drag-core and split/oxysync-building-action, merge after those.