### PR TITLE
OxySync: migrate empty-pipe tool to OxySync

### DIFF
--- a/ONI_Together/Patches/ToolPatches/EmptyPipeToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/EmptyPipeToolPatch.cs
@@ -1,33 +1,22 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
-using ONI_Together.Networking.Packets.Tools;
-using ONI_Together.Networking.Packets.Tools.Deconstruct;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 
 namespace ONI_Together.Patches.ToolPatches
 {
-	internal class EmptyPipeToolPatch
-	{
-		[HarmonyPatch(typeof(EmptyPipeTool), nameof(EmptyPipeTool.OnDragTool))]
-		public class EmptyPipeTool_OnDragTool_Patch
-		{
-			public static void Postfix(int cell, int distFromOrigin)
-			{
-				using var _ = Profiler.Scope();
-
-				if (!MultiplayerSession.InActiveSession)
-					return;
-
-				//prevent recursion
-				if (EmptyPipePacket.ProcessingIncoming)
-					return;
-				PacketSender.SendToAllOtherPeers(new EmptyPipePacket() { cell = cell, distFromOrigin = distFromOrigin });
-			}
-		}
-	}
+    internal class EmptyPipeToolPatch
+    {
+        [HarmonyPatch(typeof(EmptyPipeTool), nameof(EmptyPipeTool.OnDragTool))]
+        public class EmptyPipeTool_OnDragTool_Patch
+        {
+            public static void Postfix(int cell, int distFromOrigin)
+            {
+                using var _ = Profiler.Scope();
+                if (!MultiplayerSession.InActiveSession)
+                    return;
+                DragToolSyncer.RequestDrag("EmptyPipe", cell, distFromOrigin);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes EmptyPipeTool drag through DragToolSyncer instead of the empty-pipe packet.

Depends on split/oxysync-drag-core, merge after it.