### PR TITLE
OxySync: migrate prioritize tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/Prioritize/PrioritizeToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/Prioritize/PrioritizeToolPatch.cs
@@ -1,26 +1,16 @@
 ﻿using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Prioritize;
-using System.Collections.Generic;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
-using UnityEngine;
 
 [HarmonyPatch(typeof(PrioritizeTool), nameof(PrioritizeTool.OnDragTool))]
 public static class PrioritizeToolPatch
 {
-	public static void Postfix(int cell, int distFromOrigin)
-	{
-		using var _ = Profiler.Scope();
-
-		if (!MultiplayerSession.InActiveSession)
-			return;
-
-		//prevent recursion
-		if (PrioritizePacket.ProcessingIncoming)
-			return;
-
-		PacketSender.SendToAllOtherPeers(new PrioritizePacket { cell = cell, distFromOrigin = distFromOrigin });
-	}
+    public static void Postfix(int cell, int distFromOrigin)
+    {
+        using var _ = Profiler.Scope();
+        if (!MultiplayerSession.InActiveSession)
+            return;
+        DragToolSyncer.RequestDrag("Prioritize", cell, distFromOrigin);
+    }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes PrioritizeTool drag through DragToolSyncer instead of the prioritize packet.

Depends on split/oxysync-drag-core, merge after it.