### PR TITLE
OxySync: migrate copy-settings tool to OxySync

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/CopySettingsToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/CopySettingsToolSyncer.cs
@@ -12,6 +12,8 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
     {
         public static CopySettingsToolSyncer Instance { get; private set; }
 
+        public static bool ProcessingIncoming;
+
         public override void OnSpawn()
         {
             base.OnSpawn();
@@ -41,19 +43,43 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestCopy(int netId, int cell)
         {
             var s = Instance;
-            if (s == null) return;
-            try { s.CallCommand(nameof(CmdCopy), netId, cell); }
+            if (s == null || ProcessingIncoming) return;
+            try
+            {
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdCopy), netId, cell, originator);
+                else
+                    s.CallCommand(nameof(CmdHostCopy), netId, cell, originator);
+            }
             catch (System.Exception ex) { DebugConsole.LogWarning($"[CopySettingsToolSyncer] {ex}"); }
         }
 
         [Command]
-        private void CmdCopy(int netId, int cell)
+        private void CmdCopy(int netId, int cell, ulong originator)
         {
-            CallClientRpc(nameof(RpcCopy), netId, cell);
+            CallClientRpc(nameof(RpcCopy), netId, cell, originator);
+        }
+
+        [Command]
+        private void CmdHostCopy(int netId, int cell, ulong originator)
+        {
+            ProcessingIncoming = true;
+            try { ApplyCopy(netId, cell); }
+            finally { ProcessingIncoming = false; }
+            CallClientRpc(nameof(RpcCopy), netId, cell, originator);
         }
 
         [ClientRpc]
-        private void RpcCopy(int netId, int cell)
+        private void RpcCopy(int netId, int cell, ulong originator)
+        {
+            if (originator != 0 && originator == (LocalUserIdQuery?.Invoke() ?? 0)) return;
+            ProcessingIncoming = true;
+            try { ApplyCopy(netId, cell); }
+            finally { ProcessingIncoming = false; }
+        }
+
+        private static void ApplyCopy(int netId, int cell)
         {
             if (!NetworkIdentityRegistry.TryGet(netId, out var identity) || identity.gameObject == null || !identity.TryGetComponent<CopyBuildingSettings>(out var sourceSettings) || !identity.TryGetComponent<KPrefabID>(out var sourceId))
                 return;

--- a/ONI_Together/Networking/OxySync/Components/Tools/CopySettingsToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/CopySettingsToolSyncer.cs
@@ -1,0 +1,66 @@
+using ONI_Together.DebugTools;
+using ONI_Together.Networking.Components;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class CopySettingsToolSyncer : NetworkBehaviour
+    {
+        public static CopySettingsToolSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("CopySettingsToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<CopySettingsToolSyncer>();
+            }
+            Instance.NetId = nameof(CopySettingsToolSyncer).GetHashCode();
+        }
+
+        public static void RequestCopy(int netId, int cell)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try { s.CallCommand(nameof(CmdCopy), netId, cell); }
+            catch (System.Exception ex) { DebugConsole.LogWarning($"[CopySettingsToolSyncer] {ex}"); }
+        }
+
+        [Command]
+        private void CmdCopy(int netId, int cell)
+        {
+            CallClientRpc(nameof(RpcCopy), netId, cell);
+        }
+
+        [ClientRpc]
+        private void RpcCopy(int netId, int cell)
+        {
+            if (!NetworkIdentityRegistry.TryGet(netId, out var identity) || identity.gameObject == null || !identity.TryGetComponent<CopyBuildingSettings>(out var sourceSettings) || !identity.TryGetComponent<KPrefabID>(out var sourceId))
+                return;
+            var targetId = CopyBuildingSettings.ResolveTarget(CopyBuildingSettings.ResolveLayer(identity.gameObject), cell);
+            if (targetId == null) return;
+            CopyBuildingSettings.ApplyCopy(targetId, identity.gameObject, sourceId, sourceSettings);
+            Game.Instance.userMenu.Refresh(targetId.gameObject);
+        }
+    }
+}

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      CopySettingsToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/ToolPatches/CopySettings/CopySettingsToolPatch.cs
+++ b/ONI_Together/Patches/ToolPatches/CopySettings/CopySettingsToolPatch.cs
@@ -1,7 +1,7 @@
 ﻿using HarmonyLib;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
-using ONI_Together.Networking.Packets.Tools.CopySettingsTool;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -25,6 +25,6 @@ public class CopySettingsToolPatch
         if (identity == null)
             return;
 
-        PacketSender.SendToAllOtherPeers(new CopySettingsToolPacket(identity.NetId, cell));
+        CopySettingsToolSyncer.RequestCopy(identity.NetId, cell);
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes CopySettingsTool replication through the new CopySettingsToolSyncer (source NetId plus target cell) instead of the copy-settings packet.

Build: 0 errors.

Note: GamePatch.cs registers each syncer with one line, expect a trivial keep-both rebase once the first syncer PR lands.