### PR TITLE
OxySync: migrate mop tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/Mop/MopToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Mop/MopToolPatch.cs
@@ -1,28 +1,21 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Mop;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Mop
 {
-	[HarmonyPatch(typeof(MopTool), "OnDragTool")]
-	public static class MoptoolPatch
-	{
-		public static void Prefix(int cell, int distFromOrigin)
-		{
-			using var _ = Profiler.Scope();
-
-			if (!MultiplayerSession.InActiveSession)
-				return;
-
-			if (!Grid.IsValidCell(cell))
-				return;
-
-			if (MopToolPacket.ProcessingIncoming)
-				return;
-
-			PacketSender.SendToAllOtherPeers(new MopToolPacket { cell = cell, distFromOrigin = distFromOrigin });
-		}
-	}
-
+    [HarmonyPatch(typeof(MopTool), "OnDragTool")]
+    public static class MoptoolPatch
+    {
+        public static void Prefix(int cell, int distFromOrigin)
+        {
+            using var _ = Profiler.Scope();
+            if (!MultiplayerSession.InActiveSession)
+                return;
+            if (!Grid.IsValidCell(cell))
+                return;
+            DragToolSyncer.RequestDrag("Mop", cell, distFromOrigin);
+        }
+    }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes MopTool drag through DragToolSyncer instead of the mop packet.

Depends on split/oxysync-drag-core, merge after it.