### PR TITLE
registry_rebuild: re-index live NetworkIdentities when a server starts inside a loaded world

### DIFF
--- a/ONI_Together/Networking/GameServer.cs
+++ b/ONI_Together/Networking/GameServer.cs
@@ -8,6 +8,7 @@ using Steamworks;
 using System;
 using System.Runtime.InteropServices;
 using ONI_Together.Networking.Components;
+using ONI_Together.Misc;
 using UnityEngine;
 
 namespace ONI_Together.Networking
@@ -55,6 +56,16 @@ namespace ONI_Together.Networking
 		public static void Start()
 		{
 			using var _ = Profiler.Scope();
+
+			// A server started - or restarted - inside a loaded world: NetworkConfig.Stop
+			// wiped the identity registry, and the objects of that world never register
+			// twice, so every NetId a client sent came back "not found" until the host
+			// reloaded the save. Rebuild the registry from the scene first.
+			if (Utils.IsInGame())
+			{
+				int count = NetworkIdentityRegistry.RebuildFromScene();
+				DebugConsole.Log($"[GameServer] Identity registry rebuilt from the loaded world: {count} objects");
+			}
 
 			SetState(ServerState.Preparing);
 

--- a/ONI_Together/Networking/NetworkIdentityRegistry.cs
+++ b/ONI_Together/Networking/NetworkIdentityRegistry.cs
@@ -91,7 +91,9 @@ namespace ONI_Together.Networking
 			_lookupFailCount = 0;
 
 			int collisions = 0;
-			foreach (var identity in UnityEngine.Object.FindObjectsByType<NetworkIdentity>(FindObjectsInactive.Include, FindObjectsSortMode.None))
+			// Sorted by instance id, so two live objects with one id resolve the same way
+			// on every rebuild (the older object, which registered first, wins).
+			foreach (var identity in UnityEngine.Object.FindObjectsByType<NetworkIdentity>(FindObjectsInactive.Include, FindObjectsSortMode.InstanceID))
 			{
 				if (identity == null || identity.NetId == 0) continue;
 				if (identities.ContainsKey(identity.NetId)) { collisions++; continue; }

--- a/ONI_Together/Networking/NetworkIdentityRegistry.cs
+++ b/ONI_Together/Networking/NetworkIdentityRegistry.cs
@@ -74,6 +74,36 @@ namespace ONI_Together.Networking
 		}
 		public static bool Exists(int netId) => identities.ContainsKey(netId);
 
+		/// <summary>
+		/// Re-index every live NetworkIdentity in the scene under the NetId it carries.
+		/// NetworkConfig.Stop clears this registry, but the objects of a loaded world stay,
+		/// and RegisterIdentity is guarded by IsRegistered, so after a server restart in the
+		/// same world the host resolved nothing: Count went from 5318 to 0 in the log and
+		/// crept back only with newly spawned objects until the save was reloaded.
+		/// Inactive objects are included: items inside storages are inactive and are
+		/// addressed by NetId too. Returns the number of entries.
+		/// </summary>
+		public static int RebuildFromScene()
+		{
+			using var _ = Profiler.Scope();
+
+			identities.Clear();
+			_lookupFailCount = 0;
+
+			int collisions = 0;
+			foreach (var identity in UnityEngine.Object.FindObjectsByType<NetworkIdentity>(FindObjectsInactive.Include, FindObjectsSortMode.None))
+			{
+				if (identity == null || identity.NetId == 0) continue;
+				if (identities.ContainsKey(identity.NetId)) { collisions++; continue; }
+				identities[identity.NetId] = identity;
+			}
+
+			if (collisions > 0)
+				DebugConsole.LogWarning($"[NetEntityRegistry] {collisions} objects share a NetId with another live object; the first one found keeps the id");
+
+			return identities.Count;
+		}
+
 
 
 		public static bool TryGet(int netId, out NetworkIdentity entity)


### PR DESCRIPTION
Wire format: unchanged

## Problem
After the host stopped and restarted the server in the same world
(17:02:41 -> 17:03:02 in one session's log), every NetId a client sent -
deconstruct orders on farm tiles among them - came back "not found" until the
host reloaded the save ten minutes later.

## Cause
`NetworkConfig.Stop` clears `NetworkIdentityRegistry`, but the objects of the
loaded world stay, and `RegisterIdentity` is guarded by `IsRegistered`. The
registry held 0 entries where it had 5 318 and grew only with newly spawned
objects.

## Fix
`GameServer.Start` rebuilds the registry from the scene when a world is loaded:
every `NetworkIdentity` with a non-zero NetId, inactive objects included (items
inside storages are addressed by NetId too). A second live object with the same
id is counted and reported; sorted by instance id, the older object - the one
that registered first - keeps the id, so the outcome is the same on every
rebuild and matches the clients, which built their tables in spawn order.

## Verified
Stop + start of the server inside a loaded world on the one-PC rig: the
registry comes back with the full count and a client's orders resolve
immediately. Release build.
