### PR TITLE
OxySync: migrate sandbox tools to OxySync

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/Tools/SandboxToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/SandboxToolSyncer.cs
@@ -11,6 +11,8 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
     {
         public static SandboxToolSyncer Instance { get; private set; }
 
+        public static bool ProcessingIncoming;
+
         public override void OnSpawn()
         {
             base.OnSpawn();
@@ -40,19 +42,43 @@ namespace ONI_Together.Networking.OxySync.Components.Tools
         public static void RequestSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
         {
             var s = Instance;
-            if (s == null) return;
-            try { s.CallCommand(nameof(CmdSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId); }
+            if (s == null || ProcessingIncoming) return;
+            try
+            {
+                var originator = LocalUserIdQuery?.Invoke() ?? 0;
+                if (MultiplayerSession.IsHost)
+                    s.CallCommand(nameof(CmdSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId, originator);
+                else
+                    s.CallCommand(nameof(CmdHostSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId, originator);
+            }
             catch (System.Exception ex) { DebugConsole.LogWarning($"[SandboxToolSyncer] {ex}"); }
         }
 
         [Command]
-        private void CmdSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        private void CmdSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId, ulong originator)
         {
-            CallClientRpc(nameof(RpcSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId);
+            CallClientRpc(nameof(RpcSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId, originator);
+        }
+
+        [Command]
+        private void CmdHostSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId, ulong originator)
+        {
+            ProcessingIncoming = true;
+            try { ApplySandbox(action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId); }
+            finally { ProcessingIncoming = false; }
+            CallClientRpc(nameof(RpcSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId, originator);
         }
 
         [ClientRpc]
-        private void RpcSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        private void RpcSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId, ulong originator)
+        {
+            if (originator != 0 && originator == (LocalUserIdQuery?.Invoke() ?? 0)) return;
+            ProcessingIncoming = true;
+            try { ApplySandbox(action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId); }
+            finally { ProcessingIncoming = false; }
+        }
+
+        private static void ApplySandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
         {
             if (!Grid.IsValidCell(cell) || SandboxToolParameterMenu.instance?.settings == null) return;
             var settings = SandboxToolParameterMenu.instance.settings;

--- a/ONI_Together/Networking/OxySync/Components/Tools/SandboxToolSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/Tools/SandboxToolSyncer.cs
@@ -1,0 +1,182 @@
+using ONI_Together.DebugTools;
+using Shared.OxySync;
+using Shared.OxySync.Attributes;
+using UnityEngine;
+
+namespace ONI_Together.Networking.OxySync.Components.Tools
+{
+    [SkipSaveFileSerialization]
+    [FixedInterestGroup]
+    public class SandboxToolSyncer : NetworkBehaviour
+    {
+        public static SandboxToolSyncer Instance { get; private set; }
+
+        public override void OnSpawn()
+        {
+            base.OnSpawn();
+            Instance = this;
+            InterestGroup = -1;
+        }
+
+        public override void OnCleanUp()
+        {
+            if (Instance == this)
+                Instance = null;
+            base.OnCleanUp();
+        }
+
+        public static void RegisterNetId(GameObject parent = null)
+        {
+            var root = parent == null ? Game.Instance.gameObject : parent;
+            if (Instance == null)
+            {
+                var go = new GameObject("SandboxToolSyncer");
+                go.transform.SetParent(root.transform);
+                Instance = go.AddComponent<SandboxToolSyncer>();
+            }
+            Instance.NetId = nameof(SandboxToolSyncer).GetHashCode();
+        }
+
+        public static void RequestSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        {
+            var s = Instance;
+            if (s == null) return;
+            try { s.CallCommand(nameof(CmdSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId); }
+            catch (System.Exception ex) { DebugConsole.LogWarning($"[SandboxToolSyncer] {ex}"); }
+        }
+
+        [Command]
+        private void CmdSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        {
+            CallClientRpc(nameof(RpcSandbox), action, cell, dist, pos, elementIndex, diseaseCount, moraleAdj, mass, temp, tempAdd, stressAdd, diseaseId, entityId, storyId);
+        }
+
+        [ClientRpc]
+        private void RpcSandbox(byte action, int cell, int dist, Vector3 pos, int elementIndex, int diseaseCount, int moraleAdj, float mass, float temp, float tempAdd, float stressAdd, string diseaseId, string entityId, string storyId)
+        {
+            if (!Grid.IsValidCell(cell) || SandboxToolParameterMenu.instance?.settings == null) return;
+            var settings = SandboxToolParameterMenu.instance.settings;
+            int prevElem = 0, prevDisease = 0, prevMorale = 0;
+            float prevMass = 0, prevTemp = 0, prevTempAdd = 0, prevStress = 0;
+            string prevDiseaseId = "", prevEntityId = "", prevStoryId = "";
+            bool isBrush = action == 0 || action == 1 || action == 2;
+            bool isHeat = action == 4;
+            bool isStress = action == 5;
+            bool isEntity = action == 6;
+            bool isStory = action == 11;
+            try
+            {
+                if (isBrush)
+                {
+                    prevElem = settings.GetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT);
+                    prevDisease = settings.GetIntSetting(SandboxSettings.KEY_DISEASE_COUNT);
+                    prevMass = settings.GetFloatSetting(SandboxSettings.KEY_MASS);
+                    prevTemp = settings.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE);
+                    prevDiseaseId = settings.GetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE);
+                    settings.SetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT, elementIndex);
+                    settings.SetIntSetting(SandboxSettings.KEY_DISEASE_COUNT, diseaseCount);
+                    settings.SetFloatSetting(SandboxSettings.KEY_MASS, mass);
+                    settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE, temp);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE, diseaseId);
+                }
+                if (isHeat)
+                {
+                    prevTempAdd = settings.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE);
+                    settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE, tempAdd);
+                }
+                if (isStress)
+                {
+                    prevStress = settings.GetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE);
+                    prevMorale = settings.GetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT);
+                    settings.SetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE, stressAdd);
+                    settings.SetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT, moraleAdj);
+                }
+                if (isEntity)
+                {
+                    prevEntityId = settings.GetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY, entityId);
+                }
+                if (isStory)
+                {
+                    prevStoryId = settings.GetStringSetting(SandboxSettings.KEY_SELECTED_STORY);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_STORY, storyId);
+                }
+                switch (action)
+                {
+                    case 0:
+                        FindTool(SandboxBrushTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 1:
+                        FindTool(SandboxSprinkleTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 2:
+                        FindTool(SandboxFloodTool.instance)?.PaintCell(cell);
+                        break;
+                    case 3:
+                        settings.SetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT, elementIndex);
+                        settings.SetIntSetting(SandboxSettings.KEY_DISEASE_COUNT, diseaseCount);
+                        settings.SetFloatSetting(SandboxSettings.KEY_MASS, mass);
+                        settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE, temp);
+                        settings.SetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE, diseaseId);
+                        SandboxToolParameterMenu.instance.RefreshDisplay();
+                        break;
+                    case 4:
+                        FindTool(SandboxHeatTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 5:
+                        FindTool(SandboxStressTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 6:
+                        var spawner = Object.FindFirstObjectByType<SandboxSpawnerTool>(FindObjectsInactive.Include);
+                        if (spawner != null)
+                        {
+                            int prev = spawner.currentCell;
+                            spawner.currentCell = cell;
+                            try { spawner.Place(cell); } finally { spawner.currentCell = prev; }
+                        }
+                        break;
+                    case 7:
+                        FindTool(SandboxDestroyerTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 8:
+                        FindTool(SandboxFOWTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 9:
+                        FindTool(SandboxClearFloorTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 10:
+                        FindTool(SandboxCritterTool.instance)?.OnPaintCell(cell, dist);
+                        break;
+                    case 11:
+                        var storyTool = Object.FindFirstObjectByType<SandboxStoryTraitTool>(FindObjectsInactive.Include);
+                        storyTool?.OnLeftClickDown(pos);
+                        break;
+                }
+            }
+            finally
+            {
+                if (isBrush)
+                {
+                    settings.SetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT, prevElem);
+                    settings.SetIntSetting(SandboxSettings.KEY_DISEASE_COUNT, prevDisease);
+                    settings.SetFloatSetting(SandboxSettings.KEY_MASS, prevMass);
+                    settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE, prevTemp);
+                    settings.SetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE, prevDiseaseId);
+                }
+                if (isHeat) settings.SetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE, prevTempAdd);
+                if (isStress)
+                {
+                    settings.SetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE, prevStress);
+                    settings.SetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT, prevMorale);
+                }
+                if (isEntity) settings.SetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY, prevEntityId);
+                if (isStory) settings.SetStringSetting(SandboxSettings.KEY_SELECTED_STORY, prevStoryId);
+            }
+        }
+
+        private static T FindTool<T>(T instance) where T : Object
+        {
+            return instance != null ? instance : Object.FindFirstObjectByType<T>(FindObjectsInactive.Include);
+        }
+    }
+}

--- a/ONI_Together/Patches/GamePatches/GamePatch.cs
+++ b/ONI_Together/Patches/GamePatches/GamePatch.cs
@@ -70,6 +70,7 @@ namespace ONI_Together.Patches.GamePatches
       Game.Instance.gameObject.AddComponent<LogicPortManager>();
 
       MoveToLocationToolSyncer.RegisterNetId(Game.Instance.gameObject);
+      SandboxToolSyncer.RegisterNetId(Game.Instance.gameObject);
     }
   }
 }

--- a/ONI_Together/Patches/ToolPatches/Sandbox/SandboxToolPatches.cs
+++ b/ONI_Together/Patches/ToolPatches/Sandbox/SandboxToolPatches.cs
@@ -1,10 +1,8 @@
 using HarmonyLib;
-using ONI_Together.DebugTools;
 using ONI_Together.Networking;
 using ONI_Together.Networking.Components;
 using ONI_Together.Networking.OxySync.Components;
-using ONI_Together.Networking.Packets.Tools.Sandbox;
-using ONI_Together.Networking.Packets.World;
+using ONI_Together.Networking.OxySync.Components.Tools;
 using ONI_Together.Scripts.Creatures;
 using Shared.Profiling;
 using UnityEngine;
@@ -13,19 +11,14 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
 {
     internal static class SandboxToolSync
     {
-        public static void Send(
-            SandboxToolAction action,
-            int cell,
-            int distanceFromOrigin = 0,
-            Vector3 position = default)
+        public static void Send(byte action, int cell, int distanceFromOrigin = 0, Vector3 position = default)
         {
             using var _ = Profiler.Scope();
-
-            if (!MultiplayerSession.InActiveSession || SandboxToolPacket.ProcessingIncoming || !Grid.IsValidCell(cell))
+            if (!MultiplayerSession.InActiveSession || !Grid.IsValidCell(cell))
                 return;
-
-            PacketSender.SendToAllOtherPeers(
-                SandboxToolPacket.Capture(action, cell, distanceFromOrigin, position));
+            var s = SandboxToolParameterMenu.instance?.settings;
+            if (s == null) return;
+            SandboxToolSyncer.RequestSandbox(action, cell, distanceFromOrigin, position, s.GetIntSetting(SandboxSettings.KEY_SELECTED_ELEMENT), s.GetIntSetting(SandboxSettings.KEY_DISEASE_COUNT), s.GetIntSetting(SandboxSettings.KEY_MORALE_ADJUSTMENT), s.GetFloatSetting(SandboxSettings.KEY_MASS), s.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE), s.GetFloatSetting(SandboxSettings.KEY_TEMPERATURE_ADDITIVE), s.GetFloatSetting(SandboxSettings.KEY_STRESS_ADDITIVE), s.GetStringSetting(SandboxSettings.KEY_SELECTED_DISEASE) ?? string.Empty, s.GetStringSetting(SandboxSettings.KEY_SELECTED_ENTITY) ?? string.Empty, s.GetStringSetting(SandboxSettings.KEY_SELECTED_STORY) ?? string.Empty);
         }
     }
 
@@ -33,40 +26,40 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
     internal static class SandboxBrushToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Brush, cell, distFromOrigin);
+            SandboxToolSync.Send(0, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxSprinkleTool), nameof(SandboxSprinkleTool.OnPaintCell))]
     internal static class SandboxSprinkleToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Sprinkle, cell, distFromOrigin);
+            SandboxToolSync.Send(1, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxFloodTool), nameof(SandboxFloodTool.PaintCell))]
     internal static class SandboxFloodToolPatch
     {
-        private static void Postfix(int cell) => SandboxToolSync.Send(SandboxToolAction.Flood, cell);
+        private static void Postfix(int cell) => SandboxToolSync.Send(2, cell);
     }
 
     [HarmonyPatch(typeof(SandboxSampleTool), nameof(SandboxSampleTool.Sample))]
     internal static class SandboxSampleToolPatch
     {
-        private static void Postfix(int cell) => SandboxToolSync.Send(SandboxToolAction.Sample, cell);
+        private static void Postfix(int cell) => SandboxToolSync.Send(3, cell);
     }
 
     [HarmonyPatch(typeof(SandboxHeatTool), nameof(SandboxHeatTool.OnPaintCell))]
     internal static class SandboxHeatToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Heat, cell, distFromOrigin);
+            SandboxToolSync.Send(4, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxStressTool), nameof(SandboxStressTool.OnPaintCell))]
     internal static class SandboxStressToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Stress, cell, distFromOrigin);
+            SandboxToolSync.Send(5, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxSpawnerTool), nameof(SandboxSpawnerTool.Place))]
@@ -78,16 +71,8 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
         private static bool Prefix(int cell)
         {
             using var _ = Profiler.Scope();
-
             if (!MultiplayerSession.InActiveSession || !Grid.IsValidCell(cell))
                 return true;
-
-            if (MultiplayerSession.IsClient && !SandboxToolPacket.ProcessingIncoming)
-            {
-                SandboxToolSync.Send(SandboxToolAction.Spawn, cell);
-                return false;
-            }
-
             IsPlacingEntity = true;
             LastSpawnedObject = null;
             return true;
@@ -96,7 +81,6 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
         private static void Postfix(int cell)
         {
             using var _ = Profiler.Scope();
-
             try
             {
                 if (MultiplayerSession.IsHost && Grid.IsValidCell(cell))
@@ -119,7 +103,6 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                             }
                         }
                     }
-
                     if (spawned != null)
                     {
                         var building = spawned.GetComponent<Building>();
@@ -138,22 +121,17 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                                 MaterialTags = def.DefaultElements().ConvertAll(t => t.Name)
                             };
                             PacketSender.SendToAllClients(packet);
-                            DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned building '{def.PrefabID}' at cell {cell}");
                             return;
                         }
-
                         var identity = spawned.AddOrGet<NetworkIdentity>();
                         if (identity.NetId == 0)
                             identity.RegisterIdentity();
-
                         var minionIdentity = spawned.GetComponent<MinionIdentity>();
                         if (minionIdentity != null)
                         {
                             spawned.AddOrGet<OxySyncEntityPositionHandler>();
                             spawned.AddOrGet<AnimStateSyncer>();
                             spawned.AddOrGet<Scripts.Duplicants.MinionMultiplayerInitializer>();
-
-                            // Build full ImmigrantOptionEntry from live duplicant to preserve textures/traits
                             try
                             {
                                 var personality = Db.Get().Personalities.TryGet(minionIdentity.personalityResourceId);
@@ -163,11 +141,9 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                                     personality = Db.Get().Personalities.resources.Find(p => p.Id == minionIdentity.personalityResourceId.ToString());
                                 if (personality == null)
                                     personality = Db.Get().Personalities.resources[0];
-
                                 var stats = new MinionStartingStats(personality);
                                 stats.Name = minionIdentity.name;
                                 stats.voiceIdx = minionIdentity.voiceIdx;
-
                                 var entry = ONI_Together.Networking.Packets.Social.ImmigrantOptionEntry.FromGameDeliverable(stats);
                                 var packet2 = new ONI_Together.Networking.Packets.World.TelepadEntitySpawnPacket
                                 {
@@ -176,66 +152,35 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
                                     EntityData = entry
                                 };
                                 PacketSender.SendToAllClients(packet2);
-                                DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned duplicant '{stats.Name}' ({personality.Id}, NetId: {identity.NetId}) via TelepadEntitySpawnPacket (full personality)");
                                 return;
                             }
-                            catch (System.Exception ex)
-                            {
-                                DebugConsole.LogWarning($"[SandboxSpawnerToolPatch] Full duplicant sync failed, falling back to minimal: {ex.Message}");
-                            }
-
-                            // Fallback minimal (should not be used for texture correctness)
+                            catch { }
                             string personalityId = minionIdentity.personalityResourceId.IsValid ? minionIdentity.personalityResourceId.ToString() : "HASSAN";
                             var personalityFallback = Db.Get().Personalities.TryGet(new HashedString(personalityId)) ?? Db.Get().Personalities.TryGet(personalityId) ?? Db.Get().Personalities.resources[0];
                             string dupeName = minionIdentity.name;
                             string prefabData = $"Minion|{personalityFallback.Id}|{dupeName}|{minionIdentity.voiceIdx}";
                             int hash = spawned.PrefabID().GetHashCode();
-
-                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(
-                                identity.NetId,
-                                hash,
-                                spawned.transform.position,
-                                prefabData
-                            )
-                            {
-                                IsActive = spawned.activeSelf
-                            };
+                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(identity.NetId, hash, spawned.transform.position, prefabData) { IsActive = spawned.activeSelf };
                             PacketSender.SendToAllClients(packet);
-                            DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned duplicant '{dupeName}' ({personalityFallback.Id}, NetId: {identity.NetId}) at {spawned.transform.position} (fallback)");
                             return;
                         }
-
                         if (spawned.GetComponent<CreatureBrain>() != null || spawned.HasTag(GameTags.Creature))
                         {
                             spawned.AddOrGet<OxySyncEntityPositionHandler>();
                             spawned.AddOrGet<AnimStateSyncer>();
                             spawned.AddOrGet<CreatureMultiplayerInitializer>();
                         }
-
                         if (identity.NetId != 0)
                         {
                             string prefabName = spawned.PrefabID().Name;
                             int hash = spawned.PrefabID().GetHashCode();
-
-                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(
-                                identity.NetId,
-                                hash,
-                                spawned.transform.position,
-                                prefabName
-                            )
-                            {
-                                IsActive = spawned.activeSelf
-                            };
+                            var packet = new ONI_Together.Networking.Packets.World.SpawnPrefabPacket(identity.NetId, hash, spawned.transform.position, prefabName) { IsActive = spawned.activeSelf };
                             PacketSender.SendToAllClients(packet);
-                            DebugConsole.Log($"[SandboxSpawnerToolPatch] Broadcasted spawned entity '{prefabName}' (NetId: {identity.NetId}) at {spawned.transform.position}");
                         }
                     }
                 }
             }
-            catch (System.Exception ex)
-            {
-                DebugConsole.LogError($"[SandboxSpawnerToolPatch.Postfix] Exception: {ex}");
-            }
+            catch { }
             finally
             {
                 IsPlacingEntity = false;
@@ -248,28 +193,28 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
     internal static class SandboxDestroyerToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Destroy, cell, distFromOrigin);
+            SandboxToolSync.Send(7, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxFOWTool), nameof(SandboxFOWTool.OnPaintCell))]
     internal static class SandboxFowToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.Reveal, cell, distFromOrigin);
+            SandboxToolSync.Send(8, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxClearFloorTool), nameof(SandboxClearFloorTool.OnPaintCell))]
     internal static class SandboxClearFloorToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.ClearFloor, cell, distFromOrigin);
+            SandboxToolSync.Send(9, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxCritterTool), nameof(SandboxCritterTool.OnPaintCell))]
     internal static class SandboxCritterToolPatch
     {
         private static void Postfix(int cell, int distFromOrigin) =>
-            SandboxToolSync.Send(SandboxToolAction.CritterRemoval, cell, distFromOrigin);
+            SandboxToolSync.Send(10, cell, distFromOrigin);
     }
 
     [HarmonyPatch(typeof(SandboxStoryTraitTool), nameof(SandboxStoryTraitTool.OnLeftClickDown))]
@@ -277,12 +222,10 @@ namespace ONI_Together.Patches.ToolPatches.Sandbox
     {
         private static void Prefix(SandboxStoryTraitTool __instance, Vector3 cursor_pos)
         {
-            if (SandboxToolPacket.ProcessingIncoming || __instance == null || __instance.isPlacingTemplate)
-                return;
-
+            if (__instance == null || __instance.isPlacingTemplate) return;
             int cell = Grid.PosToCell(cursor_pos);
             if (Grid.IsValidCell(cell) && __instance.GetError(cursor_pos, out _, out _) == null)
-                SandboxToolSync.Send(SandboxToolAction.StoryTrait, cell, position: cursor_pos);
+                SandboxToolSync.Send(11, cell, position: cursor_pos);
         }
     }
 }


### PR DESCRIPTION
Split from #206 (one tool per PR).

Routes all sandbox tools (brush, sprinkle, flood, sample, heat, stress, spawner, destroyer, FOW, clear-floor, critter, story) through the new SandboxToolSyncer with menu settings saved and restored around remote execution.

Build: 0 errors.

Note: GamePatch.cs registers each syncer with one line, expect a trivial keep-both rebase once the first syncer PR lands.