### PR TITLE
OxySync: migrate harvest tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/Harvest/HarvestToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Harvest/HarvestToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Harvest;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches.Harvest;
@@ -11,13 +11,8 @@ public class HarvestToolPatch
     private static void Postfix(int cell, int distFromOrigin)
     {
         using var _ = Profiler.Scope();
-
         if (!MultiplayerSession.InActiveSession)
             return;
-
-        if (HarvestToolPacket.ProcessingIncoming)
-            return;
-
-        PacketSender.SendToAllOtherPeers(new HarvestToolPacket { cell = cell, distFromOrigin = distFromOrigin });
+        DragToolSyncer.RequestDrag("Harvest", cell, distFromOrigin);
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes HarvestTool drag through DragToolSyncer instead of the harvest packet.

Depends on split/oxysync-drag-core, merge after it.