### PR TITLE
OxySync: migrate disinfect tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/Disinfect/DisinfectToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Disinfect/DisinfectToolPatch.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools.Disinfect;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 [HarmonyPatch(typeof(DisinfectTool), "OnDragTool")]
@@ -10,13 +10,8 @@ public class DisinfectToolPatch
     public static void Prefix(int cell, int distFromOrigin)
     {
         using var _ = Profiler.Scope();
-
         if (!MultiplayerSession.InActiveSession)
             return;
-
-        if (DisinfectPacket.ProcessingIncoming)
-            return;
-
-        PacketSender.SendToAllOtherPeers(new DisinfectPacket { cell = cell, distFromOrigin = distFromOrigin });
+        DragToolSyncer.RequestDrag("Disinfect", cell, distFromOrigin);
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes DisinfectTool drag through DragToolSyncer instead of the disinfect packet.

Depends on split/oxysync-drag-core, merge after it.