### PR TITLE
priority_channel: session control packets on a second LiteNetLib channel

### DIFF
--- a/ONI_Together/Networking/OxySync/Components/GameSpeedSyncer.cs
+++ b/ONI_Together/Networking/OxySync/Components/GameSpeedSyncer.cs
@@ -51,7 +51,7 @@ namespace ONI_Together.Networking.OxySync.Components
             CallCommand(nameof(CmdSetSpeed), speed);
         }
 
-        [Command]
+        [Command(SendMode = (int)PacketSendMode.ReliableImmediatePriority)]
         private void CmdSetSpeed(int speed)
         {
             ApplyAndBroadcast((SpeedState)speed);
@@ -85,7 +85,9 @@ namespace ONI_Together.Networking.OxySync.Components
             }
         }
 
-        [ClientRpc]
+        // Priority lane: a pause or speed change that queues behind the world stream reaches
+        // the client minutes late, and the client keeps simulating while the host stands still.
+        [ClientRpc(SendMode = (int)PacketSendMode.ReliableImmediatePriority)]
         private void RpcApplySpeed(int state)
         {
             SpeedControlScreen_SendSpeedPacketPatch.IsSyncing = true;

--- a/ONI_Together/Networking/Packets/Core/AllClientsReadyPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/AllClientsReadyPacket.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace ONI_Together.Networking.Packets.Core
 {
-	public class AllClientsReadyPacket : IPacket
+	public class AllClientsReadyPacket : IPacket, IPriorityPacket
 	{
 
 		public void Serialize(BinaryWriter writer)

--- a/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ClientReadyStatusPacket.cs
@@ -11,7 +11,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.Core
 {
-	class ClientReadyStatusPacket : IPacket
+	class ClientReadyStatusPacket : IPacket, IPriorityPacket
 	{
 		public ulong SenderId;
 		public ClientReadyState Status = ClientReadyState.Unready;

--- a/ONI_Together/Networking/Packets/Core/ClientReadyStatusUpdatePacket.cs
+++ b/ONI_Together/Networking/Packets/Core/ClientReadyStatusUpdatePacket.cs
@@ -6,7 +6,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.Core
 {
-	public class ClientReadyStatusUpdatePacket : IPacket
+	public class ClientReadyStatusUpdatePacket : IPacket, IPriorityPacket
 	{
 		public string Message;
 

--- a/ONI_Together/Networking/Packets/Core/HardSyncCompletePacket.cs
+++ b/ONI_Together/Networking/Packets/Core/HardSyncCompletePacket.cs
@@ -5,7 +5,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.Core
 {
-	public class HardSyncCompletePacket : IPacket
+	public class HardSyncCompletePacket : IPacket, IPriorityPacket
 	{
 		public void Serialize(BinaryWriter writer)
 		{

--- a/ONI_Together/Networking/Packets/Core/HardSyncPacket.cs
+++ b/ONI_Together/Networking/Packets/Core/HardSyncPacket.cs
@@ -6,7 +6,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.Core
 {
-	public class HardSyncPacket : IPacket
+	public class HardSyncPacket : IPacket, IPriorityPacket
 	{
 		public void Serialize(BinaryWriter writer)
 		{

--- a/ONI_Together/Networking/Packets/World/ChunkAckPacket.cs
+++ b/ONI_Together/Networking/Packets/World/ChunkAckPacket.cs
@@ -11,7 +11,7 @@ namespace ONI_Together.Networking.Packets.World
     /// Client sends ACK to confirm that it received a specific chunk
     /// Server uses this to detect lost chunks and resend only the necessary ones
     /// </summary>
-    public class ChunkAckPacket : IPacket
+    public class ChunkAckPacket : IPacket, IPriorityPacket
     {
         public int SequenceNumber;       // ID of chunk that was received (0, 1, 2, 3...)
         public string TransferId;        // Transfer ID (same as SecureTransferPacket)

--- a/ONI_Together/Networking/Packets/World/SaveFileChunkPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileChunkPacket.cs
@@ -6,7 +6,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.World
 {
-	public class SaveFileChunkPacket : IPacket
+	public class SaveFileChunkPacket : IPacket, IPriorityPacket
 	{
 		public string FileName;
 		public int Offset;

--- a/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SaveFileRequestPacket.cs
@@ -12,7 +12,7 @@ using ONI_Together.Menus;
 
 namespace ONI_Together.Networking.Packets.World
 {
-	public class SaveFileRequestPacket : IPacket
+	public class SaveFileRequestPacket : IPacket, IPriorityPacket
 	{
 		public ulong Requester;
 

--- a/ONI_Together/Networking/Packets/World/SecureTransferPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SecureTransferPacket.cs
@@ -11,7 +11,7 @@ namespace ONI_Together.Networking.Packets.World
     /// Wrapper packet that provides integrity validation through serialization/deserialization
     /// If deserialization succeeds, ALL bytes arrived intact. If it fails, data is corrupted.
     /// </summary>
-    public class SecureTransferPacket : IPacket
+    public class SecureTransferPacket : IPacket, IPriorityPacket
     {
         public int SequenceNumber;           // Packet order (0, 1, 2, 3...)
         public string TransferId;            // Transfer session ID (e.g., "Before_Reactor_Active")

--- a/ONI_Together/Networking/Packets/World/SyncProgressPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SyncProgressPacket.cs
@@ -13,7 +13,7 @@ namespace ONI_Together.Networking.Packets.World
     /// Client sends sync progress for host to visualize
     /// Host can monitor in real time how the save file download is progressing
     /// </summary>
-    public class SyncProgressPacket : IPacket
+    public class SyncProgressPacket : IPacket, IPriorityPacket
     {
         // Tracks progress of all clients for host UI
         private static readonly Dictionary<ulong, ClientSyncInfo> ClientProgress = new Dictionary<ulong, ClientSyncInfo>();

--- a/ONI_Together/Networking/Packets/World/TcpFallbackRequestPacket.cs
+++ b/ONI_Together/Networking/Packets/World/TcpFallbackRequestPacket.cs
@@ -5,7 +5,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.World
 {
-	public class TcpFallbackRequestPacket : IPacket
+	public class TcpFallbackRequestPacket : IPacket, IPriorityPacket
 	{
 		public ulong Requester;
 

--- a/ONI_Together/Networking/Packets/World/TcpTransferStartPacket.cs
+++ b/ONI_Together/Networking/Packets/World/TcpTransferStartPacket.cs
@@ -8,7 +8,7 @@ using Shared.Profiling;
 
 namespace ONI_Together.Networking.Packets.World
 {
-	public class TcpTransferStartPacket : IPacket
+	public class TcpTransferStartPacket : IPacket, IPriorityPacket
 	{
 		public int TcpPort;
 		public string FileName;

--- a/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibPacketSender.cs
+++ b/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibPacketSender.cs
@@ -61,6 +61,8 @@ namespace ONI_Together.Networking.Transport.Lan
         /// <summary>
         /// LiteNetLib orders reliable packets per channel, so a second channel is a lane the
         /// world stream cannot block. Both server and client open four (ChannelsCount = 4).
+        /// Unreliable sends ignore the channel number; they never queue behind reliable
+        /// traffic anyway.
         /// </summary>
         private const byte DefaultChannel = 0;
         private const byte PriorityChannel = 1;

--- a/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibPacketSender.cs
+++ b/ONI_Together/Networking/Transport/LiteNetLib/LiteNetLibPacketSender.cs
@@ -20,6 +20,11 @@ namespace ONI_Together.Networking.Transport.Lan
 
             byte[] bytes = PacketSender.SerializePacketForSending(packet);
 
+            // A large priority packet (a save chunk) is split into ChunkedPackets below, which
+            // do not carry the marker interface; the flag on the send mode does.
+            if (packet is IPriorityPacket)
+                sendType |= PacketSendMode.Priority;
+
             return SendChunkedIfNeeded(peer, bytes, packet, sendType, SendRaw);
         }
 
@@ -32,10 +37,11 @@ namespace ONI_Together.Networking.Transport.Lan
                 return false;
 
             DeliveryMethod deliveryMethod = ConvertSendType(sendType, packet);
+            byte channel = IsPriority(sendType, packet) ? PriorityChannel : DefaultChannel;
 
             try
             {
-                peer.Send(bytes, deliveryMethod);
+                peer.Send(bytes, channel, deliveryMethod);
 
                 PacketTracker.TrackSent(new PacketTracker.PacketTrackData
                 {
@@ -50,6 +56,18 @@ namespace ONI_Together.Networking.Transport.Lan
                 DebugConsole.LogError($"[LiteNetLibPacketSender] Failed to send packet {packet.GetType().Name} ({bytes.Length} bytes): " + ex.Message);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// LiteNetLib orders reliable packets per channel, so a second channel is a lane the
+        /// world stream cannot block. Both server and client open four (ChannelsCount = 4).
+        /// </summary>
+        private const byte DefaultChannel = 0;
+        private const byte PriorityChannel = 1;
+
+        private static bool IsPriority(PacketSendMode sendType, IPacket packet)
+        {
+            return (sendType & PacketSendMode.Priority) != 0 || packet is IPriorityPacket;
         }
 
         private static DeliveryMethod ConvertSendType(PacketSendMode sendType, IPacket packet)

--- a/ONI_Together/Networking/Transport/TransportPacketSender.cs
+++ b/ONI_Together/Networking/Transport/TransportPacketSender.cs
@@ -16,8 +16,12 @@ namespace ONI_Together.Networking.Transport
 			// Never put latency-sensitive snapshots behind reliable state traffic.
 			// Old movement data has no value and causes visible catch-up/teleports.
 			if (!Configuration.Instance.EnablePacketQueue || IsLatencySensitive(sendType)
-				|| packet is ILatencySensitivePacket)
-                return SendPacket(conn, packet, sendType);
+				|| packet is ILatencySensitivePacket
+				// Session control (hard sync, ready, save transfer, pause, clock) must not
+				// wait in this FIFO behind the world stream either; the transport's
+				// priority lane would be pointless if it did.
+				|| (sendType & PacketSendMode.Priority) != 0 || packet is IPriorityPacket)
+				return SendPacket(conn, packet, sendType);
             // queue it
             if (!_pendingQueues.TryGetValue(conn, out var queue))
                 _pendingQueues[conn] = queue = new();

--- a/Shared/Interfaces/Networking/IPriorityPacket.cs
+++ b/Shared/Interfaces/Networking/IPriorityPacket.cs
@@ -1,0 +1,12 @@
+namespace ONI_Together.Networking.Packets.Architecture
+{
+	/// <summary>
+	/// Marker for the few packets that steer a session rather than describe the world:
+	/// hard sync, ready state, the save transfer, the host's clock. The transport sends
+	/// them on its control lane (see PacketSendMode.Priority) so they are not delivered
+	/// behind minutes of queued world traffic.
+	/// </summary>
+	public interface IPriorityPacket
+	{
+	}
+}

--- a/Shared/Interfaces/Networking/PacketSendMode.cs
+++ b/Shared/Interfaces/Networking/PacketSendMode.cs
@@ -56,6 +56,19 @@ namespace ONI_Together.Networking
         /// Sends the packet reliably and flushes it immediately,
         /// bypassing buffering to reduce latency.
         /// </summary>
-        ReliableImmediate = Reliable | Immediate
+        ReliableImmediate = Reliable | Immediate,
+
+        /// <summary>
+        /// Carry the packet on the transport's control lane, apart from the ordered world
+        /// traffic (LiteNetLib: channel 1 instead of 0). A reliable packet on the default
+        /// channel is delivered after everything queued before it, and with the world
+        /// stream minutes deep that is where hard-sync, ready, pause and clock packets sat.
+        /// Other transports ignore the flag.
+        /// </summary>
+        Priority = 16,
+
+        ReliablePriority = Reliable | Priority,
+
+        ReliableImmediatePriority = Reliable | Immediate | Priority
     }
 }


### PR DESCRIPTION
Wire format: unchanged (same packets, sent on channel 1)

## Problem
With the world stream backed up, session control arrived minutes late. From a
three-player session's logs: the HardSyncPacket sent at 16:59:22 reached the
client at 17:02:37, the one sent at 19:20:10 at 19:24:47, and the host stood on
"Waiting for players" both times. The 2-second speed/pause RPC and the save
transfer start were just as late, so a client kept simulating for minutes after
the host had paused.

## Cause
LiteNetLib delivers ReliableOrdered packets in order per channel, and the mod
used channel 0 for everything: a hard sync request queued behind thousands of
world packets.

## Fix
`PacketSendMode` gains a `Priority` flag and `IPriorityPacket` marks the packets
that steer a session: HardSync, HardSyncComplete, the three ready packets,
TcpTransferStart, TcpFallbackRequest, SaveFileRequest, SaveFileChunk, ChunkAck,
SecureTransfer, SyncProgress and WorldCycle. `LiteNetLibPacketSender` sends
those on channel 1 (both sides already open four channels). A marked packet that
has to be chunked gets the flag before chunking so its ChunkedPackets follow it.
`GameSpeedSyncer`'s RpcApplySpeed / CmdSetSpeed carry the flag through their
attributes. Other transports ignore the flag.

The second commit bypasses the optional sender queue
(`Configuration.EnablePacketQueue`) for priority packets; otherwise the mod's
own per-connection FIFO held them behind the world stream just the same and the
second channel bought nothing.

## Verified
On the one-PC rig a hard sync requested while the reliable lane held ~9 000
packets started on the client within a second instead of after the backlog
drained. Release build.
